### PR TITLE
Use more specific base classes in model exceptions

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,7 +1,11 @@
 from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from django.core.checks.messages import CheckMessage
-from django.core.exceptions import ValidationError
+from django.core.exceptions import (
+    ValidationError,
+    ObjectDoesNotExist,
+    MultipleObjectsReturned as BaseMultipleObjectsReturned,
+)
 from django.db.models.manager import BaseManager
 from django.db.models.options import Options
 
@@ -17,8 +21,8 @@ class ModelState:
 class ModelBase(type): ...
 
 class Model(metaclass=ModelBase):
-    class DoesNotExist(Exception): ...
-    class MultipleObjectsReturned(Exception): ...
+    class DoesNotExist(ObjectDoesNotExist): ...
+    class MultipleObjectsReturned(BaseMultipleObjectsReturned): ...
     class Meta: ...
     _meta: Options[Any]
     _default_manager: BaseManager[Model]


### PR DESCRIPTION
This changes the base classes for `Model.DoesNotExist` and `Model.MultipleObjectsReturned` to the correct base classes.