### PR TITLE
Add stubs for django.core.asgi

### DIFF
--- a/django-stubs/core/asgi.pyi
+++ b/django-stubs/core/asgi.pyi
@@ -1,0 +1,3 @@
+from django.core.handlers.asgi import ASGIHandler
+
+def get_asgi_application() -> ASGIHandler: ...


### PR DESCRIPTION
```
$ mypy app
app\asgi.py:12: error: Skipping analyzing 'django.core.asgi': found module but no type hints or library stubs
app\asgi.py:12: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```