### PR TITLE
Update readme with support info for mypy 931

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs | mypy version | django version | python version
 | ------------ | ---- | ---- | ---- |
+| 1.10.0 | 0.931 | 3.2.x | ^3.7
 | 1.9.0 | 0.910 | 3.2.x | ^3.6
 | 1.8.0 | 0.812 | 3.1.x | ^3.6
 | 1.7.0 | 0.790 | 2.2.x \|\| 3.x | ^3.6

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.910",
+    "mypy>=0.931",
     "django",
     "django-stubs-ext>=0.3.0",
     "tomli",


### PR DESCRIPTION
Hi.

I couldn't find a test matrix or similar, but i've been running master of django-stubs with mypy@931 on our CI for a few days now, and things seem to be working.
I updated setup.py to 931 as lowest mypy requirement now, is that the way things are done?