### PR TITLE
add stub for core/asgi.py from Django 3

### DIFF
--- a/django-stubs/core/asgi.pyi
+++ b/django-stubs/core/asgi.pyi
@@ -1,0 +1,3 @@
+from django.core.handlers.asgi import ASGIHandler
+
+def get_asgi_application() -> ASGIHandler: ...


### PR DESCRIPTION
When checking a Django 3 project, I get this error (with sufficient strictness):
```
$ mypy .
foo/asgi.py:12: error: No library stub file for module 'django.core.asgi'
foo/asgi.py:12: note: (Stub files are from https://github.com/python/typeshed)
Found 1 error in 1 file (checked 15 source files)
```

The PR creates a stub for that file, which is new in Django 3.