### PR TITLE
Don't rely on `django.db.models.manager.Manager` metadata for dynamically created manager

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -276,7 +276,7 @@ class NewSemanalDjangoPlugin(Plugin):
         if (
             info
             and info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
-            and class_name in self._get_current_manager_bases()
+            and "from_queryset_manager" in helpers.get_django_metadata(info)
         ):
             return resolve_manager_method
 


### PR DESCRIPTION
Instead of expecting the fullname of any custom manager in metadata for `django.db.models.managers.Manager`, we just look if the `TypeInfo` for the manager itself has marked up a `from_queryset_manager` in its metadata.

Having the fullname in `django.db.models.managers.Manager` isn't necessary for the attribute hook anyways..

## Related issues

Closes #903 