### PR TITLE
Add missing re-export for JSONObject.

### DIFF
--- a/django-stubs/db/models/functions/__init__.pyi
+++ b/django-stubs/db/models/functions/__init__.pyi
@@ -2,6 +2,7 @@ from .comparison import Cast as Cast
 from .comparison import Coalesce as Coalesce
 from .comparison import Collate as Collate
 from .comparison import Greatest as Greatest
+from .comparison import JSONObject as JSONObject
 from .comparison import Least as Least
 from .comparison import NullIf as NullIf
 from .datetime import Extract as Extract


### PR DESCRIPTION
# I have made things!

`JSONObject` should be re-exported from `django.db.models.functions`.

Source code: https://github.com/django/django/blob/c58a8acd413ccc992dd30afd98ed900897e1f719/django/db/models/functions/__init__.py


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
