### PR TITLE
 Fix type of min_value and max_value on FloatField

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -115,6 +115,23 @@ class IntegerField(Field):
     def widget_attrs(self, widget: Widget) -> Dict[str, Any]: ...
 
 class FloatField(IntegerField):
+    def __init__(
+        self,
+        *,
+        max_value: Union[int, float, None] = ...,
+        min_value: Union[int, float, None] = ...,
+        required: bool = ...,
+        widget: Optional[Union[Widget, Type[Widget]]] = ...,
+        label: Optional[str] = ...,
+        initial: Optional[Any] = ...,
+        help_text: str = ...,
+        error_messages: Optional[_ErrorMessagesT] = ...,
+        show_hidden_initial: bool = ...,
+        validators: Sequence[_ValidatorCallable] = ...,
+        localize: bool = ...,
+        disabled: bool = ...,
+        label_suffix: Optional[str] = ...,
+    ) -> None: ...
     def to_python(self, value: Optional[Any]) -> Optional[float]: ...  # type: ignore
     def validate(self, value: float) -> None: ...
     def widget_attrs(self, widget: Widget) -> Dict[str, Any]: ...


### PR DESCRIPTION
# I have made things!
Similar to #951 

This is common to use a `float` for the `min_value`/`max_value` of a `forms.FloatField.` 
Not sure if `Decimal` should be allowed here too.

Cheers
## Related issues
None