### PR TITLE
Improve Flake8 config

### DIFF
--- a/django_stubs_ext/django_stubs_ext/annotations.py
+++ b/django_stubs_ext/django_stubs_ext/annotations.py
@@ -16,7 +16,8 @@ class Annotations(Generic[_Annotations]):
 _T = TypeVar("_T", bound=Model)
 
 WithAnnotations = Annotated[_T, Annotations[_Annotations]]
-"""Alias to make it easy to annotate the model `_T` as having annotations `_Annotations` (a `TypedDict` or `Any` if not provided).
+"""Alias to make it easy to annotate the model `_T` as having annotations
+`_Annotations` (a `TypedDict` or `Any` if not provided).
 
 Use as `WithAnnotations[MyModel]` or `WithAnnotations[MyModel, MyTypedDict]`.
 """

--- a/mypy_django_plugin/transformers/functional.py
+++ b/mypy_django_plugin/transformers/functional.py
@@ -18,7 +18,7 @@ def resolve_str_promise_attribute(ctx: AttributeContext) -> MypyType:
         ctx.api.fail(f'Cannot resolve the attribute of "{ctx.type}"', ctx.context, code=ATTR_DEFINED)
         return AnyType(TypeOfAny.from_error)
 
-    str_info = helpers.lookup_fully_qualified_typeinfo(helpers.get_typechecker_api(ctx), f"builtins.str")
+    str_info = helpers.lookup_fully_qualified_typeinfo(helpers.get_typechecker_api(ctx), "builtins.str")
     assert str_info is not None
     str_type = Instance(str_info, [])
     return analyze_member_access(

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -128,7 +128,7 @@ class ModelClassInitializer:
         for method_name in MANAGER_METHODS_RETURNING_QUERYSET:
             helpers.add_new_sym_for_info(manager_info, name=method_name, sym_type=AnyType(TypeOfAny.special_form))
 
-        manager_info.metadata["django"] = django_metadata = {
+        manager_info.metadata["django"] = {
             "any_fallback_manager": True,
             "from_queryset_manager": fallback_queryset.fullname,
         }
@@ -521,7 +521,11 @@ class AddRelatedManagers(ModelClassInitializer):
                     )
                     related_model_fullname = related_model_cls.__module__ + "." + related_model_cls.__name__
                     self.ctx.api.fail(
-                        f"Couldn't resolve related manager for relation {relation.name!r} (from {related_model_fullname}.{relation.field}).",
+                        (
+                            "Couldn't resolve related manager for relation "
+                            f"{relation.name!r} (from {related_model_fullname}."
+                            f"{relation.field})."
+                        ),
                         self.ctx.cls,
                         code=MANAGER_MISSING,
                     )
@@ -539,8 +543,9 @@ class AddRelatedManagers(ModelClassInitializer):
                     )
                     continue
 
-                # The reverse manager we're looking for doesn't exist. So we create it.
-                # The (default) reverse manager type is built from a RelatedManager and the default manager on the related model
+                # The reverse manager we're looking for doesn't exist. So we
+                # create it. The (default) reverse manager type is built from a
+                # RelatedManager and the default manager on the related model
                 parametrized_related_manager_type = Instance(related_manager_info, [Instance(related_model_info, [])])
                 default_manager_type = default_manager.type
                 assert default_manager_type is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 exclude = .*/
-select = F401, Y
+extend-ignore = E203
+extend-select = F401, Y
 max_line_length = 120
 per-file-ignores =
     *__init__.pyi: F401


### PR DESCRIPTION
# I have made things!

Switch to `extend-select` to avoid disabling default-on built-in checks. Use `extend-ignore` to ignore the one formatting code that Black can trigger, as per [the Black docs](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8).

Fix the few issues that appeared after these changes:

```
django_stubs_ext/django_stubs_ext/annotations.py:19:121: E501 line too long (130 > 120 characters)
mypy_django_plugin/transformers/models.py:131:43: F841 local variable 'django_metadata' is assigned to but never used
mypy_django_plugin/transformers/models.py:524:121: E501 line too long (141 > 120 characters)
mypy_django_plugin/transformers/models.py:543:121: E501 line too long (128 > 120 characters)
mypy_django_plugin/django/context.py:104:54: E203 whitespace before ':'
mypy_django_plugin/transformers/functional.py:21:90: F541 f-string is missing placeholders
```

## Related issues

n/a
