### PR TITLE
add concrete attr to db.models.Field #622

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -72,6 +72,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     choices: _FieldChoices = ...
     db_column: Optional[str]
     column: str
+    concrete: bool
     default: Any
     error_messages: _ErrorMessagesToOverride
     def __init__(


### PR DESCRIPTION
Adding missing `concrete` attribute to `db.models.Field`.

related issue: https://github.com/typeddjango/django-stubs/issues/622