### PR TITLE
Add @display to django.contrib.admin

### DIFF
--- a/django-stubs/contrib/admin/__init__.pyi
+++ b/django-stubs/contrib/admin/__init__.pyi
@@ -1,5 +1,6 @@
 from . import checks as checks
 from .decorators import action as action
+from .decorators import display as display
 from .decorators import register as register
 from .filters import AllValuesFieldListFilter as AllValuesFieldListFilter
 from .filters import BooleanFieldListFilter as BooleanFieldListFilter


### PR DESCRIPTION
The `display` decorator is defined in `django.contrib.admin.decorators`, but
isn't included in `django.contrib.admin`, which is how the Django docs describe
its usage.