### PR TITLE
Re-allow expressions in UniqueConstraint

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, Optional, Sequence, Tuple, Type, TypeVar, Union, overload
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.base import Model
@@ -32,14 +32,23 @@ class UniqueConstraint(BaseConstraint):
     fields: Tuple[str, ...]
     condition: Optional[Q]
     deferrable: Optional[Deferrable]
+
+    @overload
+    def __init__(
+        self,
+        *expressions: Union[str, Combinable],
+        fields: None = ...,
+        name: str,
+        condition: Optional[Q] = ...,
+        deferrable: Optional[Deferrable] = ...,
+        include: Optional[Sequence[str]] = ...,
+        opclasses: Sequence[Any] = ...,
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         *,
-        # For 4.0:
-        # *expressions: Union[str, Combinable],
-        # fields: Optional[Sequence[str]] = ...,
-        # name: str = ...,
-        fields: Optional[Sequence[str]],
+        fields: Sequence[str],
         name: str,
         condition: Optional[Q] = ...,
         deferrable: Optional[Deferrable] = ...,

--- a/tests/typecheck/db/models/test_constraints.yml
+++ b/tests/typecheck/db/models/test_constraints.yml
@@ -1,0 +1,37 @@
+-   case: unique_constraint_expressions
+    main: |
+        from django.db.models import Q, UniqueConstraint
+        from django.db.models.functions import Lower
+
+        UniqueConstraint(
+            Lower('name').desc(),
+            'category',
+            name='unique_lower_name_category',
+        )
+
+-   case: unique_constraint_fields
+    main: |
+        from django.db.models import Q, UniqueConstraint
+        from django.db.models.functions import Lower
+
+        UniqueConstraint(
+            fields=['name'],
+            name='unqiue_name',
+        )
+
+-   case: unique_constraint_expressions_fields
+    main: |
+        from django.db.models import Q, UniqueConstraint
+        from django.db.models.functions import Lower
+
+        UniqueConstraint(
+            Lower('name'),
+            fields=['name'],
+            name='unique_mess',
+        )
+    regex: true
+    out: |
+        main:4: error: No overload variant of "UniqueConstraint" matches argument types "Lower", "List\[str\]", "str"
+        main:4: note: Possible overload variants:
+        main:4: note:     .*
+        main:4: note:     .*


### PR DESCRIPTION
# I have made things!

Re-do of #806 which was unfortunately reverted in the mega PR #909. I’m not sure why it was undone there.

Using `@overload` because `expressions` and `fields` are mutually exclusive: https://github.com/django/django/blob/c01e76c95caa1bd2995f1b6c186cbe8726c92ef9/django/db/models/constraints.py#L147-L150 . Added tests for that behaviour.

## Related issues

@knyghty would you like to check? And @linusg, since you spotted the reversion?
