### PR TITLE
Monkeypatch some more generics.

### DIFF
--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -4,6 +4,7 @@ from django import VERSION as VERSION
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
 from django.contrib.syndication.views import Feed
+from django.core.files.utils import FileProxyMixin
 from django.core.paginator import Paginator
 from django.db.models.fields import Field
 from django.db.models.manager import BaseManager
@@ -54,6 +55,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(BaseModelForm),
     MPGeneric(BaseModelFormSet),
     MPGeneric(Feed),
+    MPGeneric(FileProxyMixin),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -7,6 +7,7 @@ from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
 from django.core.paginator import Paginator
 from django.db.models.fields import Field
+from django.db.models.fields.related import ForeignKey
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
@@ -59,6 +60,8 @@ _need_generic: List[MPGeneric[Any]] = [
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),
+    # These types do have native `__class_getitem__` method since django 4.1:
+    MPGeneric(ForeignKey, (4, 1)),
 ]
 
 

--- a/django_stubs_ext/tests/test_monkeypatching.py
+++ b/django_stubs_ext/tests/test_monkeypatching.py
@@ -82,6 +82,8 @@ def test_patched_extra_classes_generics(make_generic_classes: _MakeGenericClasse
         (3, 0),
         (3, 1),
         (3, 2),
+        (4, 0),
+        (4, 1),
     ],
 )
 def test_patched_version_specific(


### PR DESCRIPTION
Adds monkey patching of the following generics:

- `django.core.files.utils.FileProxyMixin`: Fixes `django.core.files.base.ContentFile` and `django.core.files.File`.
- `django.db.models.fields.related.ForeignKey`: `__class_getitem__` is being added for Django 4.1