### PR TITLE
Expose HttpResponseBase in django.http

### DIFF
--- a/django-stubs/http/__init__.pyi
+++ b/django-stubs/http/__init__.pyi
@@ -8,6 +8,7 @@ from .response import BadHeaderError as BadHeaderError
 from .response import FileResponse as FileResponse
 from .response import Http404 as Http404
 from .response import HttpResponse as HttpResponse
+from .response import HttpResponseBase as HttpResponseBase
 from .response import HttpResponseBadRequest as HttpResponseBadRequest
 from .response import HttpResponseForbidden as HttpResponseForbidden
 from .response import HttpResponseGone as HttpResponseGone

--- a/django-stubs/http/__init__.pyi
+++ b/django-stubs/http/__init__.pyi
@@ -8,8 +8,8 @@ from .response import BadHeaderError as BadHeaderError
 from .response import FileResponse as FileResponse
 from .response import Http404 as Http404
 from .response import HttpResponse as HttpResponse
-from .response import HttpResponseBase as HttpResponseBase
 from .response import HttpResponseBadRequest as HttpResponseBadRequest
+from .response import HttpResponseBase as HttpResponseBase
 from .response import HttpResponseForbidden as HttpResponseForbidden
 from .response import HttpResponseGone as HttpResponseGone
 from .response import HttpResponseNotAllowed as HttpResponseNotAllowed


### PR DESCRIPTION
# I have made things!

Based on upstream PR released in Django 4.1: https://github.com/django/django/pull/15667

## Related issues

n/a
