### PR TITLE
Fix partially analyzed settings module

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -131,7 +131,7 @@ class NewSemanalDjangoPlugin(Plugin):
 
         # for `get_user_model()`
         if self.django_context.settings:
-            if file.fullname == "django.contrib.auth" or file.fullname in {"django.http", "django.http.request"}:
+            if file.fullname == "django.contrib.auth":
                 auth_user_model_name = self.django_context.settings.AUTH_USER_MODEL
                 try:
                     auth_user_module = self.django_context.apps_registry.get_model(auth_user_model_name).__module__

--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -45,3 +45,28 @@
             content: |
                 from pathlib import Path
                 MEDIA_ROOT = Path()
+
+-   case: imported_from_models
+    disable_cache: true
+    custom_settings: |
+        from other import other
+        AUTH_USER_MODEL = "my_app.MyUser"
+        INSTALLED_APPS = ["my_app"]
+        MY_LIST = [1]
+    main: |
+        from typing import TYPE_CHECKING
+        from django.conf import settings
+        if TYPE_CHECKING:
+            reveal_type(settings.MY_LIST)  # N: Revealed type is "builtins.list[builtins.int]"
+    files:
+        -   path: my_app/__init__.py
+        -   path: my_app/models.py
+            content: |
+                from django.db import models
+                import main
+                class MyUser(models.Model):
+                    pass
+        -   path: other.py
+            content: |
+                from django_stubs_ext import ValuesQuerySet
+                other = ()


### PR DESCRIPTION
# I have made things!

For modules `django.http` and `django.http.request`, we manually add
dependency for the module containing `AUTH_USER_MODEL` for mypy to
resolve first.

This potentially adds cyclic dependency when the models module contains
a reference to `django.conf`, and the settings depend on any modules that
rely on `django.http` or `django.http.request`. At this point, the settings module is
only partially analyzed. The symbol table is populated (so top-level settings are
accessible by the name), but the types have not been inferred.

Removing this dependency of `django.http` and `django.http.request` works. But
if the settings module also depends on `django.contrib.auth`, this still breaks.

This can potentially break the refined type for `request.user`, which does depend
on `AUTH_USER_MODEL` being available beforehand. This implicit dependency
still needs to be somehow established.

So, until these issues are addressed, this fix is not final.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

- Closes #312 
- Refs #312

<!--
Mark what issues this Pull Request closes or references.

Format is:

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
