### PR TITLE
Add test client response.redirect_chain

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -128,6 +128,7 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     context: List[Dict[str, Any]]
     content: bytes
     resolver_match: ResolverMatch
+    redirect_chain: List[Tuple[str, int]]
 
 class _MonkeyPatchedASGIResponse(_ASGIResponse):
     def json(self) -> Any: ...
@@ -137,6 +138,7 @@ class _MonkeyPatchedASGIResponse(_ASGIResponse):
     context: List[Dict[str, Any]]
     content: bytes
     resolver_match: ResolverMatch
+    redirect_chain: List[Tuple[str, int]]
 
 class ClientMixin:
     def store_exc_info(self, **kwargs: Any) -> None: ...

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -9,6 +9,7 @@
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, Any]]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
       response.json()
 -   case: async_client_methods
     main: |
@@ -22,6 +23,7 @@
         reveal_type(response.client)  # N: Revealed type is "django.test.client.AsyncClient"
         reveal_type(response.context)  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, Any]]"
         reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
+        reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
         response.json()
 -   case: request_factories
     main: |


### PR DESCRIPTION
# I have made things!

This attribute is described in the docs for `Client.get()` and `post()`: https://docs.djangoproject.com/en/4.1/topics/testing/tools/#django.test.Client.get . It's existed since before Django 1.8.

It's conditionally attached by `_handle_redirects`: https://github.com/django/django/blob/166a3b32632c141541d1c3f0eff18e1d8b389404/django/test/client.py#L960 , only when `follow-True`, but I think it's not worth the effort of an `@overload` to represent this.

## Related issues

n/a
