### PR TITLE
AttributeError exception in copy_method_to_another_class

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -360,7 +360,7 @@ def copy_method_to_another_class(
 
     if isinstance(bound_return_type, PlaceholderNode):
         return
-    
+
     try:
         original_arguments = method_node.arguments[1:]
     except AttributeError:

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -360,9 +360,14 @@ def copy_method_to_another_class(
 
     if isinstance(bound_return_type, PlaceholderNode):
         return
+    
+    try:
+        original_arguments = method_node.arguments[1:]
+    except AttributeError:
+        original_arguments = []
 
     for arg_name, arg_type, original_argument in zip(
-        method_type.arg_names[1:], method_type.arg_types[1:], method_node.arguments[1:]
+        method_type.arg_names[1:], method_type.arg_types[1:], original_arguments
     ):
         bound_arg_type = semanal_api.anal_type(arg_type, allow_placeholder=True)
         if bound_arg_type is None and not semanal_api.final_iteration:


### PR DESCRIPTION
## Related issues

Closes #423

## Description

Issue #423 was marked closed by PR #429, but that PR seems to have not fully resolved the issue.  Later in the `copy_method_to_another_class` method, a very similar pattern still exists where we may be attempting to access an `.arguments` attribute that does not exist on a `FuncItem`/`method_node`.  This PR implements similar logic to PR #429 to resolve the issue in this spot as well.

## Related Error Log from `django-stubs==1.7.0` that this PR resolves

```
Traceback (most recent call last):
  File "mypy/semanal.py", line 4700, in accept
  File "mypy/nodes.py", line 940, in accept
  File "mypy/semanal.py", line 1011, in visit_class_def
  File "mypy/semanal.py", line 1088, in analyze_class
  File "mypy/semanal.py", line 1097, in analyze_class_body_common
  File "mypy/semanal.py", line 1157, in apply_class_plugin_hooks
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/main.py", line 38, in transform_model_class
    process_model_class(ctx, django_context)
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/transformers/models.py", line 357, in process_model_class
    initializer_cls(ctx, django_context).run()
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/transformers/models.py", line 71, in run
    self.run_with_model_cls(model_cls)
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/transformers/models.py", line 230, in run_with_model_cls
    custom_manager_type = self.create_new_model_parametrized_manager(custom_model_manager_name,
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/transformers/models.py", line 183, in create_new_model_parametrized_manager
    helpers.copy_method_to_another_class(new_cls_def_context,
  File "/Users/javulticat/projects/my_proj/env/lib/python3.8/site-packages/mypy_django_plugin/lib/helpers.py", line 358, in copy_method_to_another_class
    method_node.arguments[1:]):
AttributeError: attribute 'arguments' of 'FuncItem' undefined
```