### PR TITLE
Enhance stubs for csrf decorators.

### DIFF
--- a/django-stubs/views/decorators/csrf.pyi
+++ b/django-stubs/views/decorators/csrf.pyi
@@ -8,9 +8,7 @@ class _EnsureCsrfToken(CsrfViewMiddleware): ...
 
 requires_csrf_token: Any
 
-class _EnsureCsrfCookie(CsrfViewMiddleware):
-    get_response: None
-    def process_view(self, request: Any, callback: Any, callback_args: Any, callback_kwargs: Any): ...
+class _EnsureCsrfCookie(CsrfViewMiddleware): ...
 
 ensure_csrf_cookie: Any
 

--- a/django-stubs/views/decorators/csrf.pyi
+++ b/django-stubs/views/decorators/csrf.pyi
@@ -2,15 +2,15 @@ from typing import Any, Callable, TypeVar
 
 from django.middleware.csrf import CsrfViewMiddleware
 
-csrf_protect: Any
+csrf_protect: Callable[[_F], _F]
 
 class _EnsureCsrfToken(CsrfViewMiddleware): ...
 
-requires_csrf_token: Any
+requires_csrf_token: Callable[[_F], _F]
 
 class _EnsureCsrfCookie(CsrfViewMiddleware): ...
 
-ensure_csrf_cookie: Any
+ensure_csrf_cookie: Callable[[_F], _F]
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 


### PR DESCRIPTION
`csrf_protect` and etc. are created via the `decorator_from_middleware`
helper, which doesn't modify the original signature of the wrapped view
function. Using TypeVar helps preserve the original type of the
decorated callable.

Related implementation in Django: https://github.com/django/django/blob/b92ffebb0cdc469baaf1b8f0e72dddb069eb2fb4/django/utils/decorators.py#L117-L162

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
None