### PR TITLE
Allows FileField storage to be a Callable

### DIFF
--- a/django-stubs/db/models/fields/files.pyi
+++ b/django-stubs/db/models/fields/files.pyi
@@ -39,7 +39,7 @@ class FileField(Field):
     def __init__(
         self,
         upload_to: Union[str, Callable, Path] = ...,
-        storage: Optional[Storage] = ...,
+        storage: Optional[Union[Storage, Callable[[], Storage]]] = ...,
         verbose_name: Optional[Union[str, bytes]] = ...,
         name: Optional[str] = ...,
         max_length: Optional[int] = ...,

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -70,7 +70,12 @@ class BaseForm:
     def visible_fields(self): ...
     def get_initial_for_field(self, field: Field, field_name: str) -> Any: ...
     def _html_output(
-        self, normal_row: str, error_row: str, row_ender: str, help_text_html: str, errors_on_separate_row: bool,
+        self,
+        normal_row: str,
+        error_row: str,
+        row_ender: str,
+        help_text_html: str,
+        errors_on_separate_row: bool,
     ) -> SafeText: ...
 
 class Form(BaseForm):


### PR DESCRIPTION
# I have made things!

The `storage` parameter of `FileField` (and by extension `ImageField`)
is not limited to just taking an instance of `Storage`. It can also take
a no-args callable that returns an instance of `Storage`.

## Related issues
- Closes: #452 
