### PR TITLE
Run checks against Django 4.1 and Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -83,6 +83,8 @@ jobs:
         include:
           - python-version: '3.7'
             django-version: '2.2'
+          - python-version: '3.11'
+            django-version: '4.1'
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies

--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -1,5 +1,11 @@
 import enum
+import sys
 from typing import Any, List, Tuple
+
+if sys.version_info >= (3, 11):
+    enum_property = enum.property
+else:
+    enum_property = property
 
 class ChoicesMeta(enum.EnumMeta):
     names: List[str] = ...
@@ -12,7 +18,7 @@ class Choices(enum.Enum, metaclass=ChoicesMeta):
     def __str__(self) -> str: ...
     @property
     def label(self) -> str: ...
-    @property
+    @enum_property
     def value(self) -> Any: ...
 
 # fake
@@ -23,7 +29,7 @@ class _IntegerChoicesMeta(ChoicesMeta):
     values: List[int] = ...
 
 class IntegerChoices(int, Choices, metaclass=_IntegerChoicesMeta):
-    @property
+    @enum_property
     def value(self) -> int: ...
 
 # fake
@@ -34,5 +40,5 @@ class _TextChoicesMeta(ChoicesMeta):
     values: List[str] = ...
 
 class TextChoices(str, Choices, metaclass=_TextChoicesMeta):
-    @property
+    @enum_property
     def value(self) -> str: ...

--- a/django-stubs/utils/version.pyi
+++ b/django-stubs/utils/version.pyi
@@ -4,6 +4,8 @@ PY36: bool
 PY37: bool
 PY38: bool
 PY39: bool
+PY310: bool
+PY311: bool
 
 _VT = Tuple[int, int, int, str, int]
 

--- a/django_stubs_ext/setup.py
+++ b/django_stubs_ext/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Typing :: Typed",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
@@ -41,6 +42,7 @@ setup(
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
     ],
     project_urls={
         "Release notes": "https://github.com/typeddjango/django-stubs/releases",

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -15,6 +15,7 @@ DJANGO_COMMIT_REFS = {
     "2.2": "44e7cca62382f2535ed0f5d2842b433f0bd23a57",
     "3.2": "0153a63a674937e4a56d9d5e4ca2d629b011fbde",
     "4.0": "67d0c4644acfd7707be4a31e8976f865509b09ac",
+    "4.1": "7dfd29b84e5a27d61ae62cb5ed9122d5a99ee1be",
 }
 DEFAULT_DJANGO_VERSION = "3.2"
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Typing :: Typed",
         "Framework :: Django",
         "Framework :: Django :: 2.2",


### PR DESCRIPTION
- Run the `mypy-self-check` and `typecheck` jobs on GitHub Actions against Python 3.11
- Run the `typecheck` job on GitHub Actions against Django 4.1
- Fix compatibility of enums with Python 3.11
- Add stubs for `PY310` and `PY311`
- Add trove classifiers (django-stubs already has one for Django 4.1 from typeddjango/django-stubs#1167)

## Related issues

n/a