### PR TITLE
Move BLANK_CHOICE to django.db.models.fields

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -27,6 +27,8 @@ from django.forms import Field as FormField, Widget
 
 class NOT_PROVIDED: ...
 
+BLANK_CHOICE_DASH: List[Tuple[str, str]] = ...
+
 _Choice = Tuple[Any, Any]
 _ChoiceNamedGroup = Tuple[str, Iterable[_Choice]]
 _FieldChoices = Iterable[Union[_Choice, _ChoiceNamedGroup]]

--- a/django-stubs/db/models/fields/files.pyi
+++ b/django-stubs/db/models/fields/files.pyi
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, Iterable, Optional, Type, TypeVar, Union, overload
 
 from django.core.files.base import File
 from django.core.files.images import ImageFile
@@ -7,8 +7,6 @@ from django.core.files.storage import FileSystemStorage, Storage
 from django.db.models.base import Model
 
 from django.db.models.fields import Field, _FieldChoices, _ValidatorCallable, _ErrorMessagesToOverride
-
-BLANK_CHOICE_DASH: List[Tuple[str, str]] = ...
 
 class FieldFile(File):
     instance: Model = ...


### PR DESCRIPTION
If you look at https://github.com/django/django/blob/9a17ae50c61a3a0ea6c552ce4e3eab27f796d094/django/db/models/fields/__init__.py#L56

`BLANK_CHOICE` is defined in `django.db.models.fields`, not `django.db.models.fields.files`