### PR TITLE
Fix CI build errors

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,5 @@ psycopg2
 flake8==3.7.9
 flake8-pyi==19.3.0
 isort==4.3.21
-gitpython==3.0.5
+gitpython==3.1.0
 -e .

--- a/scripts/enabled_test_modules.py
+++ b/scripts/enabled_test_modules.py
@@ -109,6 +109,7 @@ IGNORED_ERRORS = {
     ],
     'builtin_server': [
         '"ServerHandler" has no attribute',
+        'Incompatible types in assignment (expression has type "Tuple[BytesIO, BytesIO]"',
     ],
     'bulk_create': [
         'has incompatible type "List[Country]"; expected "Iterable[TwoFields]"',
@@ -282,6 +283,7 @@ IGNORED_ERRORS = {
         '"ImageFile" has no attribute "was_opened"',
         'Incompatible type for "size" of "FloatModel" (got "object", expected "Union[float, int, str, Combinable]")',
         'Incompatible type for "value" of "IntegerModel" (got "object", expected',
+        '"Child" has no attribute "get_foo_display"',
     ],
     'model_forms': [
         '"render" of "Widget"',

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -14,8 +14,8 @@ from scripts.enabled_test_modules import (
 )
 
 DJANGO_COMMIT_REFS: Dict[str, Tuple[str, str]] = {
-    '2.2': ('stable/2.2.x', '86befcc172c23170a720b3e0c06db51a99b3da59'),
-    '3.0': ('stable/3.0.x', '6cb30414bc0f83b49afc4cae76d4af5656effe9a')
+    '2.2': ('stable/2.2.x', '996be04c3ceb456754d9d527d4d708f30727f07e'),
+    '3.0': ('stable/3.0.x', 'd9f1792c7649e9f946f4a3a35a76bddf5a412b8b')
 }
 PROJECT_DIRECTORY = Path(__file__).parent.parent
 DJANGO_SOURCE_DIRECTORY = PROJECT_DIRECTORY / 'django-sources'  # type: Path


### PR DESCRIPTION
* Updated gitpython dependency to fix error:
  ModuleNotFoundError: No module named 'gitdb.utils.compat'
* Updated Django repository git refs because old 3.0.x commit hash gave error:
  stderr: 'fatal: reference is not a tree: 6cb30414bc0f83b49afc4cae76d4af5656effe9a'
* Newer Django version also needs new ignores.
