### PR TITLE
Add more method signatures for _ValuesQuerySet

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -154,6 +154,9 @@ class _ValuesQuerySet(Generic[_T, _Row], Collection[_Row], Reversible[_Row], Que
     def distinct(self, *field_names: Any) ->  _ValuesQuerySet[_T, _Row]: ... # type: ignore
     def order_by(self, *field_names: Any) -> _ValuesQuerySet[_T, _Row]: ... # type: ignore
     def all(self) -> _ValuesQuerySet[_T, _Row]: ... # type: ignore
+    def annotate(self, *args: Any, **kwargs: Any) -> _ValuesQuerySet[_T, Any]: ...
+    def filter(self, *args: Any, **kwargs: Any) -> _ValuesQuerySet[_T, _Row]: ...
+    def exclude(self, *args: Any, **kwargs: Any) -> _ValuesQuerySet[_T, _Row]: ...
 
 class RawQuerySet(Iterable[_T], Sized):
     query: RawQuery

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -29,11 +29,15 @@
 -   case: values_list_supports_queryset_methods
     main: |
         from myapp.models import MyUser
+        from django.db.models.functions import Length
         query = MyUser.objects.values_list('name')
         reveal_type(query.order_by("name").get())  # N: Revealed type is "Tuple[builtins.str]"
         reveal_type(query.distinct("name").get()) # N: Revealed type is "Tuple[builtins.str]"
         reveal_type(query.distinct().get()) # N: Revealed type is "Tuple[builtins.str]"
         reveal_type(query.all().get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.filter(age__gt=16).get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.exclude(age__lte=16).get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.annotate(name_length=Length("name")).get()) # N: Revealed type is "Any"
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
# I have made things!

Follow up from #657 - I found more cases in my codebase where method signatures where incorrectly missing.

Looking at https://github.com/typeddjango/django-stubs/issues/608 it seems like this issue has been discussed at length already about why this is an issue.

My initial thoughts was that maybe there was a way of having:

- an internal `_QuerySet[_T, _Row]` type
- an external facing alias `QuerySet[_T]` which is equivalent to `_QuerySet[_T, _T]`
- values list would then return `_QuerySet[_T, _Row]` as appropriate.

But based on the conversation you've had it seems like this might be harder than I assume it is?

The downside of keeping it in the current way is that we essentially need to redefine all `QuerySet` method signatures twice: Once for `QuerySet` and once for `_ValuesQuerySet`

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
