### PR TITLE
Do not force django.contrib.* dependencies

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -148,7 +148,9 @@ class DjangoContext:
         raise ValueError("No primary key defined")
 
     def get_expected_types(self, api: TypeChecker, model_cls: Type[Model], *, method: str) -> Dict[str, MypyType]:
-        from django.contrib.contenttypes.fields import GenericForeignKey
+        contenttypes_in_apps = self.apps_registry.is_installed("django.contrib.contenttypes")
+        if contenttypes_in_apps:
+            from django.contrib.contenttypes.fields import GenericForeignKey
 
         expected_types = {}
         # add pk if not abstract=True
@@ -192,7 +194,7 @@ class DjangoContext:
 
                     expected_types[field_name] = model_set_type
 
-            elif isinstance(field, GenericForeignKey):
+            elif contenttypes_in_apps and isinstance(field, GenericForeignKey):
                 # it's generic, so cannot set specific model
                 field_name = field.name
                 gfk_info = helpers.lookup_class_typeinfo(api, field.__class__)

--- a/mypy_django_plugin/transformers/request.py
+++ b/mypy_django_plugin/transformers/request.py
@@ -8,6 +8,9 @@ from mypy_django_plugin.lib import helpers
 
 
 def set_auth_user_model_as_type_for_request_user(ctx: AttributeContext, django_context: DjangoContext) -> MypyType:
+    if not django_context.apps_registry.is_installed("django.contrib.auth"):
+        return ctx.default_attr_type
+
     # Imported here because django isn't properly loaded yet when module is loaded
     from django.contrib.auth.base_user import AbstractBaseUser
     from django.contrib.auth.models import AnonymousUser

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -27,6 +27,14 @@
             reveal_type(request.user) # N: Revealed type is 'django.contrib.auth.models.User'
     custom_settings: |
         INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth')
+-   case: request_object_user_without_auth_and_contenttypes_apps
+    disable_cache: true
+    main: |
+        from django.http.request import HttpRequest
+        request = HttpRequest()
+        reveal_type(request.user) # N: Revealed type is 'Union[django.contrib.auth.base_user.AbstractBaseUser, django.contrib.auth.models.AnonymousUser]'
+        if request.user.is_authenticated:
+            reveal_type(request.user) # N: Revealed type is 'django.contrib.auth.base_user.AbstractBaseUser'
 -   case: subclass_request_not_changed_user_type
     disable_cache: true
     main: |

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -35,6 +35,16 @@
         reveal_type(request.user) # N: Revealed type is 'Union[django.contrib.auth.base_user.AbstractBaseUser, django.contrib.auth.models.AnonymousUser]'
         if request.user.is_authenticated:
             reveal_type(request.user) # N: Revealed type is 'django.contrib.auth.base_user.AbstractBaseUser'
+-   case: request_object_user_without_auth_but_with_contenttypes_apps
+    disable_cache: true
+    main: |
+        from django.http.request import HttpRequest
+        request = HttpRequest()
+        reveal_type(request.user) # N: Revealed type is 'Union[django.contrib.auth.base_user.AbstractBaseUser, django.contrib.auth.models.AnonymousUser]'
+        if request.user.is_authenticated:
+            reveal_type(request.user) # N: Revealed type is 'django.contrib.auth.base_user.AbstractBaseUser'
+    custom_settings: |
+        INSTALLED_APPS = ('django.contrib.contenttypes',)
 -   case: subclass_request_not_changed_user_type
     disable_cache: true
     main: |


### PR DESCRIPTION
Only import stuff from `django.contrib.*`, if they're in `INSTALLED_APPS`, otherwise do not
type hint or use defaults that do not need the imports.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

Fixes #428.
Fixes #534.

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
