### PR TITLE
Install requirements.txt with SETUPTOOLS_ENABLE_FEATURES=legacy-editable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip setuptools wheel
-          pip install -r ./requirements.txt
+          SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run pre-commit
         run: pre-commit install && pre-commit run --all-files
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip setuptools wheel
-          pip install -r ./requirements.txt
+          SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run tests
         run: pytest --mypy-ini-file=mypy.ini
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip setuptools wheel
-          pip install -r ./requirements.txt
+          SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run tests
         run: python ./scripts/typecheck_tests.py --django_version="${{ matrix.django-version }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ source .venv/bin/activate
 Then install the dev requirements:
 
 ```bash
-pip install -r ./requirements.txt
+env SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 ```
 
 Finally, install the pre-commit hooks:


### PR DESCRIPTION
This appears to be needed for passing CI now. It’s not the best solution and will probably stop working after a while, but at least it will allow development to proceed for now.

This is an alternative to #1123; we should only merge one or the other.

Closes #1108.
Closes #1118.
Closes #1123.