### PR TITLE
Adjust Postgres indexes for Django 3.2

### DIFF
--- a/django-stubs/contrib/postgres/indexes.pyi
+++ b/django-stubs/contrib/postgres/indexes.pyi
@@ -1,82 +1,90 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from django.db.models.query_utils import Q
 
 from django.db.models import Index
+from django.db.models.expressions import BaseExpression, Combinable
+
 
 class PostgresIndex(Index): ...
 
 class BrinIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         autosummarize: Optional[bool] = ...,
         pages_per_range: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...
 
 class BTreeIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         fillfactor: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...
 
 class GinIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         fastupdate: Optional[bool] = ...,
         gin_pending_list_limit: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...
 
 class GistIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         buffering: Optional[bool] = ...,
         fillfactor: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...
 
 class HashIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         fillfactor: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...
 
 class SpGistIndex(PostgresIndex):
     def __init__(
         self,
-        *,
+        *expressions: Union[BaseExpression, Combinable, str],
         fillfactor: Optional[int] = ...,
         fields: Sequence[str] = ...,
         name: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         opclasses: Sequence[str] = ...,
-        condition: Optional[Q] = ...
+        condition: Optional[Q] = ...,
+        include: Optional[Sequence[str]] = ...,
     ) -> None: ...

--- a/tests/typecheck/contrib/postgres/test_indexes.yml
+++ b/tests/typecheck/contrib/postgres/test_indexes.yml
@@ -1,0 +1,18 @@
+-   case: can_instantiate_index
+    main: |
+        from django.db import models
+        from django.db.models.functions import Lower
+        from django.contrib.postgres.indexes import {{ index }}
+        {{ index }}(fields=["foo"])
+        {{ index }}(models.F("bar"), name="test")
+        {{ index }}("foo", models.F("bar"), Lower("baz"), name="test")
+        {{ index }}("foo", name="test", opclasses=["bar"])
+        {{ index }}("foo", name="test", condition=models.Q(foo=1))
+        {{ index }}("foo", name="test", include=["bar"])
+    parametrized:
+    -   index: BrinIndex
+    -   index: BTreeIndex
+    -   index: GinIndex
+    -   index: GistIndex
+    -   index: HashIndex
+    -   index: SpGistIndex

--- a/tests/typecheck/models/test_indexes.yml
+++ b/tests/typecheck/models/test_indexes.yml
@@ -3,6 +3,7 @@
         from django.db import models
         from django.db.models.functions import Lower
         models.Index(fields=["foo"])
+        models.Index(models.F("bar"), name="test")
         models.Index("foo", models.F("bar"), Lower("baz"), name="test")
         models.Index("foo", name="test", opclasses=["bar"])
         models.Index("foo", name="test", condition=models.Q(foo=1))


### PR DESCRIPTION
Adds support to the Postgres-specific indexes for instantiating with [`*expressions`](https://docs.djangoproject.com/en/3.2/ref/models/indexes/#expressions) and the new [`include` argument](https://docs.djangoproject.com/en/3.2/ref/models/indexes/#include).

## Related issues

- Refs #587 (builds on top of, briefly mentioned this change in discussion).