### PR TITLE
Notify when Manager.from_queryset happens inside model class body

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -1,0 +1,98 @@
+import configparser
+import textwrap
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, Dict, NoReturn, Optional
+
+import tomli
+
+INI_USAGE = """
+(config)
+...
+[mypy.plugins.django_stubs]
+    django_settings_module: str (required)
+...
+"""
+TOML_USAGE = """
+(config)
+...
+[tool.django-stubs]
+django_settings_module = str (required)
+...
+"""
+INVALID_FILE = "mypy config file is not specified or found"
+COULD_NOT_LOAD_FILE = "could not load configuration file"
+MISSING_SECTION = "no section [{section}] found".format
+MISSING_DJANGO_SETTINGS = "missing required 'django_settings_module' config"
+INVALID_SETTING = "invalid {key!r}: the setting must be a boolean".format
+
+
+def exit_with_error(msg: str, is_toml: bool = False) -> NoReturn:
+    """Using mypy's argument parser, raise `SystemExit` to fail hard if validation fails.
+
+    Considering that the plugin's startup duration is around double as long as mypy's, this aims to
+    import and construct objects only when that's required - which happens once and terminates the
+    run. Considering that most of the runs are successful, there's no need for this to linger in the
+    global scope.
+    """
+    from mypy.main import CapturableArgumentParser
+
+    handler = CapturableArgumentParser(
+        prog="(django-stubs) mypy", usage=textwrap.dedent(TOML_USAGE if is_toml else INI_USAGE)
+    )
+    handler.error(msg)
+
+
+class DjangoPluginConfig:
+    __slots__ = ("django_settings_module",)
+    django_settings_module: str
+
+    def __init__(self, config_file: Optional[str]) -> None:
+        if not config_file:
+            exit_with_error(INVALID_FILE)
+
+        filepath = Path(config_file)
+        if not filepath.is_file():
+            exit_with_error(INVALID_FILE)
+
+        if filepath.suffix.lower() == ".toml":
+            self.parse_toml_file(filepath)
+        else:
+            self.parse_ini_file(filepath)
+
+    def parse_toml_file(self, filepath: Path) -> None:
+        toml_exit: Callable[[str], NoReturn] = partial(exit_with_error, is_toml=True)
+        try:
+            with filepath.open(mode="rb") as f:
+                data = tomli.load(f)
+        except (tomli.TOMLDecodeError, OSError):
+            toml_exit(COULD_NOT_LOAD_FILE)
+
+        try:
+            config: Dict[str, Any] = data["tool"]["django-stubs"]
+        except KeyError:
+            toml_exit(MISSING_SECTION(section="tool.django-stubs"))
+
+        if "django_settings_module" not in config:
+            toml_exit(MISSING_DJANGO_SETTINGS)
+
+        self.django_settings_module = config["django_settings_module"]
+        if not isinstance(self.django_settings_module, str):
+            toml_exit("invalid 'django_settings_module': the setting must be a string")
+
+    def parse_ini_file(self, filepath: Path) -> None:
+        parser = configparser.ConfigParser()
+        try:
+            with filepath.open(encoding="utf-8") as f:
+                parser.read_file(f, source=str(filepath))
+        except OSError:
+            exit_with_error(COULD_NOT_LOAD_FILE)
+
+        section = "mypy.plugins.django-stubs"
+        if not parser.has_section(section):
+            exit_with_error(MISSING_SECTION(section=section))
+
+        if not parser.has_option(section, "django_settings_module"):
+            exit_with_error(MISSING_DJANGO_SETTINGS)
+
+        self.django_settings_module = parser.get(section, "django_settings_module").strip("'\"")

--- a/mypy_django_plugin/errorcodes.py
+++ b/mypy_django_plugin/errorcodes.py
@@ -1,0 +1,3 @@
+from mypy.errorcodes import ErrorCode
+
+MANAGER_UNTYPED = ErrorCode("django-manager", "Untyped manager disallowed", "Django")

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -24,6 +24,7 @@ from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.transformers import fields, forms, init_create, meta, querysets, request, settings
 from mypy_django_plugin.transformers.managers import (
     create_new_manager_class_from_from_queryset_method,
+    fail_if_manager_type_created_in_model_body,
     resolve_manager_method,
 )
 from mypy_django_plugin.transformers.models import (
@@ -224,6 +225,11 @@ class NewSemanalDjangoPlugin(Plugin):
                 mypy_django_plugin.transformers.orm_lookups.typecheck_queryset_filter,
                 django_context=self.django_context,
             )
+
+        if method_name == "from_queryset":
+            info = self._get_typeinfo_or_none(class_fullname)
+            if info and info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME):
+                return fail_if_manager_type_created_in_model_body
 
         return None
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,10 +1,7 @@
-import configparser
 import sys
-import textwrap
 from functools import partial
-from typing import Callable, Dict, List, NoReturn, Optional, Tuple, cast
+from typing import Callable, Dict, List, Optional, Tuple
 
-import tomli
 from django.db.models.fields.related import RelatedField
 from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
@@ -21,6 +18,7 @@ from mypy.plugin import (
 from mypy.types import Type as MypyType
 
 import mypy_django_plugin.transformers.orm_lookups
+from mypy_django_plugin.config import DjangoPluginConfig
 from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.transformers import fields, forms, init_create, meta, querysets, request, settings
@@ -60,94 +58,15 @@ def add_new_manager_base_hook(ctx: ClassDefContext) -> None:
     helpers.add_new_manager_base(ctx.api, ctx.cls.fullname)
 
 
-def extract_django_settings_module(config_file_path: Optional[str]) -> str:
-    def exit(error_type: int) -> NoReturn:
-        """Using mypy's argument parser, raise `SystemExit` to fail hard if validation fails.
-
-        Considering that the plugin's startup duration is around double as long as mypy's, this aims to
-        import and construct objects only when that's required - which happens once and terminates the
-        run. Considering that most of the runs are successful, there's no need for this to linger in the
-        global scope.
-        """
-        from mypy.main import CapturableArgumentParser
-
-        usage = """
-        (config)
-        ...
-        [mypy.plugins.django_stubs]
-            django_settings_module: str (required)
-        ...
-        """
-        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=textwrap.dedent(usage))
-        messages = {
-            1: "mypy config file is not specified or found",
-            2: "no section [mypy.plugins.django-stubs]",
-            3: "the setting is not provided",
-        }
-        handler.error("'django_settings_module' is not set: " + messages[error_type])
-
-    def exit_toml(error_type: int) -> NoReturn:
-        from mypy.main import CapturableArgumentParser
-
-        usage = """
-        (config)
-        ...
-        [tool.django-stubs]
-        django_settings_module = str (required)
-        ...
-        """
-        handler = CapturableArgumentParser(prog="(django-stubs) mypy", usage=textwrap.dedent(usage))
-        messages = {
-            1: "mypy config file is not specified or found",
-            2: "no section [tool.django-stubs]",
-            3: "the setting is not provided",
-            4: "the setting must be a string",
-        }
-        handler.error("'django_settings_module' not found or invalid: " + messages[error_type])
-
-    if config_file_path and helpers.is_toml(config_file_path):
-        try:
-            with open(config_file_path, encoding="utf-8") as config_file_obj:
-                toml_data = tomli.loads(config_file_obj.read())
-        except Exception:
-            exit_toml(1)
-        try:
-            config = toml_data["tool"]["django-stubs"]
-        except KeyError:
-            exit_toml(2)
-
-        if "django_settings_module" not in config:
-            exit_toml(3)
-
-        if not isinstance(config["django_settings_module"], str):
-            exit_toml(4)
-
-        return config["django_settings_module"]
-    else:
-        parser = configparser.ConfigParser()
-        try:
-            with open(cast(str, config_file_path)) as handle:
-                parser.read_file(handle, source=config_file_path)
-        except (IsADirectoryError, OSError):
-            exit(1)
-
-        section = "mypy.plugins.django-stubs"
-        if not parser.has_section(section):
-            exit(2)
-        settings = parser.get(section, "django_settings_module", fallback=None) or exit(3)
-
-        return settings.strip("'\"")
-
-
 class NewSemanalDjangoPlugin(Plugin):
     def __init__(self, options: Options) -> None:
         super().__init__(options)
-        django_settings_module = extract_django_settings_module(options.config_file)
+        self.plugin_config = DjangoPluginConfig(options.config_file)
         # Add paths from MYPYPATH env var
         sys.path.extend(mypy_path())
         # Add paths from mypy_path config option
         sys.path.extend(options.mypy_path)
-        self.django_context = DjangoContext(django_settings_module)
+        self.django_context = DjangoContext(self.plugin_config.django_settings_module)
 
     def _get_current_queryset_bases(self) -> Dict[str, int]:
         model_sym = self.lookup_fully_qualified(fullnames.QUERYSET_CLASS_FULLNAME)

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -608,8 +608,14 @@
         reveal_type(Article().registered_by_user)  # N: Revealed type is "myapp.models.MyUser*"
 
         user = MyUser()
-        reveal_type(user.book_set) # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Book]"
-        reveal_type(user.article_set) # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Article]"
+        reveal_type(user.book_set) # N: Revealed type is "myapp.models.MyUser_Book_RelatedManager1"
+        reveal_type(user.article_set) # N: Revealed type is "myapp.models.MyUser_Article_RelatedManager1"
+        reveal_type(user.book_set.add)  # N: Revealed type is "def (*objs: Union[myapp.models.Book*, builtins.int], *, bulk: builtins.bool =)"
+        reveal_type(user.article_set.add)  # N: Revealed type is "def (*objs: Union[myapp.models.Article*, builtins.int], *, bulk: builtins.bool =)"
+        reveal_type(user.book_set.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.LibraryEntityQuerySet[myapp.models.Book*]"
+        reveal_type(user.article_set.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.LibraryEntityQuerySet[myapp.models.Article*]"
+        reveal_type(user.book_set.queryset_method())  # N: Revealed type is "builtins.int"
+        reveal_type(user.article_set.queryset_method())  # N: Revealed type is "builtins.int"
     installed_apps:
         - myapp
     files:
@@ -620,11 +626,13 @@
               class MyUser(models.Model):
                   pass
               class LibraryEntityQuerySet(models.QuerySet):
-                  pass
+                  def queryset_method(self) -> int:
+                      return 1
+              LibraryEntityManager = models.Manager.from_queryset(LibraryEntityQuerySet)
               class LibraryEntity(models.Model):
                   class Meta:
                       abstract = True
-                  objects = models.Manager.from_queryset(LibraryEntityQuerySet)()
+                  objects = LibraryEntityManager()
                   registered_by_user = models.ForeignKey(MyUser, on_delete=models.CASCADE)
               class Book(LibraryEntity):
                   pass

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -309,3 +309,40 @@
                 NewManager = MyManager.from_queryset(ModelQuerySet)
                 class MyModel(models.Model):
                     objects = NewManager()
+
+-   case: from_queryset_in_model_class_body_yields_message
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.base_manager)  # N: Revealed type is "myapp.models.BaseManagerFromMyQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerFromMyQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.custom_manager)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+
+                class MyQuerySet(models.QuerySet["MyModel"]):
+                    def queryset_method(self) -> int:
+                        return 1
+
+                class MyManager(BaseManager):
+                    ...
+
+                BaseManagerFromMyQuerySet = BaseManager.from_queryset(MyQuerySet)
+                ManagerFromMyQuerySet = models.Manager.from_queryset(MyQuerySet)
+                MyManagerFromMyQuerySet = MyManager.from_queryset(MyQuerySet)
+                class MyModel(models.Model):
+                    objects1 = BaseManager.from_queryset(MyQuerySet)()  # E: `.from_queryset` called from inside model class body
+                    objects2 = BaseManager.from_queryset(MyQuerySet)  # E: `.from_queryset` called from inside model class body
+                    objects3 = models.Manager.from_queryset(MyQuerySet)()  # E: `.from_queryset` called from inside model class body
+                    objects4 = models.Manager.from_queryset(MyQuerySet)  # E: `.from_queryset` called from inside model class body
+                    objects5 = MyManager.from_queryset(MyQuerySet)  # E: `.from_queryset` called from inside model class body
+                    objects6 = MyManager.from_queryset(MyQuerySet)()  # E: `.from_queryset` called from inside model class body
+                    # Initiating the manager type is fine
+                    base_manager = BaseManagerFromMyQuerySet()
+                    manager = ManagerFromMyQuerySet()
+                    custom_manager = MyManagerFromMyQuerySet()


### PR DESCRIPTION
Whenever `Manager.from_queryset` happens inside of a model class body, an error will be displayed

e.g. Doing

```python
class MyModel(models.Model):
    objects = BaseManager.from_queryset(MyQuerySet)()
```

Yields:

```
error: `.from_queryset` called from inside model class body
```

---
__Note:__ I've also included a refactoring commit for config parsing, that hopefully will make it less of a hassle to introduce new settings in the future.

## Related issues

Refs #738