### PR TITLE
Upgrade mypy support to 0.960

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ psycopg2-binary
 -e .
 
 # Overrides:
-mypy==0.950
+mypy==0.960

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.930,<0.960",
+    "mypy>=0.930,<0.970",
     "django",
     "django-stubs-ext>=0.4.0",
     "tomli",
@@ -32,7 +32,7 @@ dependencies = [
 
 setup(
     name="django-stubs",
-    version="1.11.0",
+    version="1.11.1",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -27,7 +27,7 @@
         booking = Booking()
         reveal_type(booking.id)  # N: Revealed type is "builtins.int"
         reveal_type(booking.time_range)  # N: Revealed type is "Any"
-        reveal_type(booking.some_decimal)  # N: Revealed type is "decimal.Decimal"
+        reveal_type(booking.some_decimal)  # N: Revealed type is "_decimal.Decimal"
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
# I have made things!

## Related issues

- Closes #972

- Updates test_model_field_classes_from_existing_locations to account
  for the behaviour change in https://github.com/python/mypy/pull/12663
- Bumps the version of django-stubs for a new release