### PR TITLE
only allow `redirect_chain` attribute in response when client sets the follow flag

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -131,7 +131,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     ) -> None: ...
     # Silence type warnings, since this class overrides arguments and return types in an unsafe manner.
     def request(self, **request: Any) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def get(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -143,7 +143,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def get(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def post(
         self,
         path: str,
@@ -167,7 +167,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def post(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def head(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -179,7 +179,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def head(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def trace(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -191,7 +191,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def trace(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def put(
         self,
         path: str,
@@ -215,7 +215,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def put(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def patch(
         self,
         path: str,
@@ -239,7 +239,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def patch(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def delete(
         self,
         path: str,

--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -3,7 +3,7 @@ from io import BytesIO
 from json import JSONEncoder
 from re import Pattern
 from types import TracebackType
-from typing import Any, Generic, NoReturn, TypeVar
+from typing import Any, Generic, NoReturn, TypeVar, overload
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -16,6 +16,7 @@ from django.http.response import HttpResponseBase
 from django.template.base import Template
 from django.test.utils import ContextList
 from django.urls import ResolverMatch
+from typing_extensions import Literal
 
 BOUNDARY: str
 MULTIPART_CONTENT: str
@@ -98,6 +99,8 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     context: ContextList | dict[str, Any]
     content: bytes
     resolver_match: ResolverMatch
+
+class _MonkeyPatchedWSGIResponseRedirect(_MonkeyPatchedWSGIResponse):
     redirect_chain: list[tuple[str, int]]
 
 class _MonkeyPatchedASGIResponse(_ASGIResponse):
@@ -128,25 +131,136 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     ) -> None: ...
     # Silence type warnings, since this class overrides arguments and return types in an unsafe manner.
     def request(self, **request: Any) -> _MonkeyPatchedWSGIResponse: ...
-    def get(  # type: ignore
+    @overload  # type: ignore
+    def get(
+        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def get(
+        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def get(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def post(  # type: ignore
+    @overload  # type: ignore
+    def post(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[False] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def post(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[True] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def post(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def head(  # type: ignore
+    @overload  # type: ignore
+    def head(
+        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def head(
+        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def head(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def trace(  # type: ignore
+    @overload  # type: ignore
+    def trace(
+        self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def trace(
+        self, path: str, data: Any = ..., follow: Literal[True] = ..., secure: bool = ..., **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def trace(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def put(  # type: ignore
+    @overload  # type: ignore
+    def put(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[False] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def put(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[True] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def put(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def patch(  # type: ignore
+    @overload  # type: ignore
+    def patch(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[False] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def patch(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[True] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def patch(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    def delete(  # type: ignore
+    @overload  # type: ignore
+    def delete(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[False] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponse: ...
+    @overload
+    def delete(
+        self,
+        path: str,
+        data: Any = ...,
+        content_type: str = ...,
+        follow: Literal[True] = ...,
+        secure: bool = ...,
+        **extra: Any
+    ) -> _MonkeyPatchedWSGIResponseRedirect: ...
+    @overload
+    def delete(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
 

--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -131,7 +131,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     ) -> None: ...
     # Silence type warnings, since this class overrides arguments and return types in an unsafe manner.
     def request(self, **request: Any) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def get(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -143,7 +143,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def get(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def post(
         self,
         path: str,
@@ -167,7 +167,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def post(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def head(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -179,7 +179,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def head(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def trace(
         self, path: str, data: Any = ..., follow: Literal[False] = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
@@ -191,7 +191,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def trace(
         self, path: str, data: Any = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def put(
         self,
         path: str,
@@ -215,7 +215,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def put(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def patch(
         self,
         path: str,
@@ -239,7 +239,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
     def patch(
         self, path: str, data: Any = ..., content_type: str = ..., follow: bool = ..., secure: bool = ..., **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
-    @overload  # type: ignore[override]
+    @overload  # type: ignore[misc,override]
     def delete(
         self,
         path: str,

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -9,7 +9,6 @@
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
       response.json()
 -   case: async_client_methods
     main: |
@@ -35,3 +34,76 @@
       async_factory = AsyncRequestFactory()
       async_request = async_factory.get('foo')
       reveal_type(async_request)  # N: Revealed type is "django.core.handlers.asgi.ASGIRequest"
+-   case: client_follow_flag
+    main: |
+      from django.test.client import Client
+      client = Client()
+      response = client.get('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.get('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.get('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.get('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.post('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.post('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.post('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.post('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.head('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.head('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.head('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.head('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.trace('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.trace('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.trace('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.trace('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.put('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.put('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.put('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.put('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.patch('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.patch('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.patch('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.patch('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+
+      response = client.delete('foo')
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.delete('foo', follow=False)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"
+      response = client.delete('foo', follow=True)
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      x: bool
+      response = client.delete('foo', follow=x)
+      response.redirect_chain  # E: "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"


### PR DESCRIPTION
Signed-off-by: Oleg Hoefling <oleg.hoefling@ionos.com>

# I have made things!

This is #1252, reintroduced. Description copied for the sake of completeness:

The `redirect_chain` attribute was added in #1124. At runtime, the response only has this attribute set when the request was made with `follow=True`:

```py
In [1]: from django.test import Client

In [2]: c = Client()

In [3]: c.get('/spam', follow=True).redirect_chain
Not Found: /spam
2022-11-12 15:42:28 [WARNING ] django.request :: Not Found: /spam
Out[3]: []

In [4]: c.get('/spam', follow=False).redirect_chain
Not Found: /spam
2022-11-12 15:42:33 [WARNING ] django.request :: Not Found: /spam
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 c.get('/spam', follow=False).redirect_chain

AttributeError: 'HttpResponseNotFound' object has no attribute 'redirect_chain'
```
This PR replicates this behaviour.

## Related issues

Refs #1252