### PR TITLE
compatibility matrix doc change for new django-stubs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs | mypy version | django version | python version
 | ------------ | ---- | ---- | ---- |
+| 1.8.0 | 0.812 | 2.2.x \|\| 3.x | ^3.6
 | 1.7.0 | 0.790 | 2.2.x \|\| 3.x | ^3.6
 | 1.6.0 | 0.780 | 2.2.x \|\| 3.x | ^3.6
 | 1.5.0 | 0.770 | 2.2.x \|\| 3.x | ^3.6


### PR DESCRIPTION
- Closes #575

I saw this and thought it would be easy to close. Please note that I set the release number to 1.8 because in your comment you said that you would be making a new release soon. I can easily change it back to 1.7.