### PR TITLE
Correct EmailMultiAlternatives.body

### DIFF
--- a/django-stubs/core/mail/message.pyi
+++ b/django-stubs/core/mail/message.pyi
@@ -109,7 +109,7 @@ class EmailMultiAlternatives(EmailMessage):
     def __init__(
         self,
         subject: str = ...,
-        body: str = ...,
+        body: Optional[str] = ...,
         from_email: Optional[str] = ...,
         to: Optional[Sequence[str]] = ...,
         bcc: Optional[Sequence[str]] = ...,


### PR DESCRIPTION
# I have made things!

Like its superclass `EmailMessage`, `EmailMultiAlternatives` also accepts `None` for `body`, which is turned into `""`.

[source](https://github.com/django/django/blob/32536b1324e98768dd892980408a8c6b26c23fd9/django/core/mail/message.py#L240)

## Related issues

n/a
