### PR TITLE
resolve_template accepts Sequences of str

### DIFF
--- a/django-stubs/template/response.pyi
+++ b/django-stubs/template/response.pyi
@@ -1,6 +1,6 @@
 import functools
 from http.cookies import SimpleCookie
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.http.request import HttpRequest
@@ -30,7 +30,7 @@ class SimpleTemplateResponse(HttpResponse):
         charset: Optional[str] = ...,
         using: Optional[str] = ...,
     ) -> None: ...
-    def resolve_template(self, template: Union[List[str], Template, str]) -> Union[Template, Template]: ...
+    def resolve_template(self, template: Union[Sequence[str], Template, str]) -> Template: ...
     def resolve_context(self, context: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]: ...
     @property
     def rendered_content(self) -> str: ...


### PR DESCRIPTION
- resolve_template is checking for lists or tuples so let's use a generic Sequence
- Union[Template, Template] seemed redundant