### PR TITLE
Fix `BaseModelForm` not working with generic type parameter

### DIFF
--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -6,6 +6,7 @@ from django.contrib.admin.options import BaseModelAdmin
 from django.db.models.fields import Field
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
+from django.forms.models import BaseModelForm
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import FormMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -44,6 +45,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(MultipleObjectMixin),
     MPGeneric(BaseModelAdmin),
     MPGeneric(Field),
+    MPGeneric(BaseModelForm),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/django_stubs_ext/tests/test_monkeypatching.py
+++ b/django_stubs_ext/tests/test_monkeypatching.py
@@ -5,6 +5,8 @@ from typing import Optional
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
+from django.db.models import Model
+from django.forms.models import ModelForm
 from typing_extensions import Protocol
 
 import django_stubs_ext
@@ -45,6 +47,9 @@ def test_patched_generics(make_generic_classes: _MakeGenericClasses) -> None:
     for el in _need_generic:
         if el.version is None:
             assert el.cls[type] is el.cls  # `type` is arbitrary
+
+    class TestForm(ModelForm[Model]):
+        pass
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: https://github.com/typeddjango/django-stubs/issues/703
