### PR TITLE
Add Point and Polygon to contrib.gis.geos

### DIFF
--- a/django-stubs/contrib/gis/geos/__init__.pyi
+++ b/django-stubs/contrib/gis/geos/__init__.pyi
@@ -8,3 +8,5 @@ from .factory import fromfile as fromfile, fromstr as fromstr
 from .geometry import GEOSGeometry as GEOSGeometry, hex_regex as hex_regex, wkt_regex as wkt_regex
 from .io import WKBReader as WKBReader, WKBWriter as WKBWriter, WKTReader as WKTReader, WKTWriter as WKTWriter
 from .linestring import LineString as LineString, LinearRing as LinearRing
+from .point import Point as Point
+from .polygon import Polygon as Polygon


### PR DESCRIPTION
The typings for these already existed, but they weren't included in `__init__.py`. This PR adds them!