### PR TITLE
Use a more general type for django.core.mail.send_mass_mail's datatuple

### DIFF
--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -23,7 +23,7 @@ def send_mail(
     html_message: Optional[str] = ...,
 ) -> int: ...
 def send_mass_mail(
-    datatuple: List[Tuple[str, str, str, List[str]]],
+    datatuple: Tuple[Tuple[str, str, str, List[str]], ...],
     fail_silently: bool = ...,
     auth_user: Optional[str] = ...,
     auth_password: Optional[str] = ...,

--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
 from .message import DEFAULT_ATTACHMENT_MIME_TYPE as DEFAULT_ATTACHMENT_MIME_TYPE
 from .message import BadHeaderError as BadHeaderError
@@ -23,7 +23,7 @@ def send_mail(
     html_message: Optional[str] = ...,
 ) -> int: ...
 def send_mass_mail(
-    datatuple: Tuple[Tuple[str, str, str, List[str]], ...],
+    datatuple: Iterable[Tuple[str, str, str, List[str]]],
     fail_silently: bool = ...,
     auth_user: Optional[str] = ...,
     auth_password: Optional[str] = ...,


### PR DESCRIPTION
The implementation works with all `Iterable`s, the current typing in this library is a `List`, and the docs recommend using a datatuple.

We can expand the datatuple's type to include all valid args

https://github.com/django/django/blob/main/django/core/mail/__init__.py#L112
https://docs.djangoproject.com/en/4.0/topics/email/#send-mass-mail
