### PR TITLE
Fix type of min_value and max_value on DecimalField

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -125,8 +125,8 @@ class DecimalField(IntegerField):
     def __init__(
         self,
         *,
-        max_value: Optional[int] = ...,
-        min_value: Optional[int] = ...,
+        max_value: Optional[Decimal] = ...,
+        min_value: Optional[Decimal] = ...,
         max_digits: Optional[int] = ...,
         decimal_places: Optional[int] = ...,
         required: bool = ...,

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -125,7 +125,7 @@ class DecimalField(IntegerField):
     def __init__(
         self,
         *,
-        max_value: Optional[Union[Decimal, int, float]] = ...,
+        max_value: Union[Decimal, int, float, None] = ...,
         min_value: Optional[Union[Decimal, int, float]] = ...,
         max_digits: Optional[int] = ...,
         decimal_places: Optional[int] = ...,

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -126,7 +126,7 @@ class DecimalField(IntegerField):
         self,
         *,
         max_value: Union[Decimal, int, float, None] = ...,
-        min_value: Optional[Union[Decimal, int, float]] = ...,
+        min_value: Union[Decimal, int, float, None] = ...,
         max_digits: Optional[int] = ...,
         decimal_places: Optional[int] = ...,
         required: bool = ...,

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -125,8 +125,8 @@ class DecimalField(IntegerField):
     def __init__(
         self,
         *,
-        max_value: Optional[Decimal] = ...,
-        min_value: Optional[Decimal] = ...,
+        max_value: Optional[Union[Decimal, int, float]] = ...,
+        min_value: Optional[Union[Decimal, int, float]] = ...,
         max_digits: Optional[int] = ...,
         decimal_places: Optional[int] = ...,
         required: bool = ...,


### PR DESCRIPTION
These should at the very least allow Decimals. Technically you can send in anything that's comparable to a Decimal, but I'm not sure if it makes sense to allow floats. Could allow both ints and Decimals I guess?

In the Django codebase these arguments are sent to [`MinValueValidator` and `MaxValueValidator`](https://github.com/django/django/blob/439cd73c1670a2af25837149a68526fe5555399d/django/core/validators.py#L386-L401) which just does `a < b`/`a > b`.