### PR TITLE
Add Model._base_manager

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -23,6 +23,7 @@ class Model(metaclass=ModelBase):
     class Meta: ...
     _meta: Options[Any]
     _default_manager: BaseManager[Model]
+    _base_manager: BaseManager[Model]
     objects: BaseManager[Any]
     pk: Any = ...
     _state: ModelState


### PR DESCRIPTION
Simple addition: `_base_manager` is missing off the model class (useful in some cases when you don't want to use the `_default_manager`)