### PR TITLE
Fix manager types scope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           pip install -r ./requirements.txt
 
       - name: Run tests
-        run: pytest
+        run: pytest --mypy-ini-file=mypy.ini
 
   typecheck:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,12 @@ To execute the unit tests, simply run:
 pytest
 ```
 
+If you get some unexpected results or want to be sure that tests run is not affected by previous one, remove `mypy` cache:
+
+```bash
+rm -r .mypy_cache
+```
+
 We also test the stubs against Django's own test suite. This is done in CI but you can also do this locally.
 To execute the script run:
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,8 +2,7 @@
 allow_redefinition = True
 check_untyped_defs = True
 ignore_missing_imports = True
-# Incremental mode causes false-negatives
-incremental = False
+incremental = True
 strict_optional = True
 show_traceback = True
 warn_no_return = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,8 @@
 allow_redefinition = True
 check_untyped_defs = True
 ignore_missing_imports = True
-incremental = True
+# Incremental mode causes false-negatives
+incremental = False
 strict_optional = True
 show_traceback = True
 warn_no_return = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,10 @@
 # Regular configuration file (can be used as base in other projects, runs in CI)
 
+# NOTE: this config file is not used by pytest locally.
+# See comment in mypy.ini.dev for explanation.
+
+# WARNING: when changing this file, consider doing the same with mypy.ini.dev
+
 [mypy]
 allow_redefinition = True
 check_untyped_defs = True

--- a/mypy.ini.dev
+++ b/mypy.ini.dev
@@ -1,10 +1,11 @@
-# Regular configuration file (can be used as base in other projects, runs in CI)
+# Configuration file to use during development
 
 [mypy]
 allow_redefinition = True
 check_untyped_defs = True
 ignore_missing_imports = True
-incremental = True
+# Avoid caching between test runs
+incremental = False
 strict_optional = True
 show_traceback = True
 warn_no_return = False

--- a/mypy.ini.dev
+++ b/mypy.ini.dev
@@ -1,5 +1,14 @@
 # Configuration file to use during development
 
+# Changes of plugin code are not detected by mypy, so
+# incremental mode can be harmful during development
+# (mypy cache is not always invalidated).
+# However, incremental mode has to be supported by django-stubs,
+# thus another config (mypy.ini) is used in CI.
+# Incremental mode is recommended for regular usage.
+
+# WARNING: when changing this file, consider doing the same with mypy.ini
+
 [mypy]
 allow_redefinition = True
 check_untyped_defs = True

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -369,11 +369,10 @@ def bind_or_analyze_type(t: MypyType, api: SemanticAnalyzer, module_name: Option
     That should hopefully give a bound type."""
     if isinstance(t, UnboundType) and module_name is not None:
         node = api.lookup_fully_qualified_or_none(module_name + "." + t.name)
-        if node is None:
-            return None
-        return node.type
-    else:
-        return api.anal_type(t)
+        if node is not None and node.type is not None:
+            return node.type
+
+    return api.anal_type(t)
 
 
 def copy_method_to_another_class(

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -212,7 +212,11 @@ class AddManagers(ModelClassInitializer):
             # replace self type with new class, if copying method
             if isinstance(sym.node, FuncDef):
                 helpers.copy_method_to_another_class(
-                    new_cls_def_context, self_type=custom_manager_type, new_method_name=name, method_node=sym.node
+                    new_cls_def_context,
+                    self_type=custom_manager_type,
+                    new_method_name=name,
+                    method_node=sym.node,
+                    original_module_name=base_manager_info.module_name,
                 )
                 continue
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,5 @@ addopts =
     -s
     -v
     --cache-clear
-    --mypy-ini-file=./mypy.ini
+    --mypy-ini-file=./mypy.ini.dev
     --mypy-extension-hook=scripts.tests_extension_hook.django_plugin_hook

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -423,3 +423,22 @@
                 class MyModel(models.Model):
 
                    objects = MyModelManager()
+
+-   case: regression_manager_scope_foreign
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.on_site)  # N: Revealed type is "myapp.models.MyModel_CurrentSiteManager[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+        - django.contrib.sites
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.contrib.sites.models import Site
+                from django.contrib.sites.managers import CurrentSiteManager
+
+                class MyModel(models.Model):
+                    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+                    on_site = CurrentSiteManager()


### PR DESCRIPTION
Fixed wrong scope of managers methods when manager is imported from another file.

On master branch the following is enough to reproduce the issue:
```
from django.db import models
from django.contrib.sites.models import Site
from django.contrib.sites.managers import CurrentSiteManager


class MyModel(models.Model):
    site = models.ForeignKey(Site, on_delete=models.CASCADE)

    on_site = CurrentSiteManager()
```

It results in weird `mypy` error:
```
myproject/myapp/models.py:6: error: Name "Optional" is not defined
myproject/myapp/models.py:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Optional")
```

The changes are self-explanatory, but here's a short explanation:
* Before this PR all types were resolved as if manager is defined in current module. However, this assumption doesn't always hold. 
* After passing `original_module_name`, two other tests began to fail. It happened because `api.anal_type` was expected, but ran only if `module_name is None`. So we want to call it even if module name was given, but only if initial solution (with `lookup_fully_qualified`) fails to return something meaningful.
* While researching this issue, I found out that with incremental mode some tests were wrongly passing. After cleaning cache this changed, so incremental mode is a bad idea for testing.
* Added regression test for this particular issue.

## Related issues
This issue was discovered in [this SO question](https://stackoverflow.com/questions/72585301/mypy-complaining-about-name-optional-is-not-defined-without-the-use-of-optiona/72587601#72587601). 