### PR TITLE
revert changes in #1252 leaked into master

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -3,7 +3,7 @@ from io import BytesIO
 from json import JSONEncoder
 from re import Pattern
 from types import TracebackType
-from typing import Any, Generic, NoReturn, TypeVar, overload
+from typing import Any, Generic, NoReturn, TypeVar
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -16,7 +16,6 @@ from django.http.response import HttpResponseBase
 from django.template.base import Template
 from django.test.utils import ContextList
 from django.urls import ResolverMatch
-from typing_extensions import Literal
 
 BOUNDARY: str
 MULTIPART_CONTENT: str
@@ -99,8 +98,6 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     context: ContextList | dict[str, Any]
     content: bytes
     resolver_match: ResolverMatch
-
-class _MonkeyPatchedWSGIResponseRedirect(_MonkeyPatchedWSGIResponse):
     redirect_chain: list[tuple[str, int]]
 
 class _MonkeyPatchedASGIResponse(_ASGIResponse):
@@ -131,136 +128,25 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     ) -> None: ...
     # Silence type warnings, since this class overrides arguments and return types in an unsafe manner.
     def request(self, **request: Any) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def get(
-        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def get(
-        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def get(
+    def get(  # type: ignore
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def post(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[False] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def post(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[True] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def post(
+    def post(  # type: ignore
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def head(
-        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def head(
-        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def head(
+    def head(  # type: ignore
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def trace(
-        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def trace(
-        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def trace(
+    def trace(  # type: ignore
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def put(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[False] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def put(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[True] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def put(
+    def put(  # type: ignore
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def patch(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[False] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def patch(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[True] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def patch(
+    def patch(  # type: ignore
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
-    def delete(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[False] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload
-    def delete(
-        self,
-        path: str,
-        data: Any = ...,
-        content_type: str = ...,
-        follow: Literal[True] = ...,
-        secure: bool = ...,
-        **extra: Any
-    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
-    @overload
-    def delete(
+    def delete(  # type: ignore
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
 

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -9,6 +9,7 @@
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
       response.json()
 -   case: async_client_methods
     main: |
@@ -34,76 +35,3 @@
       async_factory = AsyncRequestFactory()
       async_request = async_factory.get('foo')
       reveal_type(async_request)  # N: Revealed type is "django.core.handlers.asgi.ASGIRequest"
--   case: client_follow_flag
-    main: |
-      from django.test.client import Client
-      client = Client()
-      response = client.get('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.get('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.get('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.get('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.post('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.post('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.post('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.post('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.head('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.head('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.head('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.head('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.trace('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.trace('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.trace('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.trace('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.put('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.put('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.put('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.put('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.patch('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.patch('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.patch('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.patch('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-
-      response = client.delete('foo')
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.delete('foo', follow=False)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
-      response = client.delete('foo', follow=True)
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
-      x: bool
-      response = client.delete('foo', follow=x)
-      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"


### PR DESCRIPTION
# I have made things!

This addresses @intgr's comment [here](https://github.com/typeddjango/django-stubs/pull/1253#discussion_r1020940111). By accident, I based #1253 off the changes made in #1252, so it was merged into master unapproved. This PR reverts this - I will reintroduce the changes again in a proper PR.

Sorry for the noise!

## Related issues

Refs #128
Refs #1252
Refs #1253