### PR TITLE
Adjust `choices=` type variance for model fields

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -41,7 +41,7 @@ BLANK_CHOICE_DASH: List[Tuple[str, str]] = ...
 _Choice = Tuple[Any, Any]
 _ChoiceNamedGroup = Tuple[str, Iterable[_Choice]]
 _FieldChoices = Iterable[Union[_Choice, _ChoiceNamedGroup]]
-_ChoicesList = List[Union[_Choice, _ChoiceNamedGroup]]
+_ChoicesList = Union[Sequence[_Choice], Sequence[_ChoiceNamedGroup]]
 _LimitChoicesTo = Union[Q, Dict[str, Any]]
 
 class _ChoicesCallable(Protocol):


### PR DESCRIPTION
Avoid getting stuck in an invariance pit. I don't think it makes sense to mix two tuple with named group elements in the same choices sequence(?).

This also changes the outermost container type to `Sequence` as e.g. both `tuple` and `list` are supported.

Reason behind this is that I'm getting the following complaints from `mypy`:

```
error: Incompatible return value type (got "List[Tuple[Any, str]]", expected "List[Union[Tuple[Any, Any], Tuple[str, Iterable[Tuple[Any, Any]]]]]")  [return-value]
note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
note: Consider using "Sequence" instead, which is covariant
```

Docs: https://docs.djangoproject.com/en/4.1/ref/models/fields/#choices

---

I'm not sure if we should change `_FieldChoices` too? e.g. 
```python
_FieldChoices = Union[Iterable[_Choice], Iterable[_ChoiceNamedGroup]]
```