### PR TITLE
Pin flake8-pyi to 22.10.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-        - flake8-pyi
+        - flake8-pyi==22.10.0
         types: []
         files: ^.*.pyi?$
 


### PR DESCRIPTION
# I have made things!

Addressing the suggestion from @adamchainz made [here](https://github.com/typeddjango/django-stubs/pull/1253#discussion_r1020937212).

## Related issues

Refs #128