### PR TITLE
Don't allow promise to be passed to ArrayField.name

### DIFF
--- a/django-stubs/contrib/postgres/fields/array.pyi
+++ b/django-stubs/contrib/postgres/fields/array.pyi
@@ -28,7 +28,7 @@ class ArrayField(CheckFieldDefaultMixin, Field[_ST, _GT]):
         size: Optional[int] = ...,
         *,
         verbose_name: Optional[_StrOrPromise] = ...,
-        name: Optional[_StrOrPromise] = ...,
+        name: Optional[str] = ...,
         primary_key: bool = ...,
         max_length: Optional[int] = ...,
         unique: bool = ...,


### PR DESCRIPTION
This was incorrectly changed in #1168, so reverting that change.