### PR TITLE
Improve some DB expression types

### DIFF
--- a/django-stubs/contrib/gis/db/models/aggregates.pyi
+++ b/django-stubs/contrib/gis/db/models/aggregates.pyi
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django.db.models import Aggregate
-from django.db.models.sql.compiler import _AsSqlType
 
 class GeoAggregate(Aggregate):
     is_extent: bool

--- a/django-stubs/contrib/gis/db/models/aggregates.pyi
+++ b/django-stubs/contrib/gis/db/models/aggregates.pyi
@@ -4,22 +4,8 @@ from django.db.models import Aggregate
 from django.db.models.sql.compiler import _AsSqlType
 
 class GeoAggregate(Aggregate):
-    function: Any
     is_extent: bool
-    @property
-    def output_field(self) -> Any: ...
-    def as_sql(
-        self, compiler: Any, connection: Any, function: Any | None = ..., **extra_context: Any
-    ) -> _AsSqlType: ...
     def as_oracle(self, compiler: Any, connection: Any, **extra_context: Any) -> Any: ...
-    def resolve_expression(
-        self,
-        query: Any | None = ...,
-        allow_joins: bool = ...,
-        reuse: Any | None = ...,
-        summarize: bool = ...,
-        for_save: bool = ...,
-    ) -> Any: ...
 
 class Collect(GeoAggregate):
     name: str

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -2,20 +2,13 @@ from typing import Any
 
 from django.db.models import Func
 from django.db.models import Transform as StandardTransform
-from django.db.models.sql.compiler import _AsSqlType
 
 NUMERIC_TYPES: Any
 
 class GeoFuncMixin:
-    function: Any
     geom_param_pos: Any
-    def __init__(self, *expressions: Any, **extra: Any) -> None: ...
     @property
     def geo_field(self) -> Any: ...
-    def as_sql(
-        self, compiler: Any, connection: Any, function: Any | None = ..., **extra_context: Any
-    ) -> _AsSqlType: ...
-    def resolve_expression(self, *args: Any, **kwargs: Any) -> Any: ...
 
 class GeoFunc(GeoFuncMixin, Func): ...
 

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -115,6 +115,12 @@ class CombinedExpression(SQLiteNumericMixin, Expression):
     rhs: Combinable
     def __init__(self, lhs: Combinable, connector: str, rhs: Combinable, output_field: Field | None = ...) -> None: ...
 
+class DurationExpression(CombinedExpression):
+    def compile(self, side: Combinable, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...
+
+class TemporalSubtraction(CombinedExpression):
+    def __init__(self, lhs: Combinable, rhs: Combinable) -> None: ...
+
 class F(Combinable):
     name: str
     def __init__(self, name: str) -> None: ...
@@ -148,6 +154,70 @@ class OuterRef(F):
     contains_aggregate: bool
     def relabeled_clone(self: Self, relabels: Any) -> Self: ...
 
+class Func(SQLiteNumericMixin, Expression):
+    function: str
+    name: str
+    template: str
+    arg_joiner: str
+    arity: int | None
+    source_expressions: list[Expression]
+    extra: dict[Any, Any]
+    def __init__(self, *expressions: Any, output_field: Field | None = ..., **extra: Any) -> None: ...
+    def as_sql(
+        self,
+        compiler: SQLCompiler,
+        connection: BaseDatabaseWrapper,
+        function: str | None = None,
+        template: str | None = None,
+        arg_joiner: str | None = None,
+        **extra_context: Any,
+    ) -> _AsSqlType: ...
+
+class Value(Expression):
+    value: Any
+    def __init__(self, value: Any, output_field: Field | None = ...) -> None: ...
+
+class RawSQL(Expression):
+    params: list[Any]
+    sql: str
+    def __init__(self, sql: str, params: Sequence[Any], output_field: Field | None = ...) -> None: ...
+
+class Star(Expression): ...
+
+class Col(Expression):
+    target: Field
+    alias: str
+    contains_column_references: Literal[True]
+    possibly_multivalued: Literal[False]
+    def __init__(self, alias: str, target: Field, output_field: Field | None = ...) -> None: ...
+
+class Ref(Expression):
+    def __init__(self, refs: str, source: Expression) -> None: ...
+
+class ExpressionList(Func):
+    def __init__(self, *expressions: BaseExpression | Combinable, **extra: Any) -> None: ...
+
+class OrderByList(Func): ...
+
+class ExpressionWrapper(Expression):
+    def __init__(self, expression: Q | Combinable, output_field: Field) -> None: ...
+
+class When(Expression):
+    template: str
+    condition: Any
+    result: Any
+    def __init__(self, condition: Any = ..., then: Any = ..., **lookups: Any) -> None: ...
+
+class Case(Expression):
+    template: str
+    case_joiner: str
+    cases: Any
+    default: Any
+    extra: Any
+    def __init__(
+        self, *cases: Any, default: Any | None = ..., output_field: Field | None = ..., **extra: Any
+    ) -> None: ...
+
 class Subquery(BaseExpression, Combinable):
     template: str
     query: Query
@@ -173,56 +243,6 @@ class OrderBy(Expression):
         nulls_last: bool = ...,
     ) -> None: ...
 
-class Value(Expression):
-    value: Any
-    def __init__(self, value: Any, output_field: Field | None = ...) -> None: ...
-
-class RawSQL(Expression):
-    params: list[Any]
-    sql: str
-    def __init__(self, sql: str, params: Sequence[Any], output_field: Field | None = ...) -> None: ...
-
-class Func(SQLiteNumericMixin, Expression):
-    function: str
-    name: str
-    template: str
-    arg_joiner: str
-    arity: int | None
-    source_expressions: list[Expression]
-    extra: dict[Any, Any]
-    def __init__(self, *expressions: Any, output_field: Field | None = ..., **extra: Any) -> None: ...
-
-class When(Expression):
-    template: str
-    condition: Any
-    result: Any
-    def __init__(self, condition: Any = ..., then: Any = ..., **lookups: Any) -> None: ...
-
-class Case(Expression):
-    template: str
-    case_joiner: str
-    cases: Any
-    default: Any
-    extra: Any
-    def __init__(
-        self, *cases: Any, default: Any | None = ..., output_field: Field | None = ..., **extra: Any
-    ) -> None: ...
-
-class ExpressionWrapper(Expression):
-    def __init__(self, expression: Q | Combinable, output_field: Field) -> None: ...
-
-class Col(Expression):
-    target: Field
-    alias: str
-    contains_column_references: Literal[True]
-    possibly_multivalued: Literal[False]
-    def __init__(self, alias: str, target: Field, output_field: Field | None = ...) -> None: ...
-
-class Ref(Expression):
-    def __init__(self, refs: str, source: Expression) -> None: ...
-
-class ExpressionList(Func):
-    def __init__(self, *expressions: BaseExpression | Combinable, **extra: Any) -> None: ...
 
 class Window(SQLiteNumericMixin, Expression):
     template: str

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -167,9 +167,9 @@ class Func(SQLiteNumericMixin, Expression):
         self,
         compiler: SQLCompiler,
         connection: BaseDatabaseWrapper,
-        function: str | None = None,
-        template: str | None = None,
-        arg_joiner: str | None = None,
+        function: str | None = ...,
+        template: str | None = ...,
+        arg_joiner: str | None = ...,
         **extra_context: Any,
     ) -> _AsSqlType: ...
 

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -243,7 +243,6 @@ class OrderBy(Expression):
         nulls_last: bool = ...,
     ) -> None: ...
 
-
 class Window(SQLiteNumericMixin, Expression):
     template: str
     contains_aggregate: bool


### PR DESCRIPTION
# I have made things!

* Remove several things from `GeoAggregate` and `GeoFuncMixin` where the inherited types are correct
* Add missing kwargs `**extra_context` to `Func.as_sql`
* Remove `Agggregate.as_sql` since it’s a pass-through to `Func.as_sql`
* Reorganize `db/models/expressions.pyi` to follow the same order as upstream
* Add missing classes `DurationExpression`, `TemporalSubtraction`, `Star`, and `OrderByList`

## Related issues

n/a

Spotted the problem with `Aggregate` when adding Mypy to Django-MySQL, which has a custom aggregate class.