### PR TITLE
Adds urls.pyi for several contrib apps

### DIFF
--- a/django-stubs/contrib/admindocs/urls.pyi
+++ b/django-stubs/contrib/admindocs/urls.pyi
@@ -1,0 +1,3 @@
+from typing import Any, List
+
+urlpatterns: List[Any] = ...

--- a/django-stubs/contrib/flatpages/urls.pyi
+++ b/django-stubs/contrib/flatpages/urls.pyi
@@ -1,0 +1,3 @@
+from typing import Any, List
+
+urlpatterns: List[Any] = ...

--- a/django-stubs/contrib/staticfiles/urls.pyi
+++ b/django-stubs/contrib/staticfiles/urls.pyi
@@ -2,6 +2,6 @@ from typing import Any, List, Optional
 
 from django.urls.resolvers import URLPattern
 
-urlpatterns: Any
+urlpatterns: List[Any] = ...
 
 def staticfiles_urlpatterns(prefix: Optional[str] = ...) -> List[URLPattern]: ...


### PR DESCRIPTION
Adds several `urls.pyi` for:
- https://github.com/django/django/blob/master/django/contrib/flatpages/urls.py
- https://github.com/django/django/blob/master/django/contrib/staticfiles/urls.py
- https://github.com/django/django/blob/master/django/contrib/admindocs/urls.py

Closes #127 