### PR TITLE
Fix ValidationError false positive on nested inputs

### DIFF
--- a/django-stubs/core/exceptions.pyi
+++ b/django-stubs/core/exceptions.pyi
@@ -1,8 +1,6 @@
 import sys
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from django.forms.utils import ErrorDict
-
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
@@ -32,18 +30,6 @@ class FieldError(Exception): ...
 
 NON_FIELD_ERRORS: Literal["__all__"] = ...
 
-_MsgTypeBase = Union[str, ValidationError]
-# Yeah, it's really ugly, but __init__ checks with isinstance()
-_MsgType = Union[
-    _MsgTypeBase,
-    Dict[str, _MsgTypeBase],
-    List[_MsgTypeBase],
-    Dict[str, str],
-    Dict[str, ValidationError],
-    List[str],
-    List[ValidationError],
-]
-
 class ValidationError(Exception):
     error_dict: Dict[str, List[ValidationError]] = ...
     error_list: List[ValidationError] = ...
@@ -52,7 +38,8 @@ class ValidationError(Exception):
     params: Optional[Dict[str, Any]] = ...
     def __init__(
         self,
-        message: _MsgType,
+        # Accepts arbitrarily nested data structure, mypy doesn't allow describing it accurately.
+        message: Union[str, ValidationError, Dict[str, Any], List[Any]],
         code: Optional[str] = ...,
         params: Optional[Dict[str, Any]] = ...,
     ) -> None: ...

--- a/tests/typecheck/core/test_exceptions.yml
+++ b/tests/typecheck/core/test_exceptions.yml
@@ -1,0 +1,22 @@
+-   case: ValidationError_nested_message
+    main: |
+            from django.core.exceptions import ValidationError
+
+
+            ValidationError({
+                'list': [
+                    'list error 1',
+                    'list error 2'
+                ],
+                'plain_str': 'message',
+                'plain_error': ValidationError('message'),
+                'list_error': [
+                    ValidationError('list error 1', code='test'),
+                    ValidationError('list error 2', code='test'),
+                ]
+            })
+            ValidationError([
+                'message 1',
+                ValidationError('message 2'),
+                ['nested 1', 'nested 2'],
+            ])


### PR DESCRIPTION
# I have made things!

Regression from PR #909.

As previously discussed in https://github.com/typeddjango/django-stubs/pull/767#discussion_r764773385, `ValidationError` accepts arbitrarily nested data structures as the `message` argument. Mypy does not currently support recursive type aliases, so AFAIK it's impossible to accurately describe the correct type of this. In any case, the current hints are not correct.

For example this correct code from `django-rest-framework` produces a false positive error: https://github.com/encode/django-rest-framework/blob/3.13.1/tests/test_fields.py#L2428-L2433

I don't have any better ideas other than to revert to my version from #767 that uses `Any`.
