### PR TITLE
Create related managers from generated managers

### DIFF
--- a/scripts/enabled_test_modules.py
+++ b/scripts/enabled_test_modules.py
@@ -290,7 +290,7 @@ IGNORED_ERRORS = {
         'Incompatible types in assignment (expression has type "HttpResponseBase", variable has type "HttpResponse")',
     ],
     "many_to_many": [
-        '(expression has type "List[Article]", variable has type "Article_RelatedManager2',
+        '(expression has type "List[Article]", variable has type "Publication_Article_RelatedManager1',
         '"add" of "RelatedManager" has incompatible type "Article"; expected "Union[Publication, int]"',
     ],
     "many_to_one": [

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -652,10 +652,18 @@
 
 -   case: related_manager_is_a_subclass_of_default_manager
     main: |
-        from myapp.models import User
-        reveal_type(User().orders)  # N: Revealed type is 'myapp.models.Order_RelatedManager'
+        from myapp.models import User, Order, Product
+        reveal_type(User().orders)  # N: Revealed type is 'myapp.models.User_Order_RelatedManager1'
         reveal_type(User().orders.get())  # N: Revealed type is 'myapp.models.Order*'
         reveal_type(User().orders.manager_method())  # N: Revealed type is 'builtins.int'
+        reveal_type(Order().products)  # N: Revealed type is 'myapp.models.Order_Product_RelatedManager1'
+        reveal_type(Order().products.get())  # N: Revealed type is 'myapp.models.Product*'
+        reveal_type(Order().products.queryset_method())  # N: Revealed type is 'builtins.int'
+        # TODO: realted manager support to use the same type for all related managers
+        if 1 == 2:
+            manager = User().products
+        else:
+            manager = Order().products  # E: Incompatible types in assignment (expression has type "Order_Product_RelatedManager1", variable has type "User_Product_RelatedManager1")
     installed_apps:
         - myapp
     files:
@@ -671,6 +679,46 @@
                 class Order(models.Model):
                     objects = OrderManager()
                     user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='orders')
+                class ProductQueryset(models.QuerySet):
+                    def queryset_method(self) -> int:
+                        pass
+                ProductManager = models.Manager.from_queryset(ProductQueryset)
+                class Product(models.Model):
+                    objects = ProductManager()
+                    order = models.ForeignKey(to=Order, on_delete=models.CASCADE, related_name='products')
+                    user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='products')
+
+-   case: related_manager_no_conflict_from_star_import
+    main: |
+        import myapp.models
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models/__init__.py
+            content: |
+                from myapp.models.a import *
+                # make sure generated related manager from address to user doesn't have
+                # the same name with related manager from profile to user
+                from myapp.models.b import *
+        -   path: myapp/models/a.py
+            content: |
+                from django.db import models
+                class Address(models.Model):
+                    pass
+        -   path: myapp/models/b.py
+            content: |
+                from django.db import models
+                from .a import Address
+                class Profile(models.Model):
+                    pass
+                class UserQuerySet(models.QuerySet):
+                    pass
+                UserManager = models.Manager.from_queryset(UserQuerySet)
+                class User(models.Model):
+                    address = models.ForeignKey(Address, on_delete=models.CASCADE)
+                    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+                    objects = UserManager()
 
 -   case: many_to_many_field_can_be_used_in_alias
     main: |


### PR DESCRIPTION
Right now related managers don't detect generated managers, this pr fixes that by generating related manager for each related field. There's a problem left, types may conflict because of the same name, eg:

```
a.py:
AddressManager = Manager.from_queryset(AddressQuerySet)
class Address:
     ...

b.py:

class Profile:
     ...

c.py:
UserManager = Manager.from_queryset(UserQuerySet)
class User:
    address = ForeignKey(Address)
    profile = ForeignKey(Profile)
    objects = UserManager()

d.py:
from a import * # that will import generated User_RelatedManager
from b import * # that will import generated User_RelatedManager too
# as a result mypy will complain that two entities with the same name have different types
```

Possible solutions:
1) append model name to generated name, for example above names would be: `Address_User_RelatedManager` and `Profile_User_RelatedManager`
2) generate related manager at the same time when the manager generated, place it at the same module and reuse with all relations

The second approach is probably better because it returns the same type for all related managers, as a result code like below won't complain that two different types assigned to `qs` variable:

```
if cond:
   qs = address.users  
else:
   qs = profile.users
```

Thoughts? @sobolevn 
