### PR TITLE
Copy decorated queryset methods to manager too

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -1,4 +1,4 @@
-from mypy.nodes import GDEF, FuncDef, MemberExpr, NameExpr, RefExpr, StrExpr, SymbolTableNode, TypeInfo
+from mypy.nodes import GDEF, Decorator, FuncDef, MemberExpr, NameExpr, RefExpr, StrExpr, SymbolTableNode, TypeInfo
 from mypy.plugin import ClassDefContext, DynamicClassDefContext
 from mypy.types import AnyType, Instance, TypeOfAny
 
@@ -67,6 +67,11 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
             break
         for name, sym in class_mro_info.names.items():
             if isinstance(sym.node, FuncDef):
-                helpers.copy_method_to_another_class(
-                    class_def_context, self_type, new_method_name=name, method_node=sym.node
-                )
+                func_node = sym.node
+            elif isinstance(sym.node, Decorator):
+                func_node = sym.node.func
+            else:
+                continue
+            helpers.copy_method_to_another_class(
+                class_def_context, self_type, new_method_name=name, method_node=func_node
+            )

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -179,3 +179,25 @@
                 class BaseQuerySet(models.QuerySet):
                     def base_queryset_method(self, param: Union[int, str]) -> NoReturn:
                         raise ValueError
+
+-   case: from_queryset_with_decorated_queryset_methods
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.MyModel_NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models, transaction
+
+                class ModelQuerySet(models.QuerySet):
+                    @transaction.atomic
+                    def queryset_method(self) -> str:
+                        return 'hello'
+
+                NewManager = models.Manager.from_queryset(ModelQuerySet)
+                class MyModel(models.Model):
+                    objects = NewManager()


### PR DESCRIPTION
# I have made things!

This pull request adds support for copying decorated method types from the QuerySet to the Manager when using `Manager.from_queryset`. It assumes that the decorator returns a function with the same signature as the decorated function, which handles common cases like `lru_cache` and `transaction.atomic`.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

The issue is that only `FuncDef` nodes are copied to the manager class type generated by a call to `Manager.from_queryset`. Most notably, this leaves out decorated methods. I don't think there's an existing issue for this.

Here's an example:

```python
from django.db import models, transaction
from typing import TYPE_CHECKING

class TestQuerySet(models.QuerySet["Test"]):
    @transaction.atomic
    def test_queryset_method(self):
        return self

TestManager = models.Manager.from_queryset(TestQuerySet)

class Test(models.Model):
    objects = TestManager()

if TYPE_CHECKING:
    reveal_type(Test.objects.test_queryset_method)
```

At the `reveal_type` there's a type error about TestManager having no attribute `test_queryset_method`. With this fix it works as expected.

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
