### PR TITLE
Repro test case for phantom errors in #709

### DIFF
--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -22,6 +22,46 @@
                 class MyModel(models.Model):
                     objects = NewManager()
 
+-   case: from_queryset_queryset_imported_from_other_module
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel*"
+        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel().objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[Any]"
+        reveal_type(MyModel().objects.queryset_method_3())  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel*]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/querysets.py
+            content: |
+                from typing import TYPE_CHECKING, Iterable
+                from django.db import models
+                if TYPE_CHECKING:
+                    from .models import MyModel
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    def queryset_method(self) -> "ModelQuerySet":
+                        return self.filter()
+
+                    def queryset_method_2(self) -> Iterable:
+                        return []
+
+                    def queryset_method_3(self) -> str:
+                        return 'hello'
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+                from .querysets import ModelQuerySet
+
+                NewManager = BaseManager.from_queryset(ModelQuerySet)
+                class MyModel(models.Model):
+                    objects = NewManager()
+
 -   case: from_queryset_with_manager
     main: |
         from myapp.models import MyModel


### PR DESCRIPTION
I found a repro case for some(?) phantom errors mentioned in https://github.com/typeddjango/django-stubs/issues/709#issuecomment-948732864. Not at all sure about why they happen like this, or how to resolve them properly. Thought it might be useful for someone else with better insight.

Worth noting from the error is that it only seem to happen for return types imported e.g. `from typing import ...` as there's no error for the queryset methods having `-> "ModelQuerySet":` or `-> str:`

## Related issues

Refs #709

---

Here's the error output of the failing test (`from_queryset_queryset_imported_from_other_module`):

```
=================================== FAILURES ===================================
______________ from_queryset_queryset_imported_from_other_module _______________
/home/runner/work/django-stubs/django-stubs/tests/typecheck/managers/querysets/test_from_queryset.yml:31: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Invalid output: 
E   Actual:
E     ...
E     main:5: note: Revealed type is "Any"          (diff)
E    main:6: note: Revealed type is "builtins.str"
E    main:7: note: Revealed type is "myapp.querysets.ModelQuerySet"
E    main:8: note: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel*]"
E     myapp/models:10: error: Name "Iterable" is not defined (diff)
E     myapp/models:10: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable") (diff)
E   Expected:
E     ...
E     main:5: note: Revealed type is "typing.Iterable[Any]" (diff)
E    main:6: note: Revealed type is "builtins.str"
E    main:7: note: Revealed type is "myapp.querysets.ModelQuerySet"
E    main:8: note: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel*]"
E   Alignment of first line difference:
E     E: ...te: Revealed type is "typing.Iterable[Any]"
E     A: ...te: Revealed type is "Any"
E                                 ^
```