### PR TITLE
Add support for exclusion constraints

### DIFF
--- a/django-stubs/contrib/postgres/constraints.pyi
+++ b/django-stubs/contrib/postgres/constraints.pyi
@@ -1,0 +1,18 @@
+from typing import Optional, Sequence, Tuple, Union
+
+from django.db.models.constraints import BaseConstraint
+from django.db.models.expressions import Combinable
+from django.db.models.query_utils import Q
+
+class ExclusionConstraint(BaseConstraint):
+    expressions: Sequence[Tuple[Union[str, Combinable], str]]
+    index_type: str
+    condition: Optional[Q]
+    def __init__(
+        self,
+        *,
+        name: str,
+        expressions: Sequence[Tuple[Union[str, Combinable], str]],
+        condition: Optional[Q] = ...,
+        index_type: Optional[str] = ...,
+    ): ...

--- a/django-stubs/contrib/postgres/fields/__init__.pyi
+++ b/django-stubs/contrib/postgres/fields/__init__.pyi
@@ -8,6 +8,7 @@ from .ranges import (
     FloatRangeField as FloatRangeField,
     DateRangeField as DateRangeField,
     DateTimeRangeField as DateTimeRangeField,
+    RangeOperators as RangeOperators,
 )
 from .hstore import HStoreField as HStoreField
 from .citext import (

--- a/django-stubs/contrib/postgres/fields/ranges.pyi
+++ b/django-stubs/contrib/postgres/fields/ranges.pyi
@@ -29,3 +29,15 @@ class DateTimeRangeField(RangeField):
 
 class DateRangeField(RangeField):
     def __get__(self, instance, owner) -> DateRange: ...
+
+class RangeOperators:
+    EQUAL: str
+    NOT_EQUAL: str
+    CONTAINS: str
+    CONTAINED_BY: str
+    OVERLAPS: str
+    FULLY_LT: str
+    FULLY_GT: str
+    NOT_LT: str
+    NOT_GT: str
+    ADJACENT_TO: str

--- a/test-data/typecheck/test_import_all.yml
+++ b/test-data/typecheck/test_import_all.yml
@@ -96,6 +96,7 @@
         import django.contrib.postgres.aggregates.general
         import django.contrib.postgres.aggregates.mixins
         import django.contrib.postgres.aggregates.statistics
+        import django.contrib.postgres.constraints
         import django.contrib.postgres.fields
         import django.contrib.postgres.fields.array
         import django.contrib.postgres.fields.citext


### PR DESCRIPTION
This PR adds stubs for `django.contrib.postgres.constraints.ExclusionConstraint` and `django.contrib.postgres.fields.ranges.RangeOperators` for use together with https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/constraints/#exclusionconstraint