### PR TITLE
Add hints for instance variables in console.EmailBackend

### DIFF
--- a/django-stubs/core/mail/backends/console.pyi
+++ b/django-stubs/core/mail/backends/console.pyi
@@ -1,3 +1,8 @@
+import threading
+from typing import TextIO
+
 from django.core.mail.backends.base import BaseEmailBackend
 
-class EmailBackend(BaseEmailBackend): ...
+class EmailBackend(BaseEmailBackend):
+    stream: TextIO = ...
+    _lock: threading.RLock = ...


### PR DESCRIPTION
Prior to this change, the console-based email backend inherited directly
from the base email backend, so it did not declare the extra variables
that are set on the instance ([here](https://github.com/django/django/blob/main/django/core/mail/backends/console.py#L12-L13)).

This change adds hints for the `stream` and `_lock` variables that these
instances have.

I didn't add any tests as I couldn't see one that would be obviously useful,
but I can add one if needed.


## Related issues

N/A (I can raise one if needed)