### PR TITLE
Improve types of `django.contrib.admin.decorators`

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
@@ -7,21 +7,44 @@ from django.db.models import Combinable, QuerySet
 from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression
 from django.http import HttpRequest
+from django.utils.functional import _StrPromise
 
-_ModelT = TypeVar("_ModelT", bound=Model)
+_T = TypeVar("_T")
+_Model = TypeVar("_Model", bound=Model)
+_ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin)
+_Request = TypeVar("_Request", bound=HttpRequest)
+_QuerySet = TypeVar("_QuerySet", bound=QuerySet)
 
+@overload
 def action(
-    function: Callable[[ModelAdmin, HttpRequest, QuerySet], None] | None = ...,
+    function: Callable[[_ModelAdmin, _Request, _QuerySet], None],
+    permissions: Sequence[str] | None = ...,
+    description: _StrPromise | None = ...,
+) -> Callable[[_ModelAdmin, _Request, _QuerySet], None]: ...
+@overload
+def action(
     *,
     permissions: Sequence[str] | None = ...,
-    description: str | None = ...,
-) -> Callable: ...
+    description: _StrPromise | None = ...,
+) -> Callable[
+    [Callable[[_ModelAdmin, _Request, _QuerySet], None]], Callable[[_ModelAdmin, _Request, _QuerySet], None]
+]: ...
+@overload
 def display(
-    function: Callable[[_ModelT], Any] | None = ...,
+    function: Callable[[_Model], _T],
+    boolean: bool | None = ...,
+    ordering: str | Combinable | BaseExpression | None = ...,
+    description: _StrPromise | None = ...,
+    empty_value: str | None = ...,
+) -> Callable[[_Model], _T]: ...
+@overload
+def display(
     *,
     boolean: bool | None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,
-    description: str | None = ...,
+    description: _StrPromise | None = ...,
     empty_value: str | None = ...,
-) -> Callable: ...
-def register(*models: type[Model], site: AdminSite | None = ...) -> Callable: ...
+) -> Callable[[Callable[[_Model], _T]], Callable[[_Model], _T]]: ...
+def register(
+    *models: type[Model], site: AdminSite | None = ...
+) -> Callable[[type[_ModelAdmin]], type[_ModelAdmin]]: ...


### PR DESCRIPTION
# I have made things!

- Type annotations of `django.contrib.admin.decorators` previously changed the signature of the classes/functions that were decorated. Not any more.
- The decorators now set a bound on the signature of what they support decorating. As such an error will be emitted on an incorrect signature of the decorated function/class.
  - Take note that since a bound is used, annotating subclasses of the bounds are supported.
- The `description=` arguments now supports both `Promise` and `str` -> `_StrPromise` (for `gettext_lazy` support)

## Related issues

None