### PR TITLE
Add support for RangeBoundary

### DIFF
--- a/django-stubs/contrib/postgres/fields/__init__.pyi
+++ b/django-stubs/contrib/postgres/fields/__init__.pyi
@@ -9,6 +9,7 @@ from .ranges import (
     DateRangeField as DateRangeField,
     DateTimeRangeField as DateTimeRangeField,
     RangeOperators as RangeOperators,
+    RangeBoundary as RangeBoundary,
 )
 from .hstore import HStoreField as HStoreField
 from .citext import (

--- a/django-stubs/contrib/postgres/fields/ranges.pyi
+++ b/django-stubs/contrib/postgres/fields/ranges.pyi
@@ -41,3 +41,8 @@ class RangeOperators:
     NOT_LT: str
     NOT_GT: str
     ADJACENT_TO: str
+
+class RangeBoundary(models.Expression):
+    lower: str
+    upper: str
+    def __init__(self, inclusive_lower: bool = ..., inclusive_upper: bool = ...): ...


### PR DESCRIPTION
Add support for `django.contrib.postgres.fields.ranges.RangeBoundary`
https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/fields/#rangeboundary-expressions

Missed this class in https://github.com/typeddjango/django-stubs/pull/249

