### PR TITLE
Set custom queryset methods as manager attrs instead of method copies

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -34,7 +34,7 @@ from mypy.plugin import (
     MethodContext,
     SemanticAnalyzerPluginInterface,
 )
-from mypy.plugins.common import add_method
+from mypy.plugins.common import add_method_to_class
 from mypy.semanal import SemanticAnalyzer
 from mypy.types import AnyType, CallableType, Instance, NoneTyp, TupleType
 from mypy.types import Type as MypyType
@@ -383,7 +383,9 @@ def copy_method_to_another_class(
             return
 
         arguments, return_type = build_unannotated_method_args(method_node)
-        add_method(ctx, new_method_name, args=arguments, return_type=return_type, self_type=self_type)
+        add_method_to_class(
+            semanal_api, ctx.cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type
+        )
         return
 
     method_type = method_node.type
@@ -421,7 +423,9 @@ def copy_method_to_another_class(
         argument.set_line(original_argument)
         arguments.append(argument)
 
-    add_method(ctx, new_method_name, args=arguments, return_type=return_type, self_type=self_type)
+    add_method_to_class(
+        semanal_api, ctx.cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type
+    )
 
 
 def add_new_manager_base(api: SemanticAnalyzerPluginInterface, fullname: str) -> None:

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -1,13 +1,136 @@
-from mypy.checker import fill_typevars
-from mypy.nodes import GDEF, Decorator, FuncDef, MemberExpr, NameExpr, RefExpr, StrExpr, SymbolTableNode, TypeInfo
-from mypy.plugin import ClassDefContext, DynamicClassDefContext
-from mypy.types import CallableType, Instance, TypeVarType, UnboundType, get_proper_type
+from typing import Optional, Union
 
+from mypy.checker import TypeChecker, fill_typevars
+from mypy.nodes import (
+    GDEF,
+    Decorator,
+    FuncBase,
+    FuncDef,
+    MemberExpr,
+    NameExpr,
+    OverloadedFuncDef,
+    RefExpr,
+    StrExpr,
+    SymbolTableNode,
+    TypeInfo,
+    Var,
+)
+from mypy.plugin import AttributeContext, ClassDefContext, DynamicClassDefContext
+from mypy.types import AnyType, CallableType, Instance, ProperType
+from mypy.types import Type as MypyType
+from mypy.types import TypeOfAny, TypeVarType, UnboundType, get_proper_type
+
+from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import fullnames, helpers
 
 
+def get_method_type_from_dynamic_manager(
+    api: TypeChecker, method_name: str, manager_type_info: TypeInfo
+) -> Optional[ProperType]:
+    """
+    Attempt to resolve a method on a manager that was built from '.from_queryset'
+    """
+    if (
+        "django" not in manager_type_info.metadata
+        or "from_queryset_manager" not in manager_type_info.metadata["django"]
+    ):
+        # Manager isn't dynamically added
+        return None
+
+    queryset_fullname = manager_type_info.metadata["django"]["from_queryset_manager"]
+    assert isinstance(queryset_fullname, str)
+    queryset_info = helpers.lookup_fully_qualified_typeinfo(api, queryset_fullname)
+    assert queryset_info is not None
+
+    def get_funcdef_type(definition: Union[FuncBase, Decorator, None]) -> Optional[ProperType]:
+        # TODO: Handle @overload?
+        if isinstance(definition, FuncBase) and not isinstance(definition, OverloadedFuncDef):
+            return definition.type
+        elif isinstance(definition, Decorator):
+            return definition.func.type
+        return None
+
+    method_type = get_funcdef_type(queryset_info.get_method(method_name))
+    if method_type is None:
+        return None
+
+    assert isinstance(method_type, CallableType)
+    # Drop any 'self' argument as our manager is already initialized
+    return method_type.copy_modified(
+        arg_types=method_type.arg_types[1:],
+        arg_kinds=method_type.arg_kinds[1:],
+        arg_names=method_type.arg_names[1:],
+    )
+
+
+def get_method_type_from_reverse_manager(
+    api: TypeChecker, method_name: str, manager_type_info: TypeInfo
+) -> Optional[ProperType]:
+    """
+    Attempts to resolve a reverse manager's method via the '_default_manager' manager on the related model
+    From Django docs:
+      "By default the RelatedManager used for reverse relations is a subclass of the default manager for that model."
+    Ref: https://docs.djangoproject.com/en/dev/topics/db/queries/#using-a-custom-reverse-manager
+    """
+    is_reverse_manager = (
+        "django" in manager_type_info.metadata and "related_manager_to_model" in manager_type_info.metadata["django"]
+    )
+    if not is_reverse_manager:
+        return None
+
+    related_model_fullname = manager_type_info.metadata["django"]["related_manager_to_model"]
+    assert isinstance(related_model_fullname, str)
+    model_info = helpers.lookup_fully_qualified_typeinfo(api, related_model_fullname)
+    if model_info is None:
+        return None
+
+    # We should _always_ have a '_default_manager' on a model
+    assert "_default_manager" in model_info.names
+    assert isinstance(model_info.names["_default_manager"].node, Var)
+    manager_instance = model_info.names["_default_manager"].node.type
+    return (
+        get_method_type_from_dynamic_manager(api, method_name, manager_instance.type)
+        # TODO: Can we assert on None and Instance?
+        if manager_instance is not None and isinstance(manager_instance, Instance)
+        else None
+    )
+
+
+def resolve_manager_method(ctx: AttributeContext, django_context: DjangoContext) -> MypyType:
+    """
+    A 'get_attribute_hook' that is intended to be invoked whenever the TypeChecker encounters
+    an attribute on a class that has 'django.db.models.BaseManager' as a base.
+    """
+    api = helpers.get_typechecker_api(ctx)
+    # Skip (method) type that is currently something other than Any
+    if not isinstance(ctx.default_attr_type, AnyType):
+        return ctx.default_attr_type
+
+    # (Current state is:) We wouldn't end up here when looking up a method from a custom _manager_.
+    # That's why we only attempt to lookup the method for either a dynamically added or reverse manager.
+    assert isinstance(ctx.context, MemberExpr)
+    method_name = ctx.context.name
+    manager_instance = ctx.type
+    assert isinstance(manager_instance, Instance)
+    method_type = get_method_type_from_dynamic_manager(
+        api, method_name, manager_instance.type
+    ) or get_method_type_from_reverse_manager(api, method_name, manager_instance.type)
+
+    return method_type if method_type is not None else ctx.default_attr_type
+
+
 def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefContext) -> None:
+    """
+    Insert a new manager class node for a: '<Name> = <Manager>.from_queryset(<QuerySet>)'.
+    When the assignment expression lives at module level.
+    """
     semanal_api = helpers.get_semanal_api(ctx)
+
+    # Don't redeclare the manager class if we've already defined it.
+    manager_node = semanal_api.lookup_current_scope(ctx.name)
+    if manager_node and isinstance(manager_node.node, TypeInfo):
+        # This is just a deferral run where our work is already finished
+        return
 
     callee = ctx.call.callee
     assert isinstance(callee, MemberExpr)
@@ -54,9 +177,11 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
     new_manager_info.defn.type_vars = base_manager_info.defn.type_vars
     new_manager_info.defn.line = ctx.call.line
     new_manager_info.metaclass_type = new_manager_info.calculate_metaclass_type()
-
-    current_module = semanal_api.cur_mod_node
-    current_module.names[ctx.name] = SymbolTableNode(GDEF, new_manager_info, plugin_generated=True)
+    # Stash the queryset fullname which was passed to .from_queryset
+    # So that our 'resolve_manager_method' attribute hook can fetch the method from that QuerySet class
+    new_manager_info.metadata.setdefault("django", {})
+    new_manager_info.metadata["django"].setdefault("from_queryset_manager", {})
+    new_manager_info.metadata["django"]["from_queryset_manager"] = derived_queryset_fullname
 
     if len(ctx.call.args) > 1:
         expr = ctx.call.args[1]
@@ -66,8 +191,7 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
         custom_manager_generated_name = base_manager_info.name + "From" + derived_queryset_info.name
 
     custom_manager_generated_fullname = ".".join(["django.db.models.manager", custom_manager_generated_name])
-    if "from_queryset_managers" not in base_manager_info.metadata:
-        base_manager_info.metadata["from_queryset_managers"] = {}
+    base_manager_info.metadata.setdefault("from_queryset_managers", {})
     base_manager_info.metadata["from_queryset_managers"][custom_manager_generated_fullname] = new_manager_info.fullname
 
     # So that the plugin will reparameterize the manager when it is constructed inside of a Model definition
@@ -76,13 +200,10 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
     class_def_context = ClassDefContext(cls=new_manager_info.defn, reason=ctx.call, api=semanal_api)
     self_type = fill_typevars(new_manager_info)
     assert isinstance(self_type, Instance)
-    queryset_method_names = []
 
-    # we need to copy all methods in MRO before django.db.models.query.QuerySet
+    # We collect and mark up all methods before django.db.models.query.QuerySet as class members
     for class_mro_info in derived_queryset_info.mro:
         if class_mro_info.fullname == fullnames.QUERYSET_CLASS_FULLNAME:
-            for name, sym in class_mro_info.names.items():
-                queryset_method_names.append(name)
             break
         for name, sym in class_mro_info.names.items():
             if isinstance(sym.node, FuncDef):
@@ -91,10 +212,17 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
                 func_node = sym.node.func
             else:
                 continue
-            helpers.copy_method_to_another_class(
-                class_def_context, self_type, new_method_name=name, method_node=func_node
-            )
 
+            # Insert the queryset method name as a class member. Note that the type of
+            # the method is set as Any. Figuring out the type is the job of the
+            # 'resolve_manager_method' attribute hook, which comes later.
+            #
+            # class BaseManagerFromMyQuerySet(BaseManager):
+            #    queryset_method: Any = ...
+            #
+            helpers.add_new_sym_for_info(new_manager_info, name=name, sym_type=AnyType(TypeOfAny.special_form))
+
+    # we need to copy all methods in MRO before django.db.models.query.QuerySet
     # Gather names of all BaseManager methods
     manager_method_names = []
     for manager_mro_info in new_manager_info.mro:
@@ -150,3 +278,6 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
                 return_type=return_type,
                 original_module_name=class_mro_info.module_name,
             )
+
+    # Insert the new manager (dynamic) class
+    assert semanal_api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, new_manager_info, plugin_generated=True))

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -684,6 +684,7 @@
         reveal_type(User().orders)  # N: Revealed type is "myapp.models.User_Order_RelatedManager1"
         reveal_type(User().orders.get())  # N: Revealed type is "myapp.models.Order*"
         reveal_type(User().orders.manager_method())  # N: Revealed type is "builtins.int"
+        reveal_type(Product.objects.queryset_method())  # N: Revealed type is "builtins.int"
         reveal_type(Order().products)  # N: Revealed type is "myapp.models.Order_Product_RelatedManager1"
         reveal_type(Order().products.get())  # N: Revealed type is "myapp.models.Product*"
         reveal_type(Order().products.queryset_method())  # N: Revealed type is "builtins.int"

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -22,6 +22,55 @@
                 class MyModel(models.Model):
                     objects = NewManager()
 
+-   case: from_queryset_queryset_imported_from_other_module
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel*"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[myapp.querysets.Custom]"
+        reveal_type(MyModel.objects.queryset_method_3())  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel.objects.queryset_method_4([]))  # N: Revealed type is "None"
+        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel*]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/querysets.py
+            content: |
+                from typing import TYPE_CHECKING, Iterable, Sequence
+                from django.db import models
+                if TYPE_CHECKING:
+                    from .models import MyModel
+
+                class Custom:
+                    ...
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    def queryset_method(self) -> "ModelQuerySet":
+                        return self.filter()
+
+                    def queryset_method_2(self) -> Iterable[Custom]:
+                        return []
+
+                    def queryset_method_3(self) -> str:
+                        return 'hello'
+
+                    def queryset_method_4(self, arg: Sequence) -> None:
+                        return None
+
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+                from .querysets import ModelQuerySet
+
+                NewManager = BaseManager.from_queryset(ModelQuerySet)
+                class MyModel(models.Model):
+                    objects = NewManager()
+
 -   case: from_queryset_with_manager
     main: |
         from myapp.models import MyModel
@@ -48,7 +97,7 @@
     main: |
         from myapp.models import MyModel, NewManager
         reveal_type(NewManager())  # N: Revealed type is "myapp.models.NewManager"
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyModel_NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "Any"
         reveal_type(MyModel.objects.manager_only_method())  # N: Revealed type is "builtins.int"
         reveal_type(MyModel.objects.manager_and_queryset_method())  # N: Revealed type is "builtins.str"
@@ -74,7 +123,7 @@
     main: |
         from myapp.models import MyModel, NewManager
         reveal_type(NewManager())  # N: Revealed type is "myapp.models.NewManager"
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyModel_NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "Any"
         reveal_type(MyModel.objects.manager_only_method())  # N: Revealed type is "builtins.int"
         reveal_type(MyModel.objects.manager_and_queryset_method())  # N: Revealed type is "builtins.str"
@@ -187,6 +236,7 @@
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "builtins.int"
     installed_apps:
         - myapp
     files:
@@ -200,6 +250,62 @@
                     def queryset_method(self) -> str:
                         return 'hello'
 
+                    @transaction.atomic
+                    @transaction.atomic
+                    def queryset_method_2(self) -> int:
+                        return 2
+
                 NewManager = models.Manager.from_queryset(ModelQuerySet)
+                class MyModel(models.Model):
+                    objects = NewManager()
+
+-   case: from_queryset_model_gets_generated_manager_as_default_manager
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet):
+                    def queryset_method(self) -> str:
+                        return 'hello'
+
+                NewManager = models.Manager.from_queryset(ModelQuerySet)
+                class MyModel(models.Model):
+                    objects = NewManager()
+
+-   case: from_queryset_can_resolve_explicit_any_methods
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.queryset_method(1))  # N: Revealed type is "Any"
+        reveal_type(MyModel.objects.queryset_method)  # N: Revealed type is "def (qarg: Any) -> Any"
+        reveal_type(MyModel.objects.manager_method(2))  # N: Revealed type is "Any"
+        reveal_type(MyModel.objects.manager_method)  # N: Revealed type is "def (marg: Any) -> Any"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from typing import Any
+
+                class ModelQuerySet(models.QuerySet):
+                    def queryset_method(self, qarg: Any) -> Any:
+                        return 'hello'
+
+                class MyManager(models.Manager):
+                    def manager_method(self, marg: Any) -> Any:
+                        return 'hello'
+
+                NewManager = MyManager.from_queryset(ModelQuerySet)
                 class MyModel(models.Model):
                     objects = NewManager()


### PR DESCRIPTION
Instead of copying methods over from a `QuerySet` passed to a base manager when invoking `<BaseManager>.from_queryset`, any `QuerySet` methods are declared as attributes on the dynamically created manager.

This allows us to properly lookup any `QuerySet` method types via a `get_attribute_hook` and will thus remove disorienting phantom errors occuring from mypy trying to resolve types only existing in the module where the _original_ (and real) queryset method was declared.

Consider _the currently breaking_ case of having the following model and queryset modules

```python
# myapp/querysets.py
from django.db import models
from typing import TYPE_CHECKING, Iterable

if TYPE_CHECKING:
    from .models import MyModel

class MyQuerySet(models.QuerySet["MyModel"]):
    def queryset_method(self) -> Iterable[int]:
        return [1]
```

```python
# myapp/models.py
from django.db import models
from django.db.models.manager import BaseManager
from .querysets import MyQuerySet

NewManager = BaseManager.from_queryset(MyQuerySet)
class MyModel(models.Model):
    objects = NewManager()
```

Now, to elaborate a bit more, if we expand the `NewManager` type that `django-stubs` plugin will dynamically create (without the changes seen in this PR), we get:

```python
# myapp/models.py
from django.db import models
from django.db.models.manager import BaseManager
from .querysets import MyQuerySet

...

class NewManager(BaseManager):
    def queryset_method(self) -> Iterable[int]:
        ...
```

That happens via _copying_ any method definitions from the passed in queryset (`MyQuerySet` in this example) on to the manager type. Copying becomes troublesome when queryset and model live in different modules and don't share _all_ definitions. As `Iterable` isn't imported in `myapp/models.py` mypy yields an error:

```
error: Name "Iterable" is not defined
```

Which makes sense.

Now, to the fix included here. Instead of _copying the method_, we instead declare each queryset method as a class attribute of the new manager type (in this example `NewManager`). To display the difference, this is what that will look like if we unwrap the dynamically created manager:

```python
# myapp/models.py
from django.db import models
from django.db.models.manager import BaseManager
from .querysets import MyQuerySet

...

class NewManager(BaseManager):
    queryset_method = MyQuerySet.queryset_method
```

Mypy is able to resolve that attribute properly without any definition errors. And from my (very shallow) investigation of Django's [.from_queryset](https://github.com/django/django/blob/0a17666045de6739ae1c2ac695041823d5f827f7/django/db/models/manager.py#L103-L110)(more exactly the 3-arg `type` call) implementation, this representation (if we disregard or unwrap the decorator they implement) aligns better with the truth (feel free to correct me if I'm wrong).

## Related issues

Refs #709 (Not sure the fix fully resolves this issue)
Fixes https://github.com/typeddjango/django-stubs/issues/709#issuecomment-948732864
Refs #738
Supersedes #802 

---

There was a bit of a chain reaction implementing this change, mainly in regards to reversed managers. I'm having a bit of an expectation that there's some edits there that could allow the dynamically created `<Model>_<RelatedModel>_RelatedManager` named manager types to be replaced with a proper traversal via `RelatedModel._default_manager.queryset_method`(allowing us to ditch that type creation). But I've tried to leave reversed managers with as few edits as possible and dig in to that thought another time.