### PR TITLE
Update send_mail recipient_list type from List[str] to Sequence[str]

### DIFF
--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 from .message import DEFAULT_ATTACHMENT_MIME_TYPE as DEFAULT_ATTACHMENT_MIME_TYPE
 from .message import BadHeaderError as BadHeaderError
@@ -15,7 +15,7 @@ def send_mail(
     subject: str,
     message: str,
     from_email: Optional[str],
-    recipient_list: List[str],
+    recipient_list: Sequence[str],
     fail_silently: bool = ...,
     auth_user: Optional[str] = ...,
     auth_password: Optional[str] = ...,


### PR DESCRIPTION
# Change send_mail arg recipient_list type from List[str] -> Sequence[str].

I found this when my project passes a tuple of recipients instead (and that works, although mypy fails.)

From the look of [send_email](https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/core/mail/__init__.py#L38-L61) and [EmailMultiAlternatives](https://github.com/untidy-hair/django-stubs/blob/send-mail/django-stubs/core/mail/message.pyi#L101), it seems appropriate to use `Sequence` there.

I hope I'm not missing anything. Thanks!
