### PR TITLE
Update to mypy 0.991 for compatible-mypy & CI

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,13 +7,14 @@ ignore_missing_imports = True
 incremental = True
 strict_optional = True
 show_traceback = True
-warn_no_return = False
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
 warn_unreachable = True
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+show_error_codes = False
+disable_error_code = empty-body
 
 plugins =
     mypy_django_plugin.main

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -249,6 +249,8 @@ class NewSemanalDjangoPlugin(Plugin):
             and sym.node.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
         ):
             return reparametrize_any_manager_hook
+        else:
+            return None
 
     def get_base_class_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
         # Base class is a Model class definition
@@ -309,6 +311,8 @@ class NewSemanalDjangoPlugin(Plugin):
             "django_stubs_ext.annotations.WithAnnotations",
         ):
             return partial(handle_annotated_type, django_context=self.django_context)
+        else:
+            return None
 
     def get_dynamic_class_hook(self, fullname: str) -> Optional[Callable[[DynamicClassDefContext], None]]:
         # Create a new manager class definition when a manager's '.from_queryset' classmethod is called

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ psycopg2-binary
 -e .[compatible-mypy]
 
 # Overrides:
-mypy==0.982
+mypy==0.991

--- a/scripts/enabled_test_modules.py
+++ b/scripts/enabled_test_modules.py
@@ -113,6 +113,9 @@ IGNORED_ERRORS: Dict[str, List[Any]] = {
         'error: "HttpResponse" has no attribute "streaming_content"',
         'error: "HttpResponse" has no attribute "context_data"',
         'Duplicate module named "apps"',
+        "Function is missing a return type annotation",
+        "Function is missing a type annotation",
+        "Library stubs not installed for ",
     ],
     "admin_checks": ['Argument 1 to "append" of "list" has incompatible type "str"; expected "CheckMessage"'],
     "admin_default_site": [

--- a/scripts/enabled_test_modules.py
+++ b/scripts/enabled_test_modules.py
@@ -515,6 +515,11 @@ IGNORED_ERRORS: Dict[str, List[Any]] = {
     "wsgi": [
         '"HttpResponse" has no attribute "block_size"',
     ],
+    # test_runner_apps/tagged/tests_syntax_error.py
+    "test_runner_apps": [
+        "invalid syntax",
+        "invalid decimal literal",
+    ],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy>=0.980,<0.990"],
+    "compatible-mypy": ["mypy>=0.991,<0.1000"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy>=0.991,<0.1000"],
+    "compatible-mypy": ["mypy>=0.991,<1.0"],
 }
 
 setup(

--- a/tests/typecheck/contrib/admin/test_options.yml
+++ b/tests/typecheck/contrib/admin/test_options.yml
@@ -107,7 +107,7 @@
       from django.contrib import admin
 
       class A(admin.ModelAdmin):
-          fieldsets = [  # type: ignore
+          fieldsets = [
               (None, {}),  # E: Missing key "fields" for TypedDict "_FieldOpts"
           ]
 -   case: errors_on_invalid_radio_fields


### PR DESCRIPTION
Made a few tweaks that were needed to get our CI passing with mypy 0.991.

~~There is still a new regression with `mypy_django_plugin` that I haven't investigated, which happens with Django 3.2 only. Created an issue for it: #1261  Disabled testing with Django 2.2 and 3.2 in CI for now.~~ Thanks to @flaeppe for the fix!
