### PR TITLE
Enable GitHub auto generated release notes for GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
               repo: context.repo.repo,
               tag_name: tagName,
               name: `Release ${tagName.replace(/^v/, '')}`,
+              generate_release_notes: true,
             });
 
             if (release.status < 200 || release.status >= 300) {


### PR DESCRIPTION
I missed this option in #980 and figured it would be nice to have.

You can see what this would generate by clicking the "create release" button and then selecting a tag and then there's a "generate release notes" above the release notes text box. This will use that description by default and if something needs to be edited the release can be edited after it's created.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

- Refs #980 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
