### PR TITLE
Set generic type of SimpleCookie

### DIFF
--- a/django-stubs/template/response.pyi
+++ b/django-stubs/template/response.pyi
@@ -17,7 +17,7 @@ class ContentNotRenderedError(Exception): ...
 class SimpleTemplateResponse(HttpResponse):
     content: Any = ...
     closed: bool
-    cookies: SimpleCookie
+    cookies: SimpleCookie[str]
     status_code: int
     rendering_attrs: Any = ...
     template_name: _TemplateForResponseT = ...
@@ -48,7 +48,7 @@ class TemplateResponse(SimpleTemplateResponse):
     closed: bool
     context: RequestContext
     context_data: Optional[Dict[str, Any]]
-    cookies: SimpleCookie
+    cookies: SimpleCookie[str]
     csrf_cookie_set: bool
     json: functools.partial
     redirect_chain: List[Tuple[str, int]]


### PR DESCRIPTION
Pyright complains about `response.cookies` because the generic type isn't known. `str` may or may not be the correct type to use here. Something should be set here.

## Related issues

There are no related issues. I just saw this in my editor and wanted to point it out here.
