### PR TITLE
Update RunSQL type to include parametrized sql

### DIFF
--- a/django-stubs/db/migrations/operations/special.pyi
+++ b/django-stubs/db/migrations/operations/special.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
@@ -21,14 +21,14 @@ class SeparateDatabaseAndState(Operation):
 
 class RunSQL(Operation):
     noop: Literal[""] = ...
-    sql: Union[str, _ListOrTuple[str]] = ...
-    reverse_sql: Optional[Union[str, _ListOrTuple[str]]] = ...
+    sql: Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]] = ...
+    reverse_sql: Optional[Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]]] = ...
     state_operations: Sequence[Operation] = ...
     hints: Mapping[str, Any] = ...
     def __init__(
         self,
-        sql: Union[str, _ListOrTuple[str]],
-        reverse_sql: Optional[Union[str, _ListOrTuple[str]]] = ...,
+        sql: Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]],
+        reverse_sql: Optional[Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]]] = ...,
         state_operations: Sequence[Operation] = ...,
         hints: Optional[Mapping[str, Any]] = ...,
         elidable: bool = ...,

--- a/django-stubs/db/migrations/operations/special.pyi
+++ b/django-stubs/db/migrations/operations/special.pyi
@@ -28,7 +28,9 @@ class RunSQL(Operation):
     def __init__(
         self,
         sql: Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]],
-        reverse_sql: Optional[Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]]] = ...,
+        reverse_sql: Optional[
+            Union[str, _ListOrTuple[str], _ListOrTuple[Tuple[str, Optional[_ListOrTuple[str]]]]]
+        ] = ...,
         state_operations: Sequence[Operation] = ...,
         hints: Optional[Mapping[str, Any]] = ...,
         elidable: bool = ...,


### PR DESCRIPTION
`RunSQL` supports parametrized SQLs by passing list of 2-tuples, where first item is the SQL and second item is the list of parameters. Technically, the 2-tuples could also be 2-item lists, but afaik there's no way to type that, so I just went with strictly tuple there.

## Related issues
No issue I've found related to this, probably not used that frequently