### PR TITLE
Change PasswordResetForm.save() to accept HttpRequest, not WSGIRequest.

### DIFF
--- a/django-stubs/contrib/auth/forms.pyi
+++ b/django-stubs/contrib/auth/forms.pyi
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
+from django.http.request import HttpRequest
 
 UserModel: Any
 
@@ -61,7 +62,7 @@ class PasswordResetForm(forms.Form):
         use_https: bool = ...,
         token_generator: PasswordResetTokenGenerator = ...,
         from_email: Optional[str] = ...,
-        request: Optional[WSGIRequest] = ...,
+        request: Optional[HttpRequest] = ...,
         html_email_template_name: Optional[str] = ...,
         extra_email_context: Optional[Dict[str, str]] = ...,
     ) -> None: ...


### PR DESCRIPTION
This changes the `request` argument of `PasswordResetForm.save()` to be an `Optional[HttpRequest]` rather than `Optional[WSGIRequest]`. In general, Django's APIs mostly only care about getting an `HttpRequest`, not a `WSGIRequest`, since the latter is just a lightweight wrapper that bridges a raw request from WSGI to Django's `HttpRequest` type.

## Related issues
Closes #552.