### PR TITLE
flake8: ignore certain errors for .pyi files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,14 @@ exclude =
   django-stubs
   test-data
 max_line_length = 120
+per-file-ignores =
+  # E301: expected 1 blank line
+  # E302: expected 2 blank lines
+  # E305: expected 2 blank lines after class or function definition
+  # E701: multiple statements on one line (colon)
+  # E743: ambiguous function definition 'X'
+  # F821: undefined name 'X'
+  *.pyi: E301, E302, E305, E701, E743, F821
 
 [metadata]
 license_file = LICENSE.txt


### PR DESCRIPTION
They are not checked on CI, but I run flake8 for filetype=python (which is set for `.pyi` also) in Vim/Neovim (via Neomake), so it helps to ignore issues that do not need to be fixed really.