### PR TITLE
Improved return type of render_to_string().

### DIFF
--- a/django-stubs/template/loader.pyi
+++ b/django-stubs/template/loader.pyi
@@ -2,6 +2,7 @@ from typing import Any, Mapping, Optional, Sequence, Union
 
 from django.http.request import HttpRequest
 from django.template.exceptions import TemplateDoesNotExist as TemplateDoesNotExist  # noqa: F401
+from django.utils.safestring import SafeString
 
 from . import engines as engines  # noqa: F401
 from .backends.base import _EngineTemplate
@@ -13,4 +14,4 @@ def render_to_string(
     context: Optional[Mapping[str, Any]] = ...,
     request: Optional[HttpRequest] = ...,
     using: Optional[str] = ...,
-) -> str: ...
+) -> SafeString: ...


### PR DESCRIPTION
[render_to_string()](https://github.com/django/django/blob/bb2c5f69f47466fa52f3cf2727d10b3ebd79a4da/django/template/loader.py#L52) finds an [`_EngineTemplate`](https://github.com/typeddjango/django-stubs/blob/214b0c7439d67b423815515c49eda8ecf0d62bfa/django-stubs/template/backends/base.pyi#L21) and calls `render()` on it. Therefore it returns a `SafeString`. 