### PR TITLE
Add django.db.models.base.model_unpickle

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, TypeVar
+from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -65,3 +65,5 @@ class Model(metaclass=ModelBase):
     @classmethod
     def check(cls, **kwargs: Any) -> List[CheckMessage]: ...
     def __getstate__(self) -> dict: ...
+
+def model_unpickle(model_id: Union[Tuple[str, str], type[Model]]) -> Model: ...


### PR DESCRIPTION
# I have made things!

This is an internal Django function for pickling, but easy to add the types for.

To doublecheck the arg types, I added a breakpoint and ran Django’s test suite:

```
diff --git a/django/db/models/base.py b/django/db/models/base.py
index 584db319da..7450e2fe7d 100644
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -2468,6 +2468,7 @@ def model_unpickle(model_id):
     else:
         # Backwards compat - the model was cached directly in earlier versions.
         model = model_id
+    breakpoint()
     return model.__new__(model)
```

## Related issues

Fixes #1207.
