### PR TITLE
add .model field to _BaseQuerySet

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -31,6 +31,7 @@ _T = TypeVar("_T", bound=models.Model, covariant=True)
 _QS = TypeVar("_QS", bound="_BaseQuerySet")
 
 class _BaseQuerySet(Generic[_T], Sized):
+    model: Type[_T]
     query: Query
     def __init__(
         self,


### PR DESCRIPTION
# Added missing `.model` field to `_BaseQuerySet`

Django's QuerySet sets `.model` property here: https://github.com/django/django/blob/d6505273cd889886caca57884fa79941b18c2ea6/django/db/models/query.py#L190

`django-stubs` was missing it, now it (hopefully) won't.