### PR TITLE
update ChoiceField's `choices` kwarg's annotation

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -207,7 +207,7 @@ class CallableChoiceIterator:
 class ChoiceField(Field):
     def __init__(
         self,
-        choices: _FieldChoices = ...,
+        choices: Union[_FieldChoices, Callable[[], _FieldChoices]] = ...,
         required: bool = ...,
         widget: Optional[Union[Widget, Type[Widget]]] = ...,
         label: Optional[Any] = ...,


### PR DESCRIPTION
per the [docs](https://docs.djangoproject.com/en/3.0/ref/forms/fields/#choicefield), `choices` is:

> Either an iterable of 2-tuples to use as choices for this field, or a callable that returns such an iterable.

---

hi! i encountered this issue when typechecking a django repo at work, and opened this PR to attempt to resolve it. i haven't tested this change locally to ensure that it resolve my issue - is there documentation somewhere on the recommended workflow for doing that? thank you!