### PR TITLE
fix: Use supported version in typecheck_tests command in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ We also test the stubs against Django's own test suite. This is done in CI but y
 To execute the script run:
 
 ```bash
-python ./scripts/typecheck_tests.py --django_version 3.1
+python ./scripts/typecheck_tests.py --django_version 3.2
 ```
 
 
@@ -90,13 +90,13 @@ The stubs are based on auto-generated code created by Mypy's stubgen tool (see: 
 To make life easier we have a helper script that auto generates these stubs. To use it you can run:
 
 ```bash
-python ./scripts/stubgen-django.py --django_version 3.1
+python ./scripts/stubgen-django.py --django_version 3.2
 ```
 
 You can also pass an optional commit hash as a second kwarg to checkout a specific commit, e.g.
 
 ```bash
-python ./scripts/stubgen-django.py --django_version 3.1 --commit_sha <commit_sha>
+python ./scripts/stubgen-django.py --django_version 3.2 --commit_sha <commit_sha>
 ```
 
 The output for this is a gitignored folder called "stubgen" in the repo's root.


### PR DESCRIPTION
The `typecheck_tests.py` script only supports the Django versions included in its `DJANGO_COMMIT_REFS` map. Version `3.1` is no longer present, so the command from the Contributing guide failed.

For consistency, the Django version used for the `stubgen-django.py` commands has been also updated.