### PR TITLE
Add `typing-extension` as a direct dependency of `django-stubs-ext`

### DIFF
--- a/django_stubs_ext/setup.py
+++ b/django_stubs_ext/setup.py
@@ -7,6 +7,7 @@ with open("README.md") as f:
 
 dependencies = [
     "django",
+    "typing-extensions",
 ]
 
 setup(


### PR DESCRIPTION
Needed, because `django-stubs-ext` generally has to specified as a
production dependency (to use the monkey patching). `django-stubs` does
have `typing-extensions` as a dependency, but it is often used only as a
dev dependency as it has not runtime functionality.

Resolves: https://github.com/typeddjango/django-stubs/issues/702
