### PR TITLE
Support Lookup generics.

### DIFF
--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -8,6 +8,7 @@ from django.core.files.utils import FileProxyMixin
 from django.core.paginator import Paginator
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey
+from django.db.models.lookups import Lookup
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
@@ -57,6 +58,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(BaseModelFormSet),
     MPGeneric(Feed),
     MPGeneric(FileProxyMixin),
+    MPGeneric(Lookup),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),


### PR DESCRIPTION

# I have made things!

Custom `Lookup` implementation will run into
'Missing type parameters for generic type "Lookup"' without having
`Lookup` monkey-patched with django-stubs-ext.

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
