### PR TITLE
`unique` annotation on model Field

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -143,6 +143,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     description: Union[str, _Getter[str]]
     blank: bool
     null: bool
+    unique: bool
     editable: bool
     empty_strings_allowed: bool = ...
     choices: Optional[_ChoicesList] = ...


### PR DESCRIPTION
# I have made things!

Added `unique` annotation on model Field class, which is a property:
https://github.com/django/django/blob/stable/4.0.x/django/db/models/fields/__init__.py#L824

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
