### PR TITLE
Support content attribute for a Testing Response.

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -126,6 +126,7 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     client: Client
     templates: List[Template]
     context: List[Dict[str, Any]]
+    content: bytes
     resolver_match: ResolverMatch
 
 class _MonkeyPatchedASGIResponse(_ASGIResponse):
@@ -134,6 +135,7 @@ class _MonkeyPatchedASGIResponse(_ASGIResponse):
     client: AsyncClient
     templates: List[Template]
     context: List[Dict[str, Any]]
+    content: bytes
     resolver_match: ResolverMatch
 
 class ClientMixin:

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -8,6 +8,7 @@
       reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, Any]]"
+      reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
       response.json()
 -   case: async_client_methods
     main: |
@@ -20,6 +21,7 @@
         reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
         reveal_type(response.client)  # N: Revealed type is "django.test.client.AsyncClient"
         reveal_type(response.context)  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, Any]]"
+        reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
         response.json()
 -   case: request_factories
     main: |


### PR DESCRIPTION
# I have made yet another thing!

`content` is [a documented attribute of a testing response](https://docs.djangoproject.com/en/4.0/topics/testing/tools/#testing-responses) which isn't part of the parent `HttpResponseBase`, thus we need to add it to our MonkeyPatched types.

Without this attribute the [example code from the documentation](https://docs.djangoproject.com/en/4.0/topics/testing/tools/#overview-and-a-quick-example
) will fail typing:
```
>>> from django.test import Client
>>> c = Client()
>>> response = c.post('/login/', {'username': 'john', 'password': 'smith'})
>>> response.status_code
200
>>> response = c.get('/customer/details/')
>>> response.content
b'<!DOCTYPE html...'
```

This worked on 1.10.1 but broke after upgrading to 1.11.0 in my own code:
```
project/status/tests.py:28:26: error: "_MonkeyPatchedWSGIResponse" has no attribute "content"; maybe "context"?  [attr-defined]
            self.assertEqual(response.content, b'example_fixed_value EXAMPLE_VALUE\n')
```



## Related issues

None that I am aware of.