### PR TITLE
Revert manager behavior for managers without 'objects'

### DIFF
--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -273,13 +273,16 @@ class AddRelatedManagers(ModelClassInitializer):
             if isinstance(relation, (ManyToOneRel, ManyToManyRel)):
                 try:
                     related_manager_info = self.lookup_typeinfo_or_incomplete_defn_error(fullnames.RELATED_MANAGER_CLASS)  # noqa: E501
-                    if 'objects' not in related_model_info.names:
-                        raise helpers.IncompleteDefnException()
                 except helpers.IncompleteDefnException as exc:
                     if not self.api.final_iteration:
                         raise exc
                     else:
                         continue
+
+                if 'objects' not in related_model_info.names:
+                    self.add_new_node_to_model_class(
+                        attname, Instance(related_manager_info, [Instance(related_model_info, [])]))
+                    continue
 
                 # create new RelatedManager subclass
                 parametrized_related_manager_type = Instance(related_manager_info,


### PR DESCRIPTION
This fixes reverse many-to-one managers regressions in our project that
were introduced in
https://github.com/typeddjango/django-stubs/commit/665f4d8ea1723d0bcae59904a590ffb03a7c0355.
I've tried to create a reproduce in
https://github.com/typeddjango/django-stubs/pull/300 but was unable to
do so. This patch makes django-stubs work for us again, perhaps you are
able to see why this fix works, because i do not know the reason why my
class doesn't have 'objects'.

We use django 3.0.2 and python 3.8.
