### PR TITLE
Fix CI: Update flake8-pyi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-        - flake8-pyi==22.10.0
+        - flake8-pyi==22.11.0
         types: []
         files: ^.*.pyi?$
 


### PR DESCRIPTION
Older flake8-pyi is not compatible with flake8 v6.
