### PR TITLE
Improve ModelAdmin and decorator hints and attributes, add tests

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeAlias, TypeVar, overload
+from typing import Any, TypeVar, Union, overload
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
@@ -8,14 +8,14 @@ from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression
 from django.http import HttpRequest
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeAlias
 
-_T = TypeVar("_T")
 _Model = TypeVar("_Model", bound=Model)
 _ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin)
 _Request = TypeVar("_Request", bound=HttpRequest)
 _QuerySet = TypeVar("_QuerySet", bound=QuerySet)
 # This is deliberately different from _DisplayT defined in contrib.admin.options
-_DisplayCallable: TypeAlias = Callable[[_ModelAdmin, _Model], Any] | Callable[[_Model], Any]
+_DisplayCallable: TypeAlias = Union[Callable[[_ModelAdmin, _Model], Any], Callable[[_Model], Any]]
 _DisplayCallableT = TypeVar("_DisplayCallableT", bound=_DisplayCallable)
 
 @overload

--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -15,7 +15,7 @@ _ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin)
 _Request = TypeVar("_Request", bound=HttpRequest)
 _QuerySet = TypeVar("_QuerySet", bound=QuerySet)
 # This is deliberately different from _DisplayT defined in contrib.admin.options
-_DisplayCallable: TypeAlias = Union[Callable[[_ModelAdmin, _Model], Any], Callable[[_Model], Any]]
+_DisplayCallable: TypeAlias = Union[Callable[[_ModelAdmin, _Model], Any], Callable[[_Model], Any]]  # noqa: Y037
 _DisplayCallableT = TypeVar("_DisplayCallableT", bound=_DisplayCallable)
 
 @overload

--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, Union, overload
+from typing import Any, TypeVar, Union, overload  # noqa: Y037
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite

--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, TypeAlias, TypeVar, overload
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
@@ -7,44 +7,47 @@ from django.db.models import Combinable, QuerySet
 from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression
 from django.http import HttpRequest
-from django.utils.functional import _StrPromise
+from django.utils.functional import _StrOrPromise
 
 _T = TypeVar("_T")
 _Model = TypeVar("_Model", bound=Model)
 _ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin)
 _Request = TypeVar("_Request", bound=HttpRequest)
 _QuerySet = TypeVar("_QuerySet", bound=QuerySet)
+# This is deliberately different from _DisplayT defined in contrib.admin.options
+_DisplayCallable: TypeAlias = Callable[[_ModelAdmin, _Model], Any] | Callable[[_Model], Any]
+_DisplayCallableT = TypeVar("_DisplayCallableT", bound=_DisplayCallable)
 
 @overload
 def action(
     function: Callable[[_ModelAdmin, _Request, _QuerySet], None],
     permissions: Sequence[str] | None = ...,
-    description: _StrPromise | None = ...,
+    description: _StrOrPromise | None = ...,
 ) -> Callable[[_ModelAdmin, _Request, _QuerySet], None]: ...
 @overload
 def action(
     *,
     permissions: Sequence[str] | None = ...,
-    description: _StrPromise | None = ...,
+    description: _StrOrPromise | None = ...,
 ) -> Callable[
     [Callable[[_ModelAdmin, _Request, _QuerySet], None]], Callable[[_ModelAdmin, _Request, _QuerySet], None]
 ]: ...
 @overload
 def display(
-    function: Callable[[_Model], _T],
+    function: _DisplayCallableT,
     boolean: bool | None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,
-    description: _StrPromise | None = ...,
+    description: _StrOrPromise | None = ...,
     empty_value: str | None = ...,
-) -> Callable[[_Model], _T]: ...
+) -> _DisplayCallableT: ...
 @overload
 def display(
     *,
     boolean: bool | None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,
-    description: _StrPromise | None = ...,
+    description: _StrOrPromise | None = ...,
     empty_value: str | None = ...,
-) -> Callable[[Callable[[_Model], _T]], Callable[[_Model], _T]]: ...
+) -> Callable[[_DisplayCallableT], _DisplayCallableT]: ...
 def register(
     *models: type[Model], site: AdminSite | None = ...
 ) -> Callable[[type[_ModelAdmin]], type[_ModelAdmin]]: ...

--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -129,7 +129,9 @@ class BaseModelAdmin(Generic[_ModelT]):
     def has_view_or_change_permission(self, request: HttpRequest, obj: _ModelT | None = ...) -> bool: ...
     def has_module_permission(self, request: HttpRequest) -> bool: ...
 
-_DisplayT: TypeAlias = _ListOrTuple[str | Callable[[_ModelT], str]]
+_DisplayT: TypeAlias = _ListOrTuple[str | Callable[[_ModelT], str | bool]]
+_ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin)
+_ActionCallable: TypeAlias = Callable[[_ModelAdmin, HttpRequest, QuerySet[_ModelT]], None]
 
 class ModelAdmin(BaseModelAdmin[_ModelT]):
     list_display: _DisplayT
@@ -154,7 +156,7 @@ class ModelAdmin(BaseModelAdmin[_ModelT]):
     delete_selected_confirmation_template: _TemplateForResponseT | None
     object_history_template: _TemplateForResponseT | None
     popup_response_template: _TemplateForResponseT | None
-    actions: Sequence[Callable[[ModelAdmin, HttpRequest, QuerySet], None] | str] | None
+    actions: Sequence[_ActionCallable[Any, _ModelT] | str] | None
     action_form: Any
     actions_on_top: bool
     actions_on_bottom: bool

--- a/tests/typecheck/contrib/admin/test_decorators.yml
+++ b/tests/typecheck/contrib/admin/test_decorators.yml
@@ -1,0 +1,89 @@
+- case: test_admin_decorators_display
+  main: |
+    from django.db import models
+
+    from django.contrib import admin
+
+
+    class MyModel(models.Model):
+        @admin.display
+        def display_bare(self) -> str: ...
+
+        @admin.display(boolean=True, ordering="field", description="Something", empty_value="...")
+        def display_fancy(self) -> bool: ...
+
+        # Can also be a property
+        @property
+        @admin.display
+        def display_property(self) -> str: ...
+
+        @admin.display  # E: Decorators on top of @property are not supported
+        @property
+        def incorrect_property(self) -> str: ...
+
+        def method(self) -> None:
+            reveal_type(self.display_bare)  # N: Revealed type is "def () -> builtins.str"
+            reveal_type(self.display_fancy)  # N: Revealed type is "def () -> builtins.bool"
+            reveal_type(self.display_fancy())  # N: Revealed type is "builtins.bool"
+            reveal_type(self.display_property)  # N: Revealed type is "builtins.str"
+
+
+    @admin.display
+    def freestanding_display_bare(obj: MyModel) -> str: ...
+
+
+    @admin.display(boolean=True)
+    def freestanding_display_fancy(obj: MyModel) -> bool: ...
+
+
+    @admin.register(MyModel, MyModel, site=None)
+    class MyModelAdmin(admin.ModelAdmin[MyModel]):
+        list_display = [
+            "display_property",
+            "display_fancy",
+            "display_bare",
+            "admin_display_bare",
+            "admin_display_fancy",
+            freestanding_display_bare,
+            freestanding_display_fancy,
+        ]
+
+        @admin.display
+        def admin_display_bare(self, obj: MyModel) -> str: ...
+
+        @admin.display(boolean=True, ordering="field", description="Something", empty_value="Nuf")
+        def admin_display_fancy(self, obj: MyModel) -> bool: ...
+
+- case: test_admin_decorators_action
+  main: |
+    from django.db import models
+
+    from django.contrib import admin
+    from django.db.models import QuerySet
+    from django.http import HttpRequest
+
+
+    class MyModel(models.Model): ...
+
+
+    @admin.action
+    def freestanding_action_bare(modeladmin: "MyModelAdmin", request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
+
+
+    @admin.action(description="Some text here", permissions=["test"])
+    def freestanding_action_fancy(modeladmin: "MyModelAdmin", request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
+
+
+    @admin.register(MyModel)
+    class MyModelAdmin(admin.ModelAdmin[MyModel]):
+        actions = [freestanding_action_bare, freestanding_action_fancy, "method_action_bare", "method_action_fancy"]
+
+        @admin.action
+        def method_action_bare(self, request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
+
+        @admin.action(description="Some text here", permissions=["test"])
+        def method_action_fancy(self, request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
+
+        def method(self) -> None:
+            reveal_type(self.method_action_bare)  # N: Revealed type is "def (django.http.request.HttpRequest, django.db.models.query._QuerySet[main.MyModel, main.MyModel])"
+            reveal_type(self.method_action_fancy)  # N: Revealed type is "def (django.http.request.HttpRequest, django.db.models.query._QuerySet[main.MyModel, main.MyModel])"

--- a/tests/typecheck/contrib/admin/test_options.yml
+++ b/tests/typecheck/contrib/admin/test_options.yml
@@ -12,7 +12,7 @@
       from django.db.models.query import QuerySet
       from django.utils.translation import gettext_lazy as _
 
-      def an_action(modeladmin: admin.ModelAdmin, request: HttpRequest, queryset: QuerySet) -> None:
+      def an_action(modeladmin: "A", request: HttpRequest, queryset: QuerySet) -> None:
           pass
 
       class TestModel(models.Model):
@@ -137,7 +137,7 @@
           pass
 
       class A(admin.ModelAdmin):
-          actions = [an_action]  # E: List item 0 has incompatible type "Callable[[None], None]"; expected "Union[Callable[[ModelAdmin[Any], HttpRequest, _QuerySet[Any, Any]], None], str]"
+          actions = [an_action]  # E: List item 0 has incompatible type "Callable[[None], None]"; expected "Union[Callable[[Any, HttpRequest, _QuerySet[Any, Any]], None], str]"
 -   case: errors_for_invalid_model_admin_generic
     main: |
       from django.contrib.admin import ModelAdmin


### PR DESCRIPTION
Some follow-up additions on top of #1267:

* Added tests for admin decorators.
* The `@display` decorator now supports usage for `ModelAdmin` methods as well.
* Changed `_StrPromise` to `_StrOrPromise` where plain `str` should be supported as well.
* `ModelAdmin.display` didn't previously allow functions returning booleans.
* `ModelAdmin.actions` didn't previously allow having accurate type hints of the passed function (only allowed base class `ModelAdmin`)
