### PR TITLE
Output a more clear configuration error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
       python: 3.7
       script: 'pytest'
 
+    - name: Run plugin test suite with python 3.6
+      python: 3.6
+      script: 'pytest'
+
     - name: Typecheck Django 3.0 test suite with python 3.8
       python: 3.8
       script: |
@@ -29,6 +33,11 @@ jobs:
 
     - name: Typecheck Django 2.2 test suite with python 3.7
       python: 3.7
+      script: |
+        python ./scripts/typecheck_tests.py --django_version=2.2
+
+    - name: Typecheck Django 2.2 test suite with python 3.6
+      python: 3.6
       script: |
         python ./scripts/typecheck_tests.py --django_version=2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ jobs:
       python: 3.7
       script: 'pytest'
 
-    - name: Run plugin test suite with python 3.6
-      python: 3.6
-      script: 'pytest'
-
     - name: Typecheck Django 3.0 test suite with python 3.8
       python: 3.8
       script: |
@@ -33,11 +29,6 @@ jobs:
 
     - name: Typecheck Django 2.2 test suite with python 3.7
       python: 3.7
-      script: |
-        python ./scripts/typecheck_tests.py --django_version=2.2
-
-    - name: Typecheck Django 2.2 test suite with python 3.6
-      python: 3.6
       script: |
         python ./scripts/typecheck_tests.py --django_version=2.2
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -62,16 +62,17 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
         """
         from mypy.main import CapturableArgumentParser
 
-        usage = '\n'.join(['(config)',
-                           '...',
-                           '[mypy.plugins.django_stubs]',
-                           '\tdjango_settings_module: str (required)',
-                           '...']).expandtabs(4)
-        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=usage)
-        messages = {1: "'django_settings_module' is not set: mypy config file is not specified or found",
-                    2: "'django_settings_module' is not set: no section [mypy.plugins.django-stubs]",
-                    3: "'django_settings_module' is not set: the setting is not provided"}
-        handler.error(messages[error_type])
+        usage = """(config)
+        ...
+        [mypy.plugins.django_stubs]
+            django_settings_module: str (required)
+        ...
+        """.replace("\n" + 8 * " ", "\n")
+        handler = CapturableArgumentParser(prog='(django-stubs) mypy', usage=usage)
+        messages = {1: 'mypy config file is not specified or found',
+                    2: 'no section [mypy.plugins.django-stubs]',
+                    3: 'the setting is not provided'}
+        handler.error("'django_settings_module' is not set: " + messages[error_type])
 
     parser = configparser.ConfigParser()
     try:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-testpaths = ./test-data
+testpaths = 
+    ./test-plugin
+    ./test-data
 addopts =
     --tb=native
     -s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = 
+testpaths =
     ./test-plugin
     ./test-data
 addopts =

--- a/test-plugin/test_error_handling.py
+++ b/test-plugin/test_error_handling.py
@@ -5,7 +5,6 @@ import pytest
 
 from mypy_django_plugin.main import extract_django_settings_module
 
-
 TEMPLATE = """usage: (config)
 ...
 [mypy.plugins.django_stubs]

--- a/test-plugin/test_error_handling.py
+++ b/test-plugin/test_error_handling.py
@@ -42,7 +42,7 @@ TEMPLATE = """usage: (config)
 )
 def test_misconfiguration_handling(capsys, config_file_contents, message_part):
     #  type: (typing.Any, typing.List[str], str) -> None
-    '''Invalid configuration raises `SystemExit` with a precise error message.'''
+    """Invalid configuration raises `SystemExit` with a precise error message."""
     with tempfile.NamedTemporaryFile(mode='w+') as config_file:
         if not config_file_contents:
             config_file.close()
@@ -58,7 +58,7 @@ def test_misconfiguration_handling(capsys, config_file_contents, message_part):
 
 
 def test_correct_configuration() -> None:
-    '''Django settings module gets extracted given valid configuration.'''
+    """Django settings module gets extracted given valid configuration."""
     config_file_contents = [
         '[mypy.plugins.django-stubs]',
         '\tsome_other_setting = setting',

--- a/test-plugin/test_error_handling.py
+++ b/test-plugin/test_error_handling.py
@@ -1,0 +1,74 @@
+import tempfile
+import typing
+
+import pytest
+
+from mypy_django_plugin.main import extract_django_settings_module
+
+
+TEMPLATE = """usage: (config)
+...
+[mypy.plugins.django_stubs]
+    django_settings_module: str (required)
+...
+(django-stubs) mypy: error: 'django_settings_module' is not set: {}
+"""
+
+
+@pytest.mark.parametrize(
+    'config_file_contents,message_part',
+    [
+        pytest.param(
+            None,
+            'mypy config file is not specified or found',
+            id='missing-file',
+        ),
+        pytest.param(
+            ['[not-really-django-stubs]'],
+            'no section [mypy.plugins.django-stubs]',
+            id='missing-section',
+        ),
+        pytest.param(
+            ['[mypy.plugins.django-stubs]',
+             '\tnot_django_not_settings_module = badbadmodule'],
+            'the setting is not provided',
+            id='missing-settings-module',
+        ),
+        pytest.param(
+            ['[mypy.plugins.django-stubs]'],
+            'the setting is not provided',
+            id='no-settings-given',
+        ),
+    ],
+)
+def test_misconfiguration_handling(capsys, config_file_contents, message_part):
+    #  type: (typing.Any, typing.List[str], str) -> None
+    '''Invalid configuration raises `SystemExit` with a precise error message.'''
+    with tempfile.NamedTemporaryFile(mode='w+') as config_file:
+        if not config_file_contents:
+            config_file.close()
+        else:
+            config_file.write('\n'.join(config_file_contents).expandtabs(4))
+            config_file.seek(0)
+
+        with pytest.raises(SystemExit, match='2'):
+            extract_django_settings_module(config_file.name)
+
+    error_message = TEMPLATE.format(message_part)
+    assert error_message == capsys.readouterr().err
+
+
+def test_correct_configuration() -> None:
+    '''Django settings module gets extracted given valid configuration.'''
+    config_file_contents = [
+        '[mypy.plugins.django-stubs]',
+        '\tsome_other_setting = setting',
+        '\tdjango_settings_module = my.module',
+    ]
+    with tempfile.NamedTemporaryFile(mode='w+') as config_file:
+        config_file.write('\n'.join(config_file_contents).expandtabs(4))
+        config_file.seek(0)
+
+        extracted = extract_django_settings_module(config_file.name)
+
+    assert extracted == 'my.module'


### PR DESCRIPTION
# I have made things!

This tackles #420; missing configuration is now reported like this:
```
(django-stubs-3.6.11) ➜  django-stubs issue-420 ✗ mypy -p django-stubs --config-file test-data/plugins.ini                                                                                                                                    
usage: (config)
...
[mypy.plugins.django_stubs]
    django_settings_module: str (required)
...
(django-stubs) mypy: error: 'django_settings_module' is not set: no section [mypy.plugins.django-stubs]
```

The function got refactored a little bit and made a little less verbose. I thought this way it will be easier to add new configuration options (a solution to #417 which is on the way for example). 

## Related issues

- Closes #420 


