### PR TITLE
Adds support for pyproject.toml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ django_settings_module = "myproject.settings"
 
 in your `mypy.ini` or `setup.cfg` [file](https://mypy.readthedocs.io/en/latest/config_file.html).
 
-Two things happeining here:
+[pyproject.toml](https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file) configurations are also supported:
+
+```toml
+[tool.mypy]
+plugins = ["mypy_django_plugin.main"]
+
+[tool.django-stubs]
+django_settings_module = "myproject.settings"
+```
+
+Two things happening here:
 
 1. We need to explicitly list our plugin to be loaded by `mypy`
 2. Our plugin also requires `django` settings module (what you put into `DJANGO_SETTINGS_MODULE` variable) to be specified

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,6 @@ pre-commit==2.7.1
 pytest==6.1.1
 pytest-mypy-plugins==1.6.1
 psycopg2-binary
+types-toml==0.1.1
 -e ./django_stubs_ext
 -e .

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -54,6 +54,10 @@ class IncompleteDefnException(Exception):
     pass
 
 
+def is_toml(filename: str) -> bool:
+    return filename.lower().endswith(".toml")
+
+
 def lookup_fully_qualified_sym(fullname: str, all_modules: Dict[str, MypyFile]) -> Optional[SymbolTableNode]:
     if "." not in fullname:
         return None

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,5 +1,6 @@
 import configparser
 import sys
+import textwrap
 from functools import partial
 from typing import Callable, Dict, List, NoReturn, Optional, Tuple, cast
 
@@ -64,15 +65,14 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
         """
         from mypy.main import CapturableArgumentParser
 
-        usage = """(config)
+        usage = """
+        (config)
         ...
         [mypy.plugins.django_stubs]
             django_settings_module: str (required)
         ...
-        """.replace(
-            "\n" + 8 * " ", "\n"
-        )
-        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=usage)
+        """
+        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=textwrap.dedent(usage))
         messages = {
             1: "mypy config file is not specified or found",
             2: "no section [mypy.plugins.django-stubs]",
@@ -83,15 +83,14 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
     def exit_toml(error_type: int) -> NoReturn:
         from mypy.main import CapturableArgumentParser
 
-        usage = """(config)
+        usage = """
+        (config)
         ...
         [tool.django-stubs]
         django_settings_module = str (required)
         ...
-        """.replace(
-            "\n" + 8 * " ", "\n"
-        )
-        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=usage)
+        """
+        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=textwrap.dedent(usage))
         messages = {
             1: "mypy config file is not specified or found",
             2: "no section [tool.django-stubs]",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ dependencies = [
     "django",
     "django-stubs-ext",
     "types-pytz",
+    "toml",
 ]
 
 setup(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -5,7 +5,8 @@ import pytest
 
 from mypy_django_plugin.main import extract_django_settings_module
 
-TEMPLATE = """usage: (config)
+TEMPLATE = """
+(config)
 ...
 [mypy.plugins.django_stubs]
     django_settings_module: str (required)
@@ -13,7 +14,8 @@ TEMPLATE = """usage: (config)
 (django-stubs) mypy: error: 'django_settings_module' is not set: {}
 """
 
-TEMPLATE_TOML = """usage: (config)
+TEMPLATE_TOML = """
+(config)
 ...
 [tool.django-stubs]
 django_settings_module = str (required)
@@ -60,7 +62,7 @@ def test_misconfiguration_handling(capsys, config_file_contents, message_part):
         with pytest.raises(SystemExit, match="2"):
             extract_django_settings_module(config_file.name)
 
-    error_message = TEMPLATE.format(message_part)
+    error_message = "usage: " + TEMPLATE.format(message_part)
     assert error_message == capsys.readouterr().err
 
 
@@ -98,7 +100,7 @@ def test_toml_misconfiguration_handling(capsys, config_file_contents, message_pa
         with pytest.raises(SystemExit, match="2"):
             extract_django_settings_module(config_file.name)
 
-    error_message = TEMPLATE_TOML.format(message_part)
+    error_message = "usage: " + TEMPLATE_TOML.format(message_part)
     assert error_message == capsys.readouterr().err
 
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -13,6 +13,14 @@ TEMPLATE = """usage: (config)
 (django-stubs) mypy: error: 'django_settings_module' is not set: {}
 """
 
+TEMPLATE_TOML = """usage: (config)
+...
+[tool.django-stubs]
+django_settings_module = str (required)
+...
+(django-stubs) mypy: error: 'django_settings_module' not found or invalid: {}
+"""
+
 
 @pytest.mark.parametrize(
     "config_file_contents,message_part",
@@ -54,6 +62,60 @@ def test_misconfiguration_handling(capsys, config_file_contents, message_part):
 
     error_message = TEMPLATE.format(message_part)
     assert error_message == capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "config_file_contents,message_part",
+    [
+        (
+            """
+            [tool.django-stubs]
+            django_settings_module = 123
+            """,
+            "the setting must be a string",
+        ),
+        (
+            """
+            [tool.not-really-django-stubs]
+            django_settings_module = "my.module"
+            """,
+            "no section [tool.django-stubs]",
+        ),
+        (
+            """
+            [tool.django-stubs]
+            not_django_not_settings_module = "badbadmodule"
+            """,
+            "the setting is not provided",
+        ),
+    ],
+)
+def test_toml_misconfiguration_handling(capsys, config_file_contents, message_part):
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".toml") as config_file:
+        config_file.write(config_file_contents)
+        config_file.seek(0)
+
+        with pytest.raises(SystemExit, match="2"):
+            extract_django_settings_module(config_file.name)
+
+    error_message = TEMPLATE_TOML.format(message_part)
+    assert error_message == capsys.readouterr().err
+
+
+def test_correct_toml_configuration() -> None:
+    config_file_contents = """
+    [tool.django-stubs]
+    some_other_setting = "setting"
+    django_settings_module = "my.module"
+    """
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".toml") as config_file:
+        config_file.write(config_file_contents)
+        config_file.seek(0)
+
+        extracted = extract_django_settings_module(config_file.name)
+
+    assert extracted == "my.module"
 
 
 def test_correct_configuration() -> None:


### PR DESCRIPTION
Since mypy 0.900 the pyproject.toml files are supported.

This PR adds a support for it. It searchs for a `tool.django-stubs` section. This is an example configuration:

```
[tool.django-stubs]
django_settings_module = "config.settings.local"
```

Fixes #638

