### PR TITLE
Add through_defaults for RelatedManager methods

### DIFF
--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -1,6 +1,7 @@
 import datetime
 from typing import (
     Any,
+    Callable,
     Dict,
     Generic,
     Iterable,
@@ -121,10 +122,23 @@ class Manager(BaseManager[_T]): ...
 
 class RelatedManager(Manager[_T]):
     related_val: Tuple[int, ...]
-    def add(self, *objs: Union[_T, int], bulk: bool = ...) -> None: ...
+    def add(
+        self,
+        *objs: Union[_T, int],
+        bulk: bool = ...,
+        through_defaults: Optional[Union[Dict[str, Any], Callable]] = None...,
+    ) -> None: ...
+    def create(
+        self, **kwargs: Any, through_defaults: Optional[Union[Dict[str, Any], Callable]] = None...,
+    ) -> None: ...
     def remove(self, *objs: Union[_T, int], bulk: bool = ...) -> None: ...
     def set(
-        self, objs: Union[QuerySet[_T], Iterable[Union[_T, int]]], *, bulk: bool = ..., clear: bool = ...
+        self,
+        objs: Union[QuerySet[_T], Iterable[Union[_T, int]]],
+        *,
+        bulk: bool = ...,
+        clear: bool = ..., 
+        through_defaults: Optional[Union[Dict[str, Any], Callable]] = None...,
     ) -> None: ...
     def clear(self) -> None: ...
 


### PR DESCRIPTION
This PR:
- adds the `create` method stub of the RelatedManager class
- adds types for the `through_defaults` kwarg for the `create`, `add`, and `set` methods of the RelatedManager class

Documentation: https://docs.djangoproject.com/en/3.2/ref/models/relations/