### PR TITLE
Add object_list to BaseListView

### DIFF
--- a/django-stubs/views/generic/list.pyi
+++ b/django-stubs/views/generic/list.pyi
@@ -30,6 +30,7 @@ class MultipleObjectMixin(Generic[T], ContextMixin):
     def get_context_object_name(self, object_list: QuerySet) -> Optional[str]: ...
 
 class BaseListView(MultipleObjectMixin[T], View):
+    object_list: Sequence[T]
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
 
 class MultipleObjectTemplateResponseMixin(TemplateResponseMixin):


### PR DESCRIPTION
## Related issues

Closes #790

The Django documentation describes `object_list` as "the list of objects (usually, but not necessarily a queryset)", so I picked `Sequence` as the type.
