### PR TITLE
Add SimpleTestCase.assertURLEqual()

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -82,6 +82,12 @@ class SimpleTestCase(unittest.TestCase):
         msg_prefix: str = ...,
         fetch_redirect_response: bool = ...,
     ) -> None: ...
+    def assertURLEqual(
+        self,
+        url1: str | Any,  # Any for reverse_lazy() support
+        url2: str | Any,
+        msg_prefix: str = ...,
+    ) -> None: ...
     def assertContains(
         self,
         response: HttpResponseBase,


### PR DESCRIPTION
# I have made things!

This method has been around since Django 2.2, it was just missing: [docs](https://docs.djangoproject.com/en/4.1/topics/testing/tools/#django.test.SimpleTestCase.assertURLEqual).

[The source](https://github.com/django/django/blob/cb791a2540c289390b68a3ea9c6a79476890bab2/django/test/testcases.py#L571) shows that it calls `str()` on whatever's passed in, with comment saying this is for `reverse_lazy`, so we have to annotate as such.

## Related issues

n/a