### PR TITLE
Add auto_now attrs to date and time model fields

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -456,6 +456,8 @@ class DateField(DateTimeCheckMixin, Field[_ST, _GT]):
     _pyi_private_set_type: Union[str, date, Combinable]
     _pyi_private_get_type: date
     _pyi_lookup_exact_type: Union[str, date]
+    auto_now: bool
+    auto_now_add: bool
     def __init__(
         self,
         verbose_name: Optional[_StrOrPromise] = ...,
@@ -484,6 +486,8 @@ class DateField(DateTimeCheckMixin, Field[_ST, _GT]):
 class TimeField(DateTimeCheckMixin, Field[_ST, _GT]):
     _pyi_private_set_type: Union[str, time, real_datetime, Combinable]
     _pyi_private_get_type: time
+    auto_now: bool
+    auto_now_add: bool
     def __init__(
         self,
         verbose_name: Optional[_StrOrPromise] = ...,


### PR DESCRIPTION
# I have made things!

Django source:
* `DateField`: https://github.com/django/django/blob/84206607d6bfd61e7f7a88b51163ffd4153e3b5a/django/db/models/fields/__init__.py#L1335
* `TimeField`: https://github.com/django/django/blob/84206607d6bfd61e7f7a88b51163ffd4153e3b5a/django/db/models/fields/__init__.py#L2423

## Related issues

Fixes #479
