### PR TITLE
Re-export names from django.core.cache.backend.base

### DIFF
--- a/django-stubs/core/cache/__init__.pyi
+++ b/django-stubs/core/cache/__init__.pyi
@@ -1,7 +1,11 @@
 from collections import OrderedDict
 from typing import Any, Callable, Dict, Union
 
-from .backends.base import BaseCache as BaseCache
+from .backends.base import (
+    BaseCache as BaseCache,
+    CacheKeyWarning as CacheKeyWarning,
+    InvalidCacheBackendError as InvalidCacheBackendError,
+)
 
 DEFAULT_CACHE_ALIAS: str
 


### PR DESCRIPTION
Came across this while starting to type a django code base.