### PR TITLE
Drop the restriction of _ValidatorCallable's return type.

### DIFF
--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -7,7 +7,7 @@ from django.core.files.base import File
 EMPTY_VALUES: Any
 
 _Regex = Union[str, Pattern[str]]
-_ValidatorCallable = Callable[[Any], None]
+_ValidatorCallable = Callable[[Any], object]
 
 class RegexValidator:
     regex: _Regex = ...  # Pattern[str] on instance, but may be str on class definition


### PR DESCRIPTION

# I have made things!

The type of the return value of a validator is neither specified nor
required in the source code and documentation.

See also: https://docs.djangoproject.com/en/4.0/ref/validators/

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
