### PR TITLE
Add stub for OpClass

### DIFF
--- a/django-stubs/contrib/postgres/indexes.pyi
+++ b/django-stubs/contrib/postgres/indexes.pyi
@@ -2,7 +2,7 @@ from typing import Optional, Sequence, Union
 
 from django.db.models.query_utils import Q
 
-from django.db.models import Index
+from django.db.models import Index, Func
 from django.db.models.expressions import BaseExpression, Combinable
 
 
@@ -87,4 +87,11 @@ class SpGistIndex(PostgresIndex):
         opclasses: Sequence[str] = ...,
         condition: Optional[Q] = ...,
         include: Optional[Sequence[str]] = ...,
+    ) -> None: ...
+
+class OpClass(Func):
+    def __init__(
+        self,
+        expression: Union[BaseExpression, Combinable, str],
+        name: str,
     ) -> None: ...

--- a/tests/typecheck/contrib/postgres/test_indexes.yml
+++ b/tests/typecheck/contrib/postgres/test_indexes.yml
@@ -16,3 +16,13 @@
     -   index: GistIndex
     -   index: HashIndex
     -   index: SpGistIndex
+
+-   case: can_instantiate_opclass
+    main: |
+        from django.db.models import Index
+        from django.db.models.functions import Lower
+        from django.contrib.postgres.indexes import OpClass
+        Index(
+            OpClass(Lower('username'), name='varchar_pattern_ops'),
+            name='lower_username_idx',
+        )


### PR DESCRIPTION
Adds type hints for the new Postgres-specific [`OpClass`](https://docs.djangoproject.com/en/3.2/ref/contrib/postgres/indexes/#opclass-expressions). I missed this one in the previous PR :)

## Related issues

- Refs #616