### PR TITLE
fix type hint for GenericSitemap(info_dict)

### DIFF
--- a/django-stubs/contrib/sitemaps/__init__.pyi
+++ b/django-stubs/contrib/sitemaps/__init__.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from django.contrib.sites.models import Site
 from django.contrib.sites.requests import RequestSite
@@ -36,7 +36,7 @@ class GenericSitemap(Sitemap):
     protocol: Optional[str] = ...
     def __init__(
         self,
-        info_dict: Dict[str, Union[datetime, QuerySet[Model], str]],
+        info_dict: Mapping[str, Union[datetime, QuerySet[Model], str]],
         priority: Optional[float] = ...,
         changefreq: Optional[str] = ...,
         protocol: Optional[str] = ...,


### PR DESCRIPTION
# Description
This PR softens the invariant type hint `Dict` to the covariant `Mapping` of `django.contrib.sitemaps.GenericSitemap(info_dict)`.
See [Python type hints: typing.Mapping vs. typing.Dict - Stack Overflow](https://stackoverflow.com/a/52487800)
Docs: [The sitemap framework # GenericSitemap](https://docs.djangoproject.com/en/4.1/ref/contrib/sitemaps/#django.contrib.sitemaps.GenericSitemap)

# Motivation
```python
info_dict = {
    'queryset': Entry.objects.all()
}

urlpatterns = [
    path('sitemap.xml', sitemap,
         {'sitemaps': {'blog': GenericSitemap(info_dict)}},
         name='django.contrib.sitemaps.views.sitemap'),
]
```

Mypy error:
```
error: Argument 1 to "GenericSitemap" has incompatible type "Dict[str, _QuerySet[Entry, Entry]]"; expected "Dict[str, Union[datetime, _QuerySet[Model, Model], str]]"  [arg-type]
note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
note: Consider using "Mapping" instead, which is covariant in the value type
```

# Test
In my local virtualenv I modified the file `site-packages/django-stubs/contrib/sitemaps/__init__.pyi` according to the change of this PR.
Afterwars ran the mypy check again and the errors was gone.