### PR TITLE
Replace `toml` with `tomli`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,5 @@ pre-commit==2.13.0
 pytest==6.1.1
 pytest-mypy-plugins==1.9.2
 psycopg2-binary
-types-toml==0.1.1
 -e ./django_stubs_ext
 -e .

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -4,7 +4,7 @@ import textwrap
 from functools import partial
 from typing import Callable, Dict, List, NoReturn, Optional, Tuple, cast
 
-import toml
+import tomli
 from django.db.models.fields.related import RelatedField
 from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
@@ -103,7 +103,7 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
         handler.error("'django_settings_module' not found or invalid: " + messages[error_type])
 
     if config_file_path and helpers.is_toml(config_file_path):
-        toml_data = toml.load(config_file_path)
+        toml_data = tomli.load(config_file_path)
         try:
             config = toml_data["tool"]["django-stubs"]
         except KeyError:

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -103,7 +103,11 @@ def extract_django_settings_module(config_file_path: Optional[str]) -> str:
         handler.error("'django_settings_module' not found or invalid: " + messages[error_type])
 
     if config_file_path and helpers.is_toml(config_file_path):
-        toml_data = tomli.load(config_file_path)
+        try:
+            with open(config_file_path, encoding="utf-8") as config_file_obj:
+                toml_data = tomli.loads(config_file_obj.read())
+        except Exception:
+            exit_toml(1)
         try:
             config = toml_data["tool"]["django-stubs"]
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependencies = [
     "mypy>=0.910",
     "django",
     "django-stubs-ext>=0.3.0",
-    "toml",
+    "tomli",
     # Types:
     "typing-extensions",
     "types-pytz",


### PR DESCRIPTION
`toml` is not updated in a long time. `tomli` is just the same lib, but supported.
mypy now uses `tomli` as well as `typeshed`.