### PR TITLE
Fix nullability for fields with non-None default. Fixes #444

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -277,7 +277,9 @@ class DjangoContext:
         if method == "create":
             if isinstance(field, AutoField):
                 return True
-        if isinstance(field, Field) and field.has_default():
+            if isinstance(field, Field) and field.primary_key and field.has_default() and field.default is not None:
+                return True
+        if isinstance(field, Field) and field.has_default() and field.default is None:
             return True
         return nullable
 

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -281,3 +281,22 @@
                 class Blog(models.Model):
                     num_posts = models.IntegerField()
                     text = models.CharField(max_length=100, blank=True)
+
+-   case: values_list_field_defaults
+    main: |
+        from myapp.models import MyModel
+        values_tuple = MyModel.objects.values_list().get()
+        reveal_type(values_tuple[1])  # N: Revealed type is "builtins.bool"
+        reveal_type(values_tuple[2])  # N: Revealed type is "Union[builtins.bool, None]"
+        reveal_type(values_tuple[3])  # N: Revealed type is "builtins.bool"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    no_default = models.BooleanField()
+                    default_none = models.BooleanField(default=None)
+                    default_not_none = models.BooleanField(default=True)


### PR DESCRIPTION
# I have made things!

## Related issues

- Closes #444 

The original suggestion in the issue breaks `tests/typecheck/models/test_create.yml::when_default_for_primary_key_is_specified_allow_none_to_be_set` so there needs to be a separate handling when creating primary key fields with a default.

Running the unit tests fails one test that is already broken for me in the fork:

```
FAILED tests/typecheck/models/test_inheritance.yml::django_contrib_gis_base_model_mixin_inheritance
```