### PR TITLE
Add test for missing typing import when used m2m to contrib auth

### DIFF
--- a/test-data/typecheck/managers/querysets/test_from_queryset.yml
+++ b/test-data/typecheck/managers/querysets/test_from_queryset.yml
@@ -179,3 +179,44 @@
                 class BaseQuerySet(models.QuerySet):
                     def base_queryset_method(self, param: Union[int, str]) -> NoReturn:
                         raise ValueError
+-   case: from_queryset_with_inherited_manager_and_fk_to_auth_contrib
+    disable_cache: true
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel().objects)  # N: Revealed type is 'myapp.models.MyModel_NewManager[myapp.models.MyModel]'
+        reveal_type(MyModel().objects.get())  # N: Revealed type is 'myapp.models.MyModel*'
+        reveal_type(MyModel().objects.base_queryset_method)  # N: Revealed type is 'def (param: Union[builtins.int, builtins.str]) -> Union[builtins.int, builtins.str]'
+        reveal_type(MyModel().objects.base_queryset_method(2))  # N: Revealed type is 'Union[builtins.int, builtins.str]'
+    installed_apps:
+        - myapp
+        - django.contrib.auth
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from myapp.managers import NewManager
+                from django.contrib.auth.models import Permission
+
+                class MyModel(models.Model):
+                    objects = NewManager()
+
+                class AnotherModelInProjectWithContribAuthM2M(models.Model):
+                    permissions = models.ForeignKey(
+                        Permission,
+                        on_delete=models.PROTECT,
+                    )
+        -   path: myapp/managers.py
+            content: |
+                from django.db import models
+                from myapp.base_queryset import BaseQuerySet
+                class ModelQuerySet(BaseQuerySet):
+                    pass
+                NewManager = models.Manager.from_queryset(ModelQuerySet)
+        -   path: myapp/base_queryset.py
+            content: |
+                from typing import  Union
+                from django.db import models
+                class BaseQuerySet(models.QuerySet):
+                    def base_queryset_method(self, param: Union[int, str]) -> Union[int, str]:
+                        return param


### PR DESCRIPTION
In my project, we use a combination of:
 - Models with custom managers
 - Custom managers built on custom querysets and `.from_queryset`
 - Custom querysets inherited from base queryset

And if we add to this combination custom User Model with a FK (or m2m) link to any model from django.contrib.auth then we get "name is not defined" errors like `Name 'Union' is not defined`

Raw test output
```
============================= test session starts ==============================
platform darwin -- Python 3.7.5, pytest-5.3.2, py-1.8.0, pluggy-0.13.1 -- /Users/Boger/venvs/django-stubs/bin/python
cachedir: .pytest_cache
rootdir: /Users/Boger/PycharmProjects/django-stubs, inifile: pytest.ini
plugins: mypy-plugins-1.2.0
collecting ... collected 149 items / 148 deselected / 1 selected

test-data/typecheck/managers/querysets/test_from_queryset.yml::from_queryset_with_inherited_manager_and_fk_to_auth_contrib FAILED
test-data/typecheck/managers/querysets/test_from_queryset.yml:None (from_queryset_with_inherited_manager_and_fk_to_auth_contrib)
/Users/Boger/PycharmProjects/django-stubs/test-data/typecheck/managers/querysets/test_from_queryset.yml:188: 
E   pytest_mypy.utils.TypecheckAssertionError: Invalid output: 
E   Expected:
E     main:2: note: Revealed type is 'myapp.models.MyModel_NewManager[myapp.models.MyModel]'
E     main:3: note: Revealed type is 'myapp.models.MyModel*'
E     main:4: note: Revealed type is 'def (param: Union[builtins.int, builtins.str]) -> Union[builtins.int, builtins.str]' (diff)
E     main:5: note: Revealed type is 'Union[builtins.int, builtins.str]' (diff)
E   Actual:
E     main:2: note: Revealed type is 'myapp.models.MyModel_NewManager[myapp.models.MyModel]'
E     main:3: note: Revealed type is 'myapp.models.MyModel*'
E     main:4: note: Revealed type is 'def (param: Any) -> Any' (diff)
E     main:5: note: Revealed type is 'Any'          (diff)
E     myapp/managers:4: error: Name 'Union' is not defined (diff)
E     myapp/managers:4: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Union") (diff)
E   
E   Alignment of first line difference:
E     E: ...ed type is 'def (param: Union[builtins.int, builtins.str]) -> Union[b...
E     A: ...ed type is 'def (param: Any) -> Any'...
E                                   ^
```

Steps to reproduce:
 - Create Queryset with typing and typing import
 - Use `.from_queryset` in **another** file
 - Create a model with FK to django.auth.contrib anywhere
