### PR TITLE
Change PasswordResetForm.get_users() to return Iterable, not Iterator.

### DIFF
--- a/django-stubs/contrib/auth/forms.pyi
+++ b/django-stubs/contrib/auth/forms.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from django import forms
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -52,7 +52,7 @@ class PasswordResetForm(forms.Form):
         to_email: str,
         html_email_template_name: Optional[str] = ...,
     ) -> None: ...
-    def get_users(self, email: str) -> Iterator[Any]: ...
+    def get_users(self, email: str) -> Iterable[Any]: ...
     def save(
         self,
         domain_override: Optional[str] = ...,


### PR DESCRIPTION
This matches the actual implementation in Django, where it only attempts to [use the result of get_users() in a for loop](https://github.com/django/django/blob/3.2.5/django/contrib/auth/forms.py#L298), which allows for any Iterable, and it provides a more flexible and idiomatic API for users who subclass PasswordResetForm.

For what it's worth, we've had (untyped) code since Django 1.11 that subclasses `PasswordResetForm` and overrides `get_users()` by returning a QuerySet of users, and it's been working fine.