### PR TITLE
fix empty_value of TypedChoiceField

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -224,11 +224,11 @@ class ChoiceField(Field):
 
 class TypedChoiceField(ChoiceField):
     coerce: Union[Callable, Type[Any]] = ...
-    empty_value: Optional[str] = ...
+    empty_value: Optional[Any] = ...
     def __init__(
         self,
         coerce: Any = ...,
-        empty_value: Optional[str] = ...,
+        empty_value: Optional[Any] = ...,
         choices: Any = ...,
         required: bool = ...,
         widget: Optional[Union[Widget, Type[Widget]]] = ...,
@@ -251,7 +251,7 @@ class TypedMultipleChoiceField(MultipleChoiceField):
     def __init__(
         self,
         coerce: Any = ...,
-        empty_value: Optional[str] = ...,
+        empty_value: Optional[Any] = ...,
         choices: Any = ...,
         required: bool = ...,
         widget: Optional[Union[Widget, Type[Widget]]] = ...,


### PR DESCRIPTION
Hi!

I have a valid django code something like this:

```
class FineTuningsForm(forms.Form):

    LIFETIME_TYPE_MINUTES = 60
    LIFETIME_TYPE_HOURS = 60 * 60
    LIFETIME_TYPE_DAYS = 24 * 60 * 60
    LIFETIME_TYPE_CHOICES = [
        (LIFETIME_TYPE_MINUTES, _('минут')),
        (LIFETIME_TYPE_HOURS, _('часов')),
        (LIFETIME_TYPE_DAYS, _('дней')),
    ]

    DAYS_MAX_LIFETIME_VAL = 10
    DEFAULT_LIFETIME_VAL = 7
    DEFAULT_LIFETIME_TYPE = LIFETIME_TYPE_DAYS
    DEFAULT_LIFETIME = DEFAULT_LIFETIME_TYPE * DEFAULT_LIFETIME_VAL

    call_lifetime_type = forms.TypedChoiceField(
        choices=LIFETIME_TYPE_CHOICES,
        initial=DEFAULT_LIFETIME_TYPE,
        empty_value=DEFAULT_LIFETIME_TYPE,
        coerce=int,
        required=False,
    )
```

But `mypy` throws error: `Argument "empty_value" to "TypedChoiceField" has incompatible type "int"; expected "Optional[str]"`

If I change line `empty_value=DEFAULT_LIFETIME_TYPE,` to `empty_value=str(DEFAULT_LIFETIME_TYPE),` so tests will fail.

