### PR TITLE
Allow expressions in UniqueConstraint

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -1,8 +1,9 @@
 import enum
-from typing import Any, Optional, Sequence, Tuple, Type, TypeVar
+from typing import Any, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.base import Model
+from django.db.models.expressions import Combinable
 from django.db.models.query_utils import Q
 
 _T = TypeVar("_T", bound="BaseConstraint")
@@ -27,9 +28,15 @@ class CheckConstraint(BaseConstraint):
     def __init__(self, *, check: Q, name: str) -> None: ...
 
 class UniqueConstraint(BaseConstraint):
+    expressions: Tuple[Combinable]
     fields: Tuple[str]
     condition: Optional[Q]
     deferrable: Optional[Deferrable]
     def __init__(
-        self, *, fields: Sequence[str], name: str, condition: Optional[Q] = ..., deferrable: Optional[Deferrable] = ...
+        self,
+        *expressions: Union[str, Combinable],
+        fields: Optional[Sequence[str]] = ...,
+        name: str,
+        condition: Optional[Q] = ...,
+        deferrable: Optional[Deferrable] = ...,
     ) -> None: ...

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -29,7 +29,7 @@ class CheckConstraint(BaseConstraint):
 
 class UniqueConstraint(BaseConstraint):
     expressions: Tuple[Combinable, ...]
-    fields: Tuple[str]
+    fields: Tuple[str, ...]
     condition: Optional[Q]
     deferrable: Optional[Deferrable]
     def __init__(

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -28,7 +28,7 @@ class CheckConstraint(BaseConstraint):
     def __init__(self, *, check: Q, name: str) -> None: ...
 
 class UniqueConstraint(BaseConstraint):
-    expressions: Tuple[Combinable]
+    expressions: Tuple[Combinable, ...]
     fields: Tuple[str]
     condition: Optional[Q]
     deferrable: Optional[Deferrable]


### PR DESCRIPTION
## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

Closes #805

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
I'm not sure I did it right, but both using `expressions` and `fields` works with this at least, e.g.:

```python
class MyModel(models.Model):
    ...
    class Meta:
        constraints = [
            models.UniqueConstraint(Upper("foo"), name="foo_upper_key"),
            models.UniqueConstraint(fields=["bar"], name="bar_key"),
        ]
```