### PR TITLE
Add failing test case to illustrate #312

### DIFF
--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -45,3 +45,28 @@
             content: |
                 from pathlib import Path
                 MEDIA_ROOT = Path()
+
+-   case: imported_from_models
+    disable_cache: true
+    custom_settings: |
+        from other import other
+        AUTH_USER_MODEL = "my_app.MyUser"
+        INSTALLED_APPS = ["my_app"]
+        MY_LIST = [1]
+    main: |
+        from typing import TYPE_CHECKING
+        from django.conf import settings
+        if TYPE_CHECKING:
+            reveal_type(settings.MY_LIST)  # N: Revealed type is "builtins.list[builtins.int]"
+    files:
+        -   path: my_app/__init__.py
+        -   path: my_app/models.py
+            content: |
+                from django.db import models
+                import main
+                class MyUser(models.Model):
+                    pass
+        -   path: other.py
+            content: |
+                from django_stubs_ext import ValuesQuerySet
+                other = ()


### PR DESCRIPTION
Refs #312.

```console
$ pytest tests/typecheck/test_settings.yml::imported_from_models
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0 -- /home/anders/python/django-stubs/.direnv/python-3.10.6/bin/python
cachedir: .pytest_cache
rootdir: /home/anders/python/django-stubs, configfile: pytest.ini
plugins: mypy-plugins-1.10.0
collected 1 item                                                               

tests/typecheck/test_settings.yml::imported_from_models FAILED

=================================== FAILURES ===================================
_____________________________ imported_from_models _____________________________
/home/anders/python/django-stubs/tests/typecheck/test_settings.yml:60: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Invalid output: 
E   Actual:
E     main:4: note: Revealed type is "builtins.list" (diff)
E   Expected:
E     main:4: note: Revealed type is "builtins.list[builtins.int]" (diff)
E   Alignment of first line difference:
E     E: ...ed type is "builtins.list[builtins.int]"
E     A: ...ed type is "builtins.list"
E                                    ^
=========================== short test summary info ============================
FAILED tests/typecheck/test_settings.yml::imported_from_models - 
============================== 1 failed in 3.52s ===============================
```