### PR TITLE
Don't create dynamic classes for non-dynamic managers

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -182,6 +182,9 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
     """
     semanal_api = helpers.get_semanal_api(ctx)
 
+    if semanal_api.is_class_scope():
+        return
+
     # Don't redeclare the manager class if we've already defined it.
     manager_node = semanal_api.lookup_current_scope(ctx.name)
     if manager_node and isinstance(manager_node.node, TypeInfo):

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -680,7 +680,7 @@
 
                 # Note, that we cannot resolve dynamic calls for custom managers:
                 class Transaction(models.Model):
-                    objects = BaseManager.from_queryset(TransactionQuerySet)
+                    objects = BaseManager.from_queryset(TransactionQuerySet)()
                     def test(self) -> None:
                         reveal_type(self.transactionlog_set)
                         # We use a fallback Any type:
@@ -689,8 +689,10 @@
                 class TransactionLog(models.Model):
                     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
     out: |
+        myapp/models:9: error: Could not resolve manager type for "myapp.models.Transaction.objects"
         myapp/models:9: error: `.from_queryset` called from inside model class body
         myapp/models:11: note: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.TransactionLog]"
+        myapp/models:13: error: "Manager[Transaction]" has no attribute "custom"
         myapp/models:13: note: Revealed type is "Any"
 
 

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -329,19 +329,19 @@
 #                class MyUser(MyBaseUser):
 #                    objects = MyManager()
 
--   case: custom_manager_returns_proper_model_types
+-   case: custom_manager_without_typevar_returns_any_model_types
     main: |
         from myapp.models import User
-        reveal_type(User.objects)  # N: Revealed type is "myapp.models.User_MyManager2[myapp.models.User]"
-        reveal_type(User.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.User, myapp.models.User]"
-        reveal_type(User.objects.get())  # N: Revealed type is "myapp.models.User"
+        reveal_type(User.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.User]"
+        reveal_type(User.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[Any, Any]"
+        reveal_type(User.objects.get())  # N: Revealed type is "Any"
         reveal_type(User.objects.get_instance())  # N: Revealed type is "builtins.int"
         reveal_type(User.objects.get_instance_untyped('hello'))  # N: Revealed type is "Any"
 
         from myapp.models import ChildUser
-        reveal_type(ChildUser.objects)  # N: Revealed type is "myapp.models.ChildUser_MyManager2[myapp.models.ChildUser]"
-        reveal_type(ChildUser.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.ChildUser, myapp.models.ChildUser]"
-        reveal_type(ChildUser.objects.get())  # N: Revealed type is "myapp.models.ChildUser"
+        reveal_type(ChildUser.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.ChildUser]"
+        reveal_type(ChildUser.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[Any, Any]"
+        reveal_type(ChildUser.objects.get())  # N: Revealed type is "Any"
         reveal_type(ChildUser.objects.get_instance())  # N: Revealed type is "builtins.int"
         reveal_type(ChildUser.objects.get_instance_untyped('hello'))  # N: Revealed type is "Any"
     installed_apps:
@@ -361,10 +361,44 @@
                 class ChildUser(models.Model):
                     objects = MyManager()
 
+-   case: custom_manager_with_typevars_returns_proper_model_types
+    main: |
+        from myapp.models import User
+        reveal_type(User.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.User]"
+        reveal_type(User.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.User, myapp.models.User]"
+        reveal_type(User.objects.get())  # N: Revealed type is "myapp.models.User"
+        reveal_type(User.objects.get_instance())  # N: Revealed type is "builtins.int"
+        reveal_type(User.objects.get_instance_untyped('hello'))  # N: Revealed type is "Any"
+
+        from myapp.models import ChildUser
+        reveal_type(ChildUser.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.ChildUser]"
+        reveal_type(ChildUser.objects.select_related())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.ChildUser, myapp.models.ChildUser]"
+        reveal_type(ChildUser.objects.get())  # N: Revealed type is "myapp.models.ChildUser"
+        reveal_type(ChildUser.objects.get_instance())  # N: Revealed type is "builtins.int"
+        reveal_type(ChildUser.objects.get_instance_untyped('hello'))  # N: Revealed type is "Any"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import TypeVar
+                from django.db import models
+                T = TypeVar("T", bound=models.Model)
+                class MyManager(models.Manager[T]):
+                    def get_instance(self) -> int:
+                        pass
+                    def get_instance_untyped(self, name):
+                        pass
+                class User(models.Model):
+                    objects = MyManager()
+                class ChildUser(models.Model):
+                    objects = MyManager()
+
 -   case: custom_manager_annotate_method_before_type_declaration
     main: |
         from myapp.models import ModelA, ModelB, ManagerA
-        reveal_type(ModelA.objects)  # N: Revealed type is "myapp.models.ModelA_ManagerA1[myapp.models.ModelA]"
+        reveal_type(ModelA.objects)  # N: Revealed type is "myapp.models.ManagerA[myapp.models.ModelA]"
         reveal_type(ModelA.objects.do_something)  # N: Revealed type is "def (other_obj: myapp.models.ModelB) -> builtins.str"
     installed_apps:
         - myapp
@@ -383,7 +417,7 @@
                     movie = models.TextField()
 
 
--   case: override_manager_create1
+-   case: override_manager_create_missing_generic
     main: |
         from myapp.models import MyModel
         MyModel.objects.create()
@@ -397,14 +431,14 @@
                 class MyModelManager(models.Manager):
 
                     def create(self, **kwargs) -> 'MyModel':
-                          return super().create(**kwargs)
+                        return super().create(**kwargs)
 
 
                 class MyModel(models.Model):
 
                    objects = MyModelManager()
 
--   case: override_manager_create2
+-   case: override_manager_create_with_generic
     main: |
         from myapp.models import MyModel
         MyModel.objects.create()
@@ -427,7 +461,7 @@
 -   case: regression_manager_scope_foreign
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel.on_site)  # N: Revealed type is "myapp.models.MyModel_CurrentSiteManager[myapp.models.MyModel]"
+        reveal_type(MyModel.on_site)  # N: Revealed type is "django.contrib.sites.managers.CurrentSiteManager[myapp.models.MyModel]"
     installed_apps:
         - myapp
         - django.contrib.sites


### PR DESCRIPTION
We don't need to create custom managers when the manager isn't dynamically created. This changes the logic to just set the type of the manager on the class.

There's a small regression/limitation with this approach, as demonstrated by the `custom_manager_without_typevar_returns_any_model_types` test case. If the manager is _not_ typed with generics (ie. `MyManager(Manager)` vs `MyManager(Manager[T])` the manager will return querysets with `Any` as the model type instead because of implicit generics.

That can be solved in one of two ways: either through "reparametrization" as implemented in #1030 or possibly through setting the methods as attributes with type `Any` as we do for dynamic managers.