### PR TITLE
Allow Collection for 'fields' and 'exclude' of form model helpers (#637)

### DIFF
--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -37,7 +37,7 @@ from django.db.models import ForeignKey
 
 ALL_FIELDS: str
 
-_Fields = Union[List[Union[Callable, str]], Collection[str], Literal["__all__"]]
+_Fields = Union[Collection[str], Literal["__all__"]]
 _Labels = Dict[str, str]
 _ErrorMessages = Dict[str, Dict[str, str]]
 

--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Iterator,
     List,
@@ -36,7 +37,7 @@ from django.db.models import ForeignKey
 
 ALL_FIELDS: str
 
-_Fields = Union[List[Union[Callable, str]], Sequence[str], Literal["__all__"]]
+_Fields = Union[List[Union[Callable, str]], Collection[str], Literal["__all__"]]
 _Labels = Dict[str, str]
 _ErrorMessages = Dict[str, Dict[str, str]]
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.790",
+    "mypy>=0.790,<0.900",
     "typing-extensions",
     "django",
     "django-stubs-ext",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.790,<0.900",
+    "mypy>=0.900",
     "typing-extensions",
     "django",
     "django-stubs-ext",


### PR DESCRIPTION
## Related issues

Closes #637

There are several functions and classes in `django.forms.models` that take a `fields` or `exclude` argument. Previously, `Sequence` was used to annotate these, but the code of Django (I checked version 3.2.4) doesn't require `__getitem__()` to be implemented, so requiring `Collection` instead is sufficient.

The practical advantage of requiring `Collection` is that a set, such as the key set of a dictionary, can be passed without first having to convert it to a list or tuple.

---

By the way, the full definition of `_Fields` is:
```py
_Fields = Union[List[Union[Callable, str]], Collection[str], Literal["__all__"]]
```
The `Literal["__all__"]` is for accepting `ALL_FIELDS`, but I don't know what `List[Union[Callable, str]]` is for. I couldn't find any code or documentation that treats elements of `fields` and `exclude` as callable.
