### PR TITLE
Fix #224 add paths in mypy's mypy_path option for import discovery

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,8 +1,10 @@
 import configparser
+import sys
 from functools import partial
 from typing import Callable, Dict, List, NoReturn, Optional, Tuple, cast
 
 from django.db.models.fields.related import RelatedField
+from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
 from mypy.options import Options
 from mypy.plugin import (
@@ -91,6 +93,10 @@ class NewSemanalDjangoPlugin(Plugin):
     def __init__(self, options: Options) -> None:
         super().__init__(options)
         django_settings_module = extract_django_settings_module(options.config_file)
+        # Add paths from MYPYPATH env var
+        sys.path.extend(mypy_path())
+        # Add paths from mypy_path config option
+        sys.path.extend(options.mypy_path)
         self.django_context = DjangoContext(django_settings_module)
 
     def _get_current_queryset_bases(self) -> Dict[str, int]:

--- a/test-data/typecheck/test_config.yml
+++ b/test-data/typecheck/test_config.yml
@@ -38,3 +38,30 @@
               class MyModel(models.Model):
                   user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
 
+-   case: add_mypy_path_to_package_search
+    main: |
+        import extra_module
+    mypy_config: |
+        [mypy]
+        mypy_path = ./extras
+        [mypy.plugins.django-stubs]
+        django_settings_module = mysettings
+    files:
+        -   path: extras/extra_module.py
+            content: |
+                def extra_fn():
+                  pass
+
+-   case: add_mypypath_env_var_to_package_search
+    main: |
+        import extra_module
+    mypy_config: |
+        [mypy.plugins.django-stubs]
+        django_settings_module = mysettings
+    env:
+      - MYPYPATH=./extras
+    files:
+        -   path: extras/extra_module.py
+            content: |
+                def extra_fn():
+                  pass


### PR DESCRIPTION
Search paths in mypy_path config option for module resolution

This allows packages to be located outside of PYTHONPATH and still be imported.

Adds a test for this feature
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues
Closes #224
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
