### PR TITLE
Fix type of update_fields parameter to Model.save

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, Collection
+from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import ValidationError
@@ -43,7 +43,7 @@ class Model(metaclass=ModelBase):
         force_insert: bool = ...,
         force_update: bool = ...,
         using: Optional[str] = ...,
-        update_fields: Optional[Union[Sequence[str], str]] = ...,
+        update_fields: Optional[Iterable[str]] = ...,
     ) -> None: ...
     def save_base(
         self,
@@ -51,7 +51,7 @@ class Model(metaclass=ModelBase):
         force_insert: bool = ...,
         force_update: bool = ...,
         using: Optional[str] = ...,
-        update_fields: Optional[Union[Sequence[str], str]] = ...,
+        update_fields: Optional[Iterable[str]] = ...,
     ): ...
     def refresh_from_db(self: _Self, using: Optional[str] = ..., fields: Optional[List[str]] = ...) -> None: ...
     def get_deferred_fields(self) -> Set[str]: ...


### PR DESCRIPTION
Sending in a single string leads to unexpected behavior and the method
accepts any iterable, not just sequences, of strings.

Technically sending in a single string is still allowed because a string
is an iterable of strings, but this way the intention of that argument
is clearer.

## Related issues

Closes #434 