### PR TITLE
Allow `assertQuerysetEqual` to compare with a collection of values

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -5,6 +5,7 @@ from types import TracebackType
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Iterable,
     Iterator,
@@ -200,8 +201,8 @@ class TransactionTestCase(SimpleTestCase):
     def assertQuerysetEqual(
         self,
         qs: Union[Iterator[Any], List[Model], QuerySet, RawQuerySet],
-        values: Union[List[None], List[Tuple[str, str]], List[date], List[int], List[str], Set[str], QuerySet],
-        transform: Union[Callable, Type[str]] = ...,
+        values: Collection[Any],
+        transform: Union[Callable[[Model], Any], Type[str]] = ...,
         ordered: bool = ...,
         msg: Optional[str] = ...,
     ) -> None: ...


### PR DESCRIPTION
It should be possible to do e.g.

```python
self.assertQuerysetEqual(
    MyModel.objects.all(),
    [(1, timezone.now(), Decimal(1337), 1337), ...],
    transform=attrgetter("pk", "created_at", "some_decimal", "some_int", ...),
)
```

(Not just compare with pk's, which I think the old hints suggested?)