### PR TITLE
Make formfield_from_dbfield return forms.Field instead of models.Field

### DIFF
--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 
+from django import forms
 from django.contrib.admin.filters import ListFilter
 from django.contrib.admin.models import LogEntry
 from django.contrib.admin.sites import AdminSite
@@ -24,6 +25,7 @@ from django.contrib.auth.forms import AdminPasswordChangeForm
 from django.contrib.contenttypes.models import ContentType
 from django.core.checks.messages import CheckMessage
 from django.core.paginator import Paginator
+from django.db import models
 from django.db.models.base import Model
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey, ManyToManyField, RelatedField
@@ -93,8 +95,8 @@ class BaseModelAdmin(Generic[_ModelT]):
     checks_class: Any = ...
     def check(self, **kwargs: Any) -> List[CheckMessage]: ...
     def formfield_for_dbfield(
-        self, db_field: Field, request: Optional[HttpRequest], **kwargs: Any
-    ) -> Optional[Field]: ...
+        self, db_field: models.Field, request: Optional[HttpRequest], **kwargs: Any
+    ) -> Optional[forms.Field]: ...
     def formfield_for_choice_field(
         self, db_field: Field, request: Optional[HttpRequest], **kwargs: Any
     ) -> TypedChoiceField: ...


### PR DESCRIPTION
In `django.contrib.admin.options`, `BaseModelAdmin` has a `formfield_from_dbfield` method that takes a `django.db.models.Field` argument and returns an optional `django.forms.Field`. The existing stub incorrectly typed the return value as `django.db.models.Field`.

I could have left the argument type as `Field` (imported from `django.db.models.fields`) but for clarity I added an import of `models` to make it explicit which `Field` is being used here; let me know if you prefer to leave the argument type as `Field` or something else.