### PR TITLE
Import Literal from typing_extensions for 3.7 compatibility

### DIFF
--- a/django-stubs/core/exceptions.pyi
+++ b/django-stubs/core/exceptions.pyi
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Iterator, List, Literal, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 from django.forms.utils import ErrorDict
+from typing_extensions import Literal
 
 class FieldDoesNotExist(Exception): ...
 class AppRegistryNotReady(Exception): ...

--- a/django-stubs/db/migrations/operations/special.pyi
+++ b/django-stubs/db/migrations/operations/special.pyi
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
+from typing_extensions import Literal
 
 from .base import Operation
 


### PR DESCRIPTION
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
Literal wasn't added to `typing` until 3.8. Most of the imports already use `typing_extensions`, but seems a few imports from `typing` has slipped in.

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
