### PR TITLE
Add distinct, order_by and all method signatures for _ValuesQuerySet

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -169,6 +169,9 @@ class _ValuesQuerySet(Generic[_T, _Row], Collection[_Row], Reversible[_Row], Que
     def latest(self, *fields: Any, field_name: Optional[Any] = ...) -> _Row: ...  # type: ignore
     def first(self) -> Optional[_Row]: ...  # type: ignore
     def last(self) -> Optional[_Row]: ...  # type: ignore
+    def distinct(self, *field_names: Any) ->  _ValuesQuerySet[_T, _Row]: ... # type: ignore
+    def order_by(self, *field_names: Any) -> _ValuesQuerySet[_T, _Row]: ... # type: ignore
+    def all(self) -> _ValuesQuerySet[_T, _Row]: ... # type: ignore
 
 class RawQuerySet(Iterable[_T], Sized):
     query: RawQuery

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -26,6 +26,25 @@
                     name = models.CharField(max_length=100)
                     age = models.IntegerField()
 
+-   case: values_list_supports_queryset_methods
+    main: |
+        from myapp.models import MyUser
+        query = MyUser.objects.values_list('name')
+        reveal_type(query.order_by("name").get())  # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.distinct("name").get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.distinct().get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.all().get()) # N: Revealed type is "Tuple[builtins.str]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyUser(models.Model):
+                    name = models.CharField(max_length=100)
+                    age = models.IntegerField()
+
 -   case: values_list_related_model_fields
     main: |
         from myapp.models import Post, Blog


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

Solves incorrect results reported by `django-stubs` when using `values_list` and `values`:

```
core/models/foo.py:100: error: "_ValuesQuerySet[Foo, Any]" has no attribute "distinct"
core/models/foo.py:119: error: "_ValuesQuerySet[Foo, str]" has no attribute "distinct"
```

```
core/tasks.py:32: error: "_ValuesQuerySet[Foo, int]" has no attribute "order_by"
```

```
core/tasks.py:154: error: "_ValuesQuerySet[Foo, int]" has no attribute "order_by"
```

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
