### PR TITLE
Implement stubs for views.decorators.common.no_append_slash

### DIFF
--- a/django-stubs/views/decorators/common.pyi
+++ b/django-stubs/views/decorators/common.pyi
@@ -1,0 +1,5 @@
+from typing import Any, Callable, TypeVar
+
+_C = TypeVar("_C", bound=Callable[..., Any])
+
+def no_append_slash(view_func: _C) -> _C: ...


### PR DESCRIPTION
[Relevant no_append_slash docs](https://docs.djangoproject.com/en/3.2/topics/http/decorators/#django.views.decorators.common.no_append_slash), decorator was introduced in `3.2`