### PR TITLE
Add gzip_page decorator

### DIFF
--- a/django-stubs/views/decorators/gzip.pyi
+++ b/django-stubs/views/decorators/gzip.pyi
@@ -1,3 +1,5 @@
-from typing import Callable
+from typing import Callable, TypeVar
 
-def gzip_page(view_func: Callable) -> Callable: ...
+_C = TypeVar("_C", bound=Callable)
+
+def gzip_page(view_func: _C) -> _C: ...

--- a/django-stubs/views/decorators/gzip.pyi
+++ b/django-stubs/views/decorators/gzip.pyi
@@ -1,0 +1,3 @@
+from typing import Callable
+
+def gzip_page(view_func: Callable) -> Callable: ...


### PR DESCRIPTION
Adds the `gzip_page` decorator from `django.views.decorators.gzip`:

https://github.com/django/django/blob/master/django/views/decorators/gzip.py
