### PR TITLE
Prevent building an editable wheel with setuptools<64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ include = '\.pyi?$'
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
+
+[build-system]
+requires = ["setuptools<64", "wheel"]


### PR DESCRIPTION
This seems to be needed for passing CI now.

This is an alternative to #1122; we should only merge one or the other.

Closes #1108.
Closes #1118.
Closes #1122.