### PR TITLE
Tweak the constructor signature for ManyToManyField

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -189,7 +189,7 @@ class ManyToManyField(RelatedField[_ST, _GT]):
     swappable: bool = ...
     def __init__(
         self,
-        to: Union[Type[_T], str],
+        to: Union[Type[Model], str],
         related_name: Optional[str] = ...,
         related_query_name: Optional[str] = ...,
         limit_choices_to: Optional[Union[Dict[str, Any], Callable[[], Any], Q]] = ...,

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -672,3 +672,9 @@
                     objects = OrderManager()
                     user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='orders')
 
+-   case: many_to_many_field_can_be_used_in_alias
+    main: |
+        from typing import TypeVar, Sequence, Union
+        from django.db import models
+        T = TypeVar("T", bound=models.Model)
+        ManyToManyFieldAlias = Union["models.ManyToManyField[Sequence[T], models.manager.RelatedManager[T]]"]


### PR DESCRIPTION
Prior to this change, ManyToManyField was declared as being generic in
`_ST` and `_GT`, but also used the `_T` Typevar in its `__init__` signature.
This caused mypy to add `_T` to the variables it was generic in when used
as an alias.

The symptom of this problem was that mypy would show an error with the
message "Type application has too few types (3 expected)" where a
ManyToManyField alias was declared, but adding an extra argument would
fail because the type only takes two arguments.

This change brings the signature of ManyToManyField in line with
ForeignKey and OneToOneField.

## Related issues

None - I can raise one if required.