### PR TITLE
Type `ModelAdmin.fieldsets` 'description' option to support `gettext_lazy`

### DIFF
--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -54,7 +54,7 @@ _FieldGroups: TypeAlias = Sequence[str | Sequence[str]]
 
 class _OptionalFieldOpts(TypedDict, total=False):
     classes: Sequence[str]
-    description: str
+    description: _StrOrPromise
 
 class _FieldOpts(_OptionalFieldOpts, total=True):
     fields: _FieldGroups


### PR DESCRIPTION
# I have made things!

Quite a bit far down into `ModelAdmin.fieldsets`, the `"description"` value should support being `gettext_lazy`

i.e. the following should type check

```python
from django.utils.translation import gettext_lazy
...


class MyModelAdmin(ModelAdmin):
    fieldsets = (
        (
            gettext_lazy("group 1 header"),
            {"description": gettext_lazy("description"), "fields": ("f1", "f2")},
        ),
        (
            gettext_lazy("group 2 header"),
            {"fields": ("f3", "f4")},
        ),
    )
```

## Related issues

None