### PR TITLE
Move mypy version upper bound to a [compatible-mypy] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package contains [type stubs](https://www.python.org/dev/peps/pep-0561/) an
 ## Installation
 
 ```bash
-pip install django-stubs
+pip install django-stubs[compatible-mypy]
 ```
 
 To make mypy aware of the plugin, you need to add

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest==7.1.2
 pytest-mypy-plugins==1.9.3
 psycopg2-binary
 -e ./django_stubs_ext
--e .
+-e .[compatible-mypy]
 
 # Overrides:
 mypy==0.960

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy<0.970"],
+    "compatible-mypy": ["mypy>=0.930,<0.970"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.930,<0.970",
+    "mypy>=0.930",
     "django",
     "django-stubs-ext>=0.4.0",
     "tomli",
@@ -29,6 +29,10 @@ dependencies = [
     "types-pytz",
     "types-PyYAML",
 ]
+
+extras_require = {
+    "compatible-mypy": ["mypy<0.970"],
+}
 
 setup(
     name="django-stubs",
@@ -43,6 +47,7 @@ setup(
     py_modules=[],
     python_requires=">=3.7",
     install_requires=dependencies,
+    extras_require=extras_require,
     packages=["django-stubs", *find_packages(exclude=["scripts"])],
     package_data={
         "django-stubs": find_stub_files("django-stubs"),


### PR DESCRIPTION
Due to a bug in mypy 0.940 (#870), we made two changes in #871:

* pinned `mypy==0.931` in `requirements.txt` (for running our tests);
* bounded `mypy<0.940` in `setup.py` (for downstream users).

After the mypy bug was quickly fixed upstream in 0.941, our `setup.py` bound has been repeatedly raised but not removed (#886, #939, #973). The only changes in those commits have been to the precise wording of error messages expected in our tests.  Those wording changes don’t impact compatibility for downstream users, so it should be safe to go back to allowing them to upgrade mypy independently.

Since mypy doesn’t yet guarantee backwards compatibility in the plugin API (although in practice it has rarely been an issue), add a `django-stubs[compatible-mypy]` extra for users who prefer a known-good version of mypy even if it’s a little out of date.