### PR TITLE
AUTH_PASSWORD_VALIDATORS should support OPTIONS

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -390,8 +390,8 @@ PASSWORD_RESET_TIMEOUT_DAYS = 3
 # upon login
 PASSWORD_HASHERS: List[str] = ...
 
-AUTH_PASSWORD_VALIDATORS: List[Dict[str, str]] = ...
-
+AUTH_PASSWORD_VALIDATORS: List[Dict[str, Union[str, Dict[str, Any]]]] = ...
+    
 ###########
 # SIGNING #
 ###########


### PR DESCRIPTION
Django allows a Dict as the value for the key 'OPTIONS' inside of the list of validators in AUTH_PASSWORD_VALIDATORS.
See https://docs.djangoproject.com/en/2.2/topics/auth/passwords/#enabling-password-validation

The type annotation is currently overly strict.
Although, it is possible to be more specific with TypedDict, the key 'OPTIONS' is not required to be present, and there is no way to represent that currently, so I have used Union.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
