### PR TITLE
Add GitHub release action to upload to PyPI & create GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,6 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `release-ci failure on ${new Date().toDateString()}`,
+              title: `Release failure on ${new Date().toDateString()}`,
               body: `Details: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/release.yml`,
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    if: github.repository == 'typeddjango/django-stubs'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+          print_hash: true
+
+      - name: Create release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const tagName = context.ref.replace(/^refs\/tags\//, '');
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: `Release ${tagName.replace(/^v/, '')}`,
+            });
+
+            if (release.status < 200 || release.status >= 300) {
+              core.setFailed(`Could not create release for tag '${tagName}'`);
+              return;
+            }
+
+  # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
+  create-issue-on-failure:
+    name: Create an issue if release failed
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.repository == 'typeddjango/django-stubs' && always() && needs.build.result == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `release-ci failure on ${new Date().toDateString()}`,
+              body: `Details: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/release.yml`,
+            })


### PR DESCRIPTION
Creating a release action as mentioned in https://github.com/typeddjango/django-stubs/issues/959

I have tested everything except the PyPI part (commented out in https://github.com/terencehonles/django-stubs/commit/78924b806a77da623530a964cc49117132694f00 and https://github.com/terencehonles/django-stubs/commit/cc1e839df2107fb0c0be5f650aa922f1144a5d59) by pushing the tags[`test-tag-failure`](https://github.com/terencehonles/django-stubs/tree/test-tag-failure) & [`test-tag-success`](https://github.com/terencehonles/django-stubs/tree/test-tag-success) in my fork which created the relase https://github.com/terencehonles/django-stubs/releases/tag/test-tag-success


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

- Refs https://github.com/typeddjango/django-stubs/issues/959

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

I can open the PR in the other repos if this looks good.
