### PR TITLE
Fix CI error introduced since Django 4.1

### DIFF
--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -654,6 +654,7 @@
                     pass
                 TransactionManager = BaseManager.from_queryset(TransactionQuerySet)
                 class Transaction(models.Model):
+                    pk = 0
                     objects = TransactionManager()
                     def test(self) -> None:
                         self.transactionlog_set


### PR DESCRIPTION
# I have made things!

This fixes the CI starting occur on #1086 and following PRs due to [the release of Django 4.1](https://docs.djangoproject.com/en/4.1/releases/4.1/) which shipped the change

    # Even if this relation is not to pk, we require still pk value.
    # The wish is that the instance has been already saved to DB,
    # although having a pk value isn't a guarantee of that.
    if self.instance.pk is None:
        raise ValueError(
            f"{instance.__class__.__name__!r} instance needs to have a primary "
            f"key value before this relationship can be used."
        )

in https://github.com/django/django/pull/15318.

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
