### PR TITLE
Disable fallback to runtime types for Django settings

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -62,7 +62,7 @@ def initialize_django(settings_module: str) -> Tuple["Apps", "LazySettings"]:
         apps.get_swappable_settings_name.cache_clear()  # type: ignore
 
         if not settings.configured:
-            settings._setup()
+            settings._setup()  # type: ignore
 
         apps.populate(settings.INSTALLED_APPS)
 


### PR DESCRIPTION
This fallback to `value.__class__` seems to be doing more harm than good; see #312 and #1162. Replace it with a clear error message that suggests a way to fix the problem rather than incompletely papering over it.