### PR TITLE
fix `django.contrib.auth.models.Group.natural_key` no return type

### DIFF
--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -39,7 +39,7 @@ class Group(models.Model):
 
     name = models.CharField(max_length=150)
     permissions = models.ManyToManyField(Permission)
-    def natural_key(self): ...
+    def natural_key(self) -> Tuple[str]: ...
 
 _T = TypeVar("_T", bound=Model)
 


### PR DESCRIPTION
## Related issues

Closes #723
