### PR TITLE
Add signature for Django 3.2 TimestampSigner

### DIFF
--- a/django-stubs/core/signing.pyi
+++ b/django-stubs/core/signing.pyi
@@ -51,3 +51,15 @@ class Signer:
 class TimestampSigner(Signer):
     def timestamp(self) -> str: ...
     def unsign(self, value: str, max_age: Optional[Union[int, timedelta]] = ...) -> str: ...
+    def sign_object(
+        self,
+        obj: Any,
+        serializer: Type[Serializer] = ...,
+        compress: bool = ...,
+    ) -> str: ...
+    def unsign_object(
+        self,
+        signed_obj: str,
+        serializer: Type[Serializer] = ...,
+        max_age: Optional[Union[int, timedelta]] = ...,
+    ) -> Any: ...


### PR DESCRIPTION
Django 3.2 introduced two new methods: `sign_object` and
`unsign_object` which can sign/unsign "complex data structures" such as
lists, tuples, dictionaries:

https://docs.djangoproject.com/en/3.2/topics/signing/#django.core.signing.TimestampSigner

Because the methods take an arbitrary serializer (a JSON serializer by
default, but not guaranteed), we cannot be sure of the type of `obj`.

-----

First PR here! I followed [the guidelines](https://github.com/typeddjango/django-stubs/blob/b5c20100ffbca86338a29229f59d0de931bd767c/CONTRIBUTING.md#dev-setup):
- local tests pass with `pytest`
- in a venv with `requirements-dev.txt`, Black does seem to want to reformat *most* files, so I just left my two stubs be (they're Black-compatible, even though the rest of the file disagrees a bit)