### PR TITLE
Fix return type for django.shortcuts.render

### DIFF
--- a/django-stubs/shortcuts.pyi
+++ b/django-stubs/shortcuts.pyi
@@ -21,8 +21,8 @@ class SupportsGetAbsoluteUrl(Protocol):
     def get_absolute_url(self) -> str: ...
 
 @overload
-def redirect(  # type: ignore
-    to: Union[Callable, str, SupportsGetAbsoluteUrl], *args: Any, permanent: Literal[True] = ..., **kwargs: Any
+def redirect(
+    to: Union[Callable, str, SupportsGetAbsoluteUrl], *args: Any, permanent: Literal[True], **kwargs: Any
 ) -> HttpResponsePermanentRedirect: ...
 @overload
 def redirect(
@@ -30,7 +30,7 @@ def redirect(
 ) -> HttpResponseRedirect: ...
 @overload
 def redirect(
-    to: Union[Callable, str, SupportsGetAbsoluteUrl], *args: Any, permanent: bool = ..., **kwargs: Any
+    to: Union[Callable, str, SupportsGetAbsoluteUrl], *args: Any, permanent: bool, **kwargs: Any
 ) -> Union[HttpResponseRedirect, HttpResponsePermanentRedirect]: ...
 
 _T = TypeVar("_T", bound=Model)

--- a/tests/typecheck/test_shortcuts.yml
+++ b/tests/typecheck/test_shortcuts.yml
@@ -54,6 +54,7 @@
         from django.shortcuts import redirect
         reveal_type(redirect(to = '', permanent = True)) # N: Revealed type is "django.http.response.HttpResponsePermanentRedirect"
         reveal_type(redirect(to = '', permanent = False)) # N: Revealed type is "django.http.response.HttpResponseRedirect"
+        reveal_type(redirect(to = '')) # N: Revealed type is "django.http.response.HttpResponseRedirect"
 
         var = True
         reveal_type(redirect(to = '', permanent = var)) # N: Revealed type is "Union[django.http.response.HttpResponseRedirect, django.http.response.HttpResponsePermanentRedirect]"


### PR DESCRIPTION
The return type for calling `shorcuts.render` without providing a value for the `permanent` kwarg was `HttpResponsePermanentRedirect`, while it should be `HttpResponseRedirect`.

The reason is that the first two overloads of the type stub overlap for the case of using the default argument. While `mypy` does issue an error for this, it was previously ignored with the `# type: ignore` comment.

As the first overload annotates the function as having the return type `HttpResponsePermanentRedirect`, this overlap would cause mypy to assume that the return type is `HttpResponsePermanentRedirect` instead of the actual return type `HttpResponseRedirect`.

Since calling `django.shortcuts.redirect` without providing an argument for `permanent` is the same as calling it with a `Literal[False]` (as the default value is a `False`), we can improve the stub by only specifying the option to use the default argument (`= ...`) in the second overload.

This also removes the overlap in stub definitions, meaning that the `# type: ignore` can also be removed.

## Related issues

- Closes #1138 