### PR TITLE
Add HttpRequest current_app and LANGUAGE_CODE attrs

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -57,6 +57,8 @@ class HttpRequest(BytesIO):
     site: Site
     session: SessionBase
     _stream: BinaryIO
+    # django.contrib.admin uses this attribute:
+    current_app: str = ...
     # The magic. If we instantiate HttpRequest directly somewhere, it has
     # mutable GET and POST. However, both ASGIRequest and WSGIRequest have immutable,
     # so when we use HttpRequest to refer to any of them we want exactly this.

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -53,12 +53,18 @@ class HttpRequest(BytesIO):
     resolver_match: Optional[ResolverMatch] = ...
     content_type: Optional[str] = ...
     content_params: Optional[Dict[str, str]] = ...
-    user: Union[AbstractBaseUser, AnonymousUser]
-    site: Site
-    session: SessionBase
     _stream: BinaryIO
-    # django.contrib.admin uses this attribute:
-    current_app: str = ...
+    # Attributes added by optional parts of Django
+    # django.contrib.admin views:
+    current_app: str
+    # django.contrib.auth.middleware.AuthenticationMiddleware:
+    user: Union[AbstractBaseUser, AnonymousUser]
+    # django.middleware.locale.LocaleMiddleware:
+    LANGUAGE_CODE: str
+    # django.contrib.sites.middleware.CurrentSiteMiddleware
+    site: Site
+    # django.contrib.sessions.middleware.SessionMiddleware
+    session: SessionBase
     # The magic. If we instantiate HttpRequest directly somewhere, it has
     # mutable GET and POST. However, both ASGIRequest and WSGIRequest have immutable,
     # so when we use HttpRequest to refer to any of them we want exactly this.


### PR DESCRIPTION
# I have made things!

Found two more optional attrs, like `user`, that Django may add to `HttpRequest`. I figured the same pragmatic approach of declaring them as always present could be taken. Also I rearranged and documented these attributes with references to where they come from.

(1) Views in `django.contrib.admin` set `request.current_app`, and the templates use it. The docs also encourage setting the attribute when writing custom views: https://docs.djangoproject.com/en/4.1/ref/contrib/admin/#adding-views-to-admin-sites

(2) `LocaleMiddleware` sets `request.LANGUAGE_CODE`, see right at the bottom of: https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#how-django-discovers-language-preference

## Related issues

n/a