### PR TITLE
Fix missing args on SlugField.__init__

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -378,6 +378,10 @@ class SlugField(CharField):
     def __init__(
         self,
         allow_unicode: bool = ...,
+        max_length: Optional[Any] = ...,
+        min_length: Optional[Any] = ...,
+        strip: bool = ...,
+        empty_value: Optional[str] = ...,
         required: bool = ...,
         widget: Optional[Union[Widget, Type[Widget]]] = ...,
         label: Optional[Any] = ...,


### PR DESCRIPTION
This PR includes the args `max_length`, `min_length`, `strip` and `empty_value` on `forms.SlugField.__init__`'.

These args are accepted as `kwargs` on `SlugField` and passed to CharField using `super().__init__(**kwargs)`, where they are defined.