### PR TITLE
Remove bad redirect_chain attributes

### DIFF
--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -93,7 +93,6 @@ class HttpResponseBase:
 class HttpResponse(HttpResponseBase, Iterable[bytes]):
     content = _PropertyDescriptor[object, bytes]()
     csrf_cookie_set: bool
-    redirect_chain: List[Tuple[str, int]]
     sameorigin: bool
     test_server_port: str
     test_was_secure_request: bool

--- a/django-stubs/template/response.pyi
+++ b/django-stubs/template/response.pyi
@@ -51,7 +51,6 @@ class TemplateResponse(SimpleTemplateResponse):
     cookies: SimpleCookie[str]
     csrf_cookie_set: bool
     json: functools.partial
-    redirect_chain: List[Tuple[str, int]]
     _request: HttpRequest
     status_code: int
     template_name: _TemplateForResponseT


### PR DESCRIPTION
# I have made things!

`redirect_chain` is monkey-patched on by the test client. I added it in #1124 . I just spotted there are bad `redirect_chain` attributes declared on the base `HttpResponse` and `TemplateResponse` classes, added in fa718b8e55e4ac74b309b0068eeced6f89f48728. These are not generally there, only the monkey-patching adds them, so we should remove these declarations.

## Related issues

Looking at #1085 made me check the history.
