### PR TITLE
Sync django.contrib.gis.gdal with upstream

### DIFF
--- a/django-stubs/contrib/gis/gdal/__init__.pyi
+++ b/django-stubs/contrib/gis/gdal/__init__.pyi
@@ -1,11 +1,15 @@
-from django.contrib.gis.gdal.datasource import DataSource
-from django.contrib.gis.gdal.driver import Driver
+from django.contrib.gis.gdal.datasource import DataSource as DataSource
+from django.contrib.gis.gdal.driver import Driver as Driver
+from django.contrib.gis.gdal.envelope import Envelope as Envelope
 from django.contrib.gis.gdal.error import GDALException as GDALException
 from django.contrib.gis.gdal.error import SRSException as SRSException
 from django.contrib.gis.gdal.error import check_err as check_err
+from django.contrib.gis.gdal.geometries import OGRGeometry as OGRGeometry
+from django.contrib.gis.gdal.geomtype import OGRGeomType as OGRGeomType
 from django.contrib.gis.gdal.libgdal import GDAL_VERSION as GDAL_VERSION
 from django.contrib.gis.gdal.libgdal import gdal_full_version as gdal_full_version
 from django.contrib.gis.gdal.libgdal import gdal_version as gdal_version
+from django.contrib.gis.gdal.raster.source import GDALRaster as GDALRaster
 from django.contrib.gis.gdal.srs import AxisOrder as AxisOrder
 from django.contrib.gis.gdal.srs import CoordTransform as CoordTransform
 from django.contrib.gis.gdal.srs import SpatialReference as SpatialReference


### PR DESCRIPTION
Dear maintainers,

I was missing `GDALRaster` in `django.contrib.gis.gdal` and found some other missing exports compared to the upstream Django project (3.2/4.0) that I have added in this PR:
- Add `Envelope`, `OGRGeometry`, `OGRGeomType`, and `GDALRaster`.
- Add explicit re-exports for `DataSource` and `Driver`.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

#797 added `DataSource` and `Driver` but it seems like the re-exports disappeared.

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
