### PR TITLE
Export Datasource, Driver from gdal

### DIFF
--- a/django-stubs/contrib/gis/gdal/__init__.pyi
+++ b/django-stubs/contrib/gis/gdal/__init__.pyi
@@ -1,3 +1,5 @@
+from django.contrib.gis.gdal.datasource import DataSource
+from django.contrib.gis.gdal.driver import Driver
 from django.contrib.gis.gdal.error import GDALException as GDALException
 from django.contrib.gis.gdal.error import SRSException as SRSException
 from django.contrib.gis.gdal.error import check_err as check_err


### PR DESCRIPTION
It looks like gdal default exports are not consistent with Django, notably missing DataSource and Driver amongst others.


https://github.com/django/django/blob/main/django/contrib/gis/gdal/__init__.py#L29

## Related issues
