### PR TITLE
Update django_stubs_ext documentation to reference settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Install it:
 pip install django-stubs-ext  # as a production dependency
 ```
 
-And then place in your `manage.py`, `wsgi.py`, and `asgi.py` files:
+And then place in your top-level settings:
 
 ```python
 import django_stubs_ext
 
-django_stubs_ext.monkeypath()
+django_stubs_ext.monkeypatch()
 ```
 
 2. You can use strings instead: `'QuerySet[MyModel]'` and `'Manager[MyModel]'`, this way it will work as a type for `mypy` and as a regular `str` in runtime.

--- a/django_stubs_ext/README.md
+++ b/django_stubs_ext/README.md
@@ -20,10 +20,10 @@ In your Django application, use the following code:
 ```py
 import django_stubs_ext
 
-django_stubs_ext.monkeypath()
+django_stubs_ext.monkeypatch()
 ```
 
-This only needs to be called once, so the call to `monkeypatch` should be placed in your top-level urlconf.
+This only needs to be called once, so the call to `monkeypatch` should be placed in your top-level settings.
 
 ## Version compatibility
 


### PR DESCRIPTION
This change fixes two issues in the django_stubs_ext documentation:

1) The call to `django_stubs_ext.monkeypatch()` works best in settings
2) The example code had a typo ("monkeypath" -> "monkeypatch")

## Related issues

- Closes #544