### PR TITLE
Reuse reverse managers instead of recreating

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -209,7 +209,11 @@ def is_annotated_model_fullname(model_cls_fullname: str) -> bool:
 
 
 def add_new_class_for_module(
-    module: MypyFile, name: str, bases: List[Instance], fields: Optional[Dict[str, MypyType]] = None
+    module: MypyFile,
+    name: str,
+    bases: List[Instance],
+    fields: Optional[Dict[str, MypyType]] = None,
+    no_serialize: bool = False,
 ) -> TypeInfo:
     new_class_unique_name = checker.gen_unique_name(name, module.names)
 
@@ -229,10 +233,14 @@ def add_new_class_for_module(
             var = Var(field_name, type=field_type)
             var.info = new_typeinfo
             var._fullname = new_typeinfo.fullname + "." + field_name
-            new_typeinfo.names[field_name] = SymbolTableNode(MDEF, var, plugin_generated=True)
+            new_typeinfo.names[field_name] = SymbolTableNode(
+                MDEF, var, plugin_generated=True, no_serialize=no_serialize
+            )
 
     classdef.info = new_typeinfo
-    module.names[new_class_unique_name] = SymbolTableNode(GDEF, new_typeinfo, plugin_generated=True)
+    module.names[new_class_unique_name] = SymbolTableNode(
+        GDEF, new_typeinfo, plugin_generated=True, no_serialize=no_serialize
+    )
     return new_typeinfo
 
 
@@ -331,7 +339,7 @@ def check_types_compatible(
     api.check_subtype(actual_type, expected_type, ctx.context, error_message, "got", "expected")
 
 
-def add_new_sym_for_info(info: TypeInfo, *, name: str, sym_type: MypyType) -> None:
+def add_new_sym_for_info(info: TypeInfo, *, name: str, sym_type: MypyType, no_serialize: bool = False) -> None:
     # type=: type of the variable itself
     var = Var(name=name, type=sym_type)
     # var.info: type of the object variable is bound to
@@ -339,7 +347,7 @@ def add_new_sym_for_info(info: TypeInfo, *, name: str, sym_type: MypyType) -> No
     var._fullname = info.fullname + "." + name
     var.is_initialized_in_class = True
     var.is_inferred = True
-    info.names[name] = SymbolTableNode(MDEF, var, plugin_generated=True)
+    info.names[name] = SymbolTableNode(MDEF, var, plugin_generated=True, no_serialize=no_serialize)
 
 
 def build_unannotated_method_args(method_node: FuncDef) -> Tuple[List[Argument], MypyType]:

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -608,8 +608,8 @@
         reveal_type(Article().registered_by_user)  # N: Revealed type is "myapp.models.MyUser*"
 
         user = MyUser()
-        reveal_type(user.book_set) # N: Revealed type is "myapp.models.MyUser_Book_RelatedManager1"
-        reveal_type(user.article_set) # N: Revealed type is "myapp.models.MyUser_Article_RelatedManager1"
+        reveal_type(user.book_set) # N: Revealed type is "myapp.models.Book_RelatedManager"
+        reveal_type(user.article_set) # N: Revealed type is "myapp.models.Article_RelatedManager"
         reveal_type(user.book_set.add)  # N: Revealed type is "def (*objs: Union[myapp.models.Book*, builtins.int], *, bulk: builtins.bool =)"
         reveal_type(user.article_set.add)  # N: Revealed type is "def (*objs: Union[myapp.models.Article*, builtins.int], *, bulk: builtins.bool =)"
         reveal_type(user.book_set.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.LibraryEntityQuerySet[myapp.models.Book*]"
@@ -689,18 +689,18 @@
 -   case: related_manager_is_a_subclass_of_default_manager
     main: |
         from myapp.models import User, Order, Product
-        reveal_type(User().orders)  # N: Revealed type is "myapp.models.User_Order_RelatedManager1"
+        reveal_type(User().orders)  # N: Revealed type is "myapp.models.Order_RelatedManager"
         reveal_type(User().orders.get())  # N: Revealed type is "myapp.models.Order*"
         reveal_type(User().orders.manager_method())  # N: Revealed type is "builtins.int"
         reveal_type(Product.objects.queryset_method())  # N: Revealed type is "builtins.int"
-        reveal_type(Order().products)  # N: Revealed type is "myapp.models.Order_Product_RelatedManager1"
+        reveal_type(Order().products)  # N: Revealed type is "myapp.models.Product_RelatedManager"
         reveal_type(Order().products.get())  # N: Revealed type is "myapp.models.Product*"
         reveal_type(Order().products.queryset_method())  # N: Revealed type is "builtins.int"
-        # TODO: realted manager support to use the same type for all related managers
         if 1 == 2:
             manager = User().products
         else:
-            manager = Order().products  # E: Incompatible types in assignment (expression has type "Order_Product_RelatedManager1", variable has type "User_Product_RelatedManager1")
+            manager = Order().products
+        reveal_type(manager)  # N: Revealed type is "myapp.models.Product_RelatedManager"
     installed_apps:
         - myapp
     files:
@@ -724,6 +724,90 @@
                     objects = ProductManager()
                     order = models.ForeignKey(to=Order, on_delete=models.CASCADE, related_name='products')
                     user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='products')
+
+-   case: related_manager_shared_between_multiple_relations
+    main: |
+        from myapp.models.store import Store
+        from myapp.models.user import User
+        reveal_type(Store().purchases)  # N: Revealed type is "myapp.models.purchase.Purchase_RelatedManager"
+        reveal_type(Store().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(Store().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase*]"
+        reveal_type(Store().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(User().purchases)  # N: Revealed type is "myapp.models.purchase.Purchase_RelatedManager"
+        reveal_type(User().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(User().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase*]"
+        reveal_type(User().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models/__init__.py
+            content: |
+                from .purchase import Purchase
+                from .store import Store
+                from .user import User
+        -   path: myapp/models/store.py
+            content: |
+                from django.db import models
+
+                class Store(models.Model):
+                    ...
+        -   path: myapp/models/user.py
+            content: |
+                from django.db import models
+
+                class User(models.Model):
+                    ...
+        -   path: myapp/models/querysets.py
+            content: |
+                from django.db.models import QuerySet
+                from typing import TYPE_CHECKING
+                if TYPE_CHECKING:
+                    from .purchase import Purchase
+
+                class PurchaseQuerySet(QuerySet['Purchase']):
+                    def queryset_method(self) -> "PurchaseQuerySet":
+                        return self.all()
+        -   path: myapp/models/purchase.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+                from .querysets import PurchaseQuerySet
+                from .store import Store
+                from .user import User
+
+                PurchaseManager = BaseManager.from_queryset(PurchaseQuerySet)
+                class Purchase(models.Model):
+                    objects = PurchaseManager()
+                    store = models.ForeignKey(to=Store, on_delete=models.CASCADE, related_name='purchases')
+                    user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='purchases')
+
+-   case: explicitly_declared_related_manager_is_not_overridden
+    main: |
+        from myapp.models import User
+        reveal_type(User().purchases)  # N: Revealed type is "builtins.int"
+        User().purchases.filter()  # E: "int" has no attribute "filter"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+
+                class User(models.Model):
+                    purchases: int
+
+                class PurchaseQuerySet(models.QuerySet['Purchase']):
+                    def queryset_method(self) -> "PurchaseQuerySet":
+                        return self.all()
+
+                PurchaseManager = BaseManager.from_queryset(PurchaseQuerySet)
+                class Purchase(models.Model):
+                    objects = PurchaseManager()
+                    user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='purchases')
+
 
 -   case: related_manager_no_conflict_from_star_import
     main: |


### PR DESCRIPTION
Instead of recreating related managers for each pass through `AddManagers`, a subclass of `RelatedManager` is created __once__ for a related model. The model's `_default_manager` is also set as base for the related manager.

The generated reverse manager's fullname is stored in metadata on the related model. Allowing us to collect that manager, if it exists, for other related models.

There's currently only support for a reverse manager having `_default_manager` as base. (Not really sure how one would go about to support `Model().related_set("custom_manager").queryset_method`).

---

The changes here should mostly affect internals and resolved a `TODO:` found in a test case

https://github.com/typeddjango/django-stubs/blob/edec5a1c99a784208d5d8ce78237016cdaa1c54f/tests/typecheck/fields/test_related.yml#L699

 In general minimizing the amount of dynamically generated reverse managers for a model.

## Related issues

Refs #269 (Not really touching the source of that problem though..)