### PR TITLE
Improve system check registry hints

### DIFF
--- a/django-stubs/core/checks/registry.pyi
+++ b/django-stubs/core/checks/registry.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Iterable, Protocol, Sequence, TypeVar, overload
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, Protocol, TypeVar, overload
 
 from django.apps.config import AppConfig
 from django.apps.registry import Apps
@@ -48,7 +49,7 @@ class CheckRegistry:
     def tags_available(self, deployment_checks: bool = ...) -> set[str]: ...
     def get_checks(self, include_deployment_checks: bool = ...) -> list[_ProcessedCheckCallable]: ...
 
-registry: CheckRegistry
+registry: CheckRegistry = ...
 register = registry.register
 run_checks = registry.run_checks
 tag_exists = registry.tag_exists

--- a/django-stubs/core/checks/registry.pyi
+++ b/django-stubs/core/checks/registry.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Protocol, Sequence, TypeVar, overload
+from typing import Any, Callable, Iterable, Protocol, Sequence, TypeVar, overload
 
 from django.apps.config import AppConfig
 from django.apps.registry import Apps
@@ -19,7 +19,7 @@ class Tags:
     urls: str
 
 class _CheckCallable(Protocol):
-    def __call__(self, app_configs: Apps, **kwargs: Any) -> Sequence[CheckMessage]: ...
+    def __call__(self, *, app_configs: Apps, **kwargs: Any) -> Iterable[CheckMessage]: ...
 
 _C = TypeVar("_C", bound=_CheckCallable)
 

--- a/django-stubs/core/checks/registry.pyi
+++ b/django-stubs/core/checks/registry.pyi
@@ -19,7 +19,9 @@ class Tags:
     urls: str
 
 class _CheckCallable(Protocol):
-    def __call__(self, *, app_configs: Apps, **kwargs: Any) -> Iterable[CheckMessage]: ...
+    def __call__(
+        self, *, app_configs: Apps, databases: Sequence[str] | None, **kwargs: Any
+    ) -> Iterable[CheckMessage]: ...
 
 _C = TypeVar("_C", bound=_CheckCallable)
 
@@ -40,7 +42,7 @@ class CheckRegistry:
         app_configs: Sequence[AppConfig] | None = ...,
         tags: Sequence[str] | None = ...,
         include_deployment_checks: bool = ...,
-        databases: Any | None = ...,
+        databases: Sequence[str] | None = ...,
     ) -> list[CheckMessage]: ...
     def tag_exists(self, tag: str, include_deployment_checks: bool = ...) -> bool: ...
     def tags_available(self, deployment_checks: bool = ...) -> set[str]: ...

--- a/django-stubs/core/checks/registry.pyi
+++ b/django-stubs/core/checks/registry.pyi
@@ -2,7 +2,6 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Protocol, TypeVar, overload
 
 from django.apps.config import AppConfig
-from django.apps.registry import Apps
 from django.core.checks.messages import CheckMessage
 
 class Tags:
@@ -21,7 +20,11 @@ class Tags:
 
 class _CheckCallable(Protocol):
     def __call__(
-        self, *, app_configs: Apps, databases: Sequence[str] | None, **kwargs: Any
+        self,
+        *,
+        app_configs: Sequence[AppConfig] | None,
+        databases: Sequence[str] | None,
+        **kwargs: Any,
     ) -> Iterable[CheckMessage]: ...
 
 _C = TypeVar("_C", bound=_CheckCallable)

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -1,20 +1,23 @@
 - case: test_checks_register
   main: |
-    from typing import Any, List, Sequence
+    from typing import Any, List, Sequence, Iterable
 
     from django.apps.registry import Apps
     from django.core.checks import register, Warning, CheckMessage
 
     @register("foo", deploy=True)
-    def check_foo(app_configs: Apps, **kwargs: Any) -> List[Warning]: ...
+    def check_foo(app_configs: Apps, databases: Sequence[str] | None, **kwargs: Any) -> list[Warning]:
+        if databases and 'databass' in databases:
+            return [Warning("Naughty list")]
+        return []
 
-    reveal_type(check_foo)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, **kwargs: Any) -> builtins.list[django.core.checks.messages.Warning]]"
+    reveal_type(check_foo)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, databases: Union[typing.Sequence[builtins.str], None], **kwargs: Any) -> builtins.list[django.core.checks.messages.Warning]]"
     reveal_type(check_foo.tags)  # N: Revealed type is "typing.Sequence[builtins.str]"
 
     @register
-    def check_bar(app_configs: Apps, **kwargs: Any) -> Sequence[CheckMessage]: ...
+    def check_bar(**kwargs: Any) -> Sequence[CheckMessage]: ...
 
-    reveal_type(check_bar)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, **kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
+    reveal_type(check_bar)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (**kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
 
     @register()  # E: Value of type variable "_C" of function cannot be "Callable[[int], Sequence[CheckMessage]]"
     def wrong_args(bla: int) -> Sequence[CheckMessage]: ...

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -1,0 +1,20 @@
+- case: test_checks_register
+  main: |
+    from typing import Any, List, Sequence
+
+    from django.apps.registry import Apps
+    from django.core.checks import register, Warning, CheckMessage
+
+    @register("foo", deploy=True)
+    def check_foo(app_configs: Apps, **kwargs: Any) -> List[Warning]: ...
+
+    reveal_type(check_foo)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, **kwargs: Any) -> builtins.list[django.core.checks.messages.Warning]]"
+    reveal_type(check_foo.tags)  # N: Revealed type is "typing.Sequence[builtins.str]"
+
+    @register
+    def check_bar(app_configs: Apps, **kwargs: Any) -> Sequence[CheckMessage]: ...
+
+    reveal_type(check_bar)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, **kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
+
+    @register()  # E: Value of type variable "_C" of function cannot be "Callable[[int], Sequence[CheckMessage]]"
+    def wrong_args(bla: int) -> Sequence[CheckMessage]: ...

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -1,12 +1,13 @@
 - case: test_checks_register
   main: |
-    from typing import Any, List, Sequence, Iterable
+    from typing import Any, Sequence, Optional
 
-    from django.apps.registry import Apps
     from django.core.checks import register, Warning, CheckMessage
+    from django.apps.registry import Apps
+
 
     @register("foo", deploy=True)
-    def check_foo(app_configs: Apps, databases: Sequence[str] | None, **kwargs: Any) -> list[Warning]:
+    def check_foo(app_configs: Apps, databases: Optional[Sequence[str]], **kwargs: Any) -> list[Warning]:
         if databases and 'databass' in databases:
             return [Warning("Naughty list")]
         return []

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -1,24 +1,29 @@
 - case: test_checks_register
   main: |
-    from typing import Any, Sequence, Optional
+    from typing import Any, Sequence, Optional, Union
 
+    from django.apps.config import AppConfig
     from django.core.checks import register, Warning, CheckMessage
-    from django.apps.registry import Apps
 
 
     @register("foo", deploy=True)
-    def check_foo(app_configs: Apps, databases: Optional[Sequence[str]], **kwargs: Any) -> list[Warning]:
+    def check_foo(app_configs: Union[Sequence[AppConfig], None], databases: Optional[Sequence[str]], **kwargs: Any) -> list[Warning]:
         if databases and 'databass' in databases:
             return [Warning("Naughty list")]
         return []
 
-    reveal_type(check_foo)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: django.apps.registry.Apps, databases: Union[typing.Sequence[builtins.str], None], **kwargs: Any) -> builtins.list[django.core.checks.messages.Warning]]"
+    reveal_type(check_foo)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (app_configs: Union[typing.Sequence[django.apps.config.AppConfig], None], databases: Union[typing.Sequence[builtins.str], None], **kwargs: Any) -> builtins.list[django.core.checks.messages.Warning]]"
     reveal_type(check_foo.tags)  # N: Revealed type is "typing.Sequence[builtins.str]"
 
     @register
-    def check_bar(**kwargs: Any) -> Sequence[CheckMessage]: ...
+    def check_bar(*, app_configs: Union[Sequence[AppConfig], None], **kwargs: Any) -> Sequence[CheckMessage]: ...
 
-    reveal_type(check_bar)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (**kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
+    reveal_type(check_bar)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (*, app_configs: Union[typing.Sequence[django.apps.config.AppConfig], None], **kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
+
+    @register
+    def check_baz(**kwargs: Any) -> Sequence[CheckMessage]: ...
+
+    reveal_type(check_baz)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (**kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
 
     @register()  # E: Value of type variable "_C" of function cannot be "Callable[[int], Sequence[CheckMessage]]"
     def wrong_args(bla: int) -> Sequence[CheckMessage]: ...


### PR DESCRIPTION
The `@register` decorator from `django.core.checks` was previously untyped.

Fixes #1098.
