### PR TITLE
Fix ResourceWarning

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -81,7 +81,8 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
 
     parser = configparser.ConfigParser()
     try:
-        parser.read_file(open(cast(str, config_file_path)), source=config_file_path)
+        with open(cast(str, config_file_path)) as handle:
+            parser.read_file(handle, source=config_file_path)
     except (IsADirectoryError, OSError):
         exit(1)
 


### PR DESCRIPTION
# A tiny PR

A tiny PR: I run my projects with `PYTHONWARNINGS="default"`, and I constantly see a ResourceWarning with the latest `mypy`:
```php
me@my-computer /mnt/drive/projects/ytec-something/website $ mypy --config-file mypy.ini some_file.py 
/long/path/to/my/virtual/mypy_django_plugin/main.py:84: ResourceWarning: unclosed file <_io.TextIOWrapper name='mypy.ini' mode='r' encoding='UTF-8'>
  parser.read_file(open(cast(str, config_file_path)), source=config_file_path)
Success: no issues found in 1 source file
```

I prefer to see:
```php
me@my-computer /mnt/drive/projects/ytec-something/website $ mypy --config-file mypy.ini some_file.py 
Success: no issues found in 1 source file
```


## Related issues

None.