### PR TITLE
Avoid failing on GM2MRelations

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -189,7 +189,7 @@ class DjangoContext:
 
         model_info = helpers.lookup_class_typeinfo(api, model_cls)
         for field in model_cls._meta.get_fields():
-            if isinstance(field, Field):
+            if isinstance(field, Field) and hasattr(field, 'attname'):
                 field_name = field.attname
                 # Try to retrieve set type from a model's TypeInfo object and fallback to retrieving it manually
                 # from django-stubs own declaration. This is to align with the setter types declared for


### PR DESCRIPTION
GM2MRelation fields from [django-gm2m](https://pypi.org/project/django-gm2m/) do not have `attname` set:

```
error: INTERNAL ERROR -- Please try using mypy master on Github:
https://mypy.rtfd.io/en/latest/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 0.790
Traceback (most recent call last):
  File "mypy/checkexpr.py", line 3766, in accept
  File "mypy/checkexpr.py", line 263, in visit_call_expr
  File "mypy/checkexpr.py", line 340, in visit_call_expr_inner
  File "mypy/checkexpr.py", line 817, in check_call_expr_with_callee_type
  File "mypy/checkexpr.py", line 907, in check_call
  File "mypy/checkexpr.py", line 876, in check_call
  File "mypy/checkexpr.py", line 988, in check_callable_call
  File "mypy/checkexpr.py", line 716, in apply_function_plugin
  File ".../.venv/lib/python3.7/site-packages/mypy_django_plugin/transformers/init_create.py", line 62, in redefine_and_typecheck_model_init
    return typecheck_model_method(ctx, django_context, model_cls, '__init__')
  File ".../.venv/lib/python3.7/site-packages/mypy_django_plugin/transformers/init_create.py", line 36, in typecheck_model_method
    expected_types = django_context.get_expected_types(typechecker_api, model_cls, method=method)
  File ".../.venv/lib/python3.7/site-packages/mypy_django_plugin/django/context.py", line 165, in get_expected_types
    field.set_attributes_from_name()
TypeError: set_attributes_from_name() missing 1 required positional argument: 'name'
.../models/counter.py:155: : note: use --pdb to drop into pdb

```

This avoids accessing field.attname if it is not available.

Looking at the `GenericForeignKey` handling below, someone with more experience
might be able to provide a better fix actually handling `GM2MRelation`, but this
at least avoids the exception, ignoring the field.
