### PR TITLE
Fix type of <fieldname>_id in query lookups when using ForeignKey(to_field=)

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -516,6 +516,7 @@ class DateTimeField(DateField[_ST, _GT]):
 class UUIDField(Field[_ST, _GT]):
     _pyi_private_set_type: Union[str, uuid.UUID]
     _pyi_private_get_type: uuid.UUID
+    _pyi_lookup_exact_type: Union[uuid.UUID, str]
     def __init__(
         self,
         verbose_name: Optional[_StrOrPromise] = ...,

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -43,12 +43,21 @@
         from myapp.models import Book, Publisher
         from uuid import UUID
         book = Book()
-        book.publisher = Publisher()
         reveal_type(book.publisher_id)  # N: Revealed type is "uuid.UUID"
         book.publisher_id = '821850bb-c105-426f-b340-3974419d00ca'
         book.publisher_id = UUID('821850bb-c105-426f-b340-3974419d00ca')
         book.publisher_id = [1]  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[str, UUID]")
         book.publisher_id = Publisher()  # E: Incompatible types in assignment (expression has type "Publisher", variable has type "Union[str, UUID]")
+        Book.objects.filter(publisher=UUID('821850bb-c105-426f-b340-3974419d00ca'))
+        Book.objects.filter(publisher_id=UUID('821850bb-c105-426f-b340-3974419d00ca'))
+        Book.objects.filter(publisher='821850bb-c105-426f-b340-3974419d00ca')
+        Book.objects.filter(publisher_id='821850bb-c105-426f-b340-3974419d00ca')
+        Book.objects.filter(publisher=Publisher())
+        Book.objects.filter(publisher_id=Publisher())  # E: Incompatible type for lookup 'publisher_id': (got "Publisher", expected "Union[UUID, str]")
+        Book.objects.filter(publisher=1)  # E: Incompatible type for lookup 'publisher': (got "int", expected "Union[Publisher, UUID, str, None]")
+        Book.objects.filter(publisher_id=1)  # E: Incompatible type for lookup 'publisher_id': (got "int", expected "Union[UUID, str]")
+        reveal_type(Book.objects.values_list("publisher", flat=True))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Book, uuid.UUID]"
+        reveal_type(Book.objects.values_list("publisher_id", flat=True))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Book, uuid.UUID]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -128,7 +128,7 @@
         Blog.objects.filter(publisher__id=1)
 
         Blog.objects.filter(publisher=blog)  # E: Incompatible type for lookup 'publisher': (got "Blog", expected "Union[Publisher, int, None]")
-        Blog.objects.filter(publisher_id=blog)  # E: Incompatible type for lookup 'publisher_id': (got "Blog", expected "Union[str, int]")
+        Blog.objects.filter(publisher_id=blog)  # E: Incompatible type for lookup 'publisher_id': (got "Blog", expected "Union[Publisher, int, None]")
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
This is similar to #1176, but applies to query lookups instead of model attribute access.

This should be merged after #1178.