### PR TITLE
Fix type for related fields in values_list querysets

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -306,7 +306,7 @@ class DjangoContext:
             if related_model_cls is None:
                 return AnyType(TypeOfAny.from_error)
 
-            if method == "values":
+            if method in ("values", "values_list"):
                 primary_key_field = self.get_primary_key_field(related_model_cls)
                 return self.get_field_get_type(api, primary_key_field, method=method)
 

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -53,9 +53,9 @@
     main: |
         from myapp.models import Post, Blog
         values_tuple = Post.objects.values_list('blog', 'blog__num_posts', 'blog__publisher', 'blog__publisher__name').get()
-        reveal_type(values_tuple[0])  # N: Revealed type is "myapp.models.Blog"
+        reveal_type(values_tuple[0])  # N: Revealed type is "builtins.int"
         reveal_type(values_tuple[1])  # N: Revealed type is "builtins.int"
-        reveal_type(values_tuple[2])  # N: Revealed type is "myapp.models.Publisher"
+        reveal_type(values_tuple[2])  # N: Revealed type is "builtins.int"
         reveal_type(values_tuple[3])  # N: Revealed type is "builtins.str"
 
         reverse_fields_list = Blog.objects.values_list('post__text').get()
@@ -215,6 +215,7 @@
     main: |
         from myapp.models import Blog, Publisher
         reveal_type(Blog.objects.values_list('id', flat=True))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Blog, builtins.int]"
+        reveal_type(Blog.objects.values_list('publisher', flat=True))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Blog, builtins.int]"
         reveal_type(Blog.objects.values_list('publisher_id', flat=True))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Blog, builtins.int]"
         # is Iterable[int]
         reveal_type(list(Blog.objects.values_list('id', flat=True)))  # N: Revealed type is "builtins.list[builtins.int]"


### PR DESCRIPTION
When fetching a related field in a values_list queryset Django will
return the object's primary key, not model instances as was previously
what the mypy plugin assumed.