### PR TITLE
Add models.JSONField introduced in Django 3.1

### DIFF
--- a/django-stubs/db/models/__init__.pyi
+++ b/django-stubs/db/models/__init__.pyi
@@ -60,6 +60,7 @@ from .fields.files import (
     FileDescriptor as FileDescriptor,
 )
 from .fields.proxy import OrderWrt as OrderWrt
+from .fields.json import JSONField as JSONField
 
 from .deletion import (
     CASCADE as CASCADE,

--- a/django-stubs/db/models/fields/json.pyi
+++ b/django-stubs/db/models/fields/json.pyi
@@ -1,0 +1,21 @@
+from typing import Any, Callable, Dict, TypeVar
+
+from . import Field
+
+_ErrorMessagesToOverride = Dict[str, Any]
+
+# __set__ value type
+_ST = TypeVar("_ST")
+# __get__ return type
+_GT = TypeVar("_GT")
+
+class JSONField(Field[_ST, _GT]):
+    empty_strings_allowed: str
+    error_messages: _ErrorMessagesToOverride
+    def __init__(
+        self,
+        verbose_name: str = ...,
+        name: str = ...,
+        encoder: Callable = ...,
+        decoder: Callable = ...,
+    ): ...


### PR DESCRIPTION
Ref: https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.JSONField