### PR TITLE
Add different signatures for form assertions from Django 4.1

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -25,6 +25,7 @@ from django.db import connections as connections  # noqa: F401
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.base import Model
 from django.db.models.query import QuerySet, RawQuerySet
+from django.forms import BaseFormSet, Form
 from django.forms.fields import EmailField
 from django.http.response import FileResponse, HttpResponseBase
 from django.template.base import Template
@@ -105,6 +106,15 @@ class SimpleTestCase(unittest.TestCase):
         msg_prefix: str = ...,
         html: bool = ...,
     ) -> None: ...
+    @overload
+    def assertFormError(
+        self,
+        form: Form,
+        field: Optional[str],
+        errors: Union[List[str], str],
+        msg_prefix: str = ...,
+    ) -> None: ...
+    @overload
     def assertFormError(
         self,
         response: HttpResponseBase,
@@ -113,6 +123,16 @@ class SimpleTestCase(unittest.TestCase):
         errors: Union[List[str], str],
         msg_prefix: str = ...,
     ) -> None: ...
+    @overload
+    def assertFormsetError(
+        self,
+        formset: BaseFormSet,
+        form_index: Optional[int],
+        field: Optional[str],
+        errors: Union[List[str], str],
+        msg_prefix: str = ...,
+    ) -> None: ...
+    @overload
     def assertFormsetError(
         self,
         response: HttpResponseBase,


### PR DESCRIPTION
# I have made things!

As per release note from [testing section](https://docs.djangoproject.com/en/4.1/releases/4.1/#tests): 

> [SimpleTestCase.assertFormError()](https://docs.djangoproject.com/en/4.1/topics/testing/tools/#django.test.SimpleTestCase.assertFormError) and [assertFormsetError()](https://docs.djangoproject.com/en/4.1/topics/testing/tools/#django.test.SimpleTestCase.assertFormsetError) now support passing a form/formset object directly.

## Related issues

n/a
