### PR TITLE
request arg to shortcuts.render() can be None.

### DIFF
--- a/django-stubs/shortcuts.pyi
+++ b/django-stubs/shortcuts.pyi
@@ -11,7 +11,7 @@ from django.template.context import _ContextKeys
 from typing_extensions import Literal
 
 def render(
-    request: HttpRequest,
+    request: HttpRequest | None,
     template_name: str | Sequence[str],
     context: Mapping[_ContextKeys, Any] | None = ...,
     content_type: str | None = ...,


### PR DESCRIPTION
# I have made things!


The request arg of `shortcuts.render()` is passed to `loader.render_to_string()`, where the function signature is `render_to_string(template_name, context=None, request=None, using=None)`. Therefore I believe `None` is valid for the request argument of `shortcuts.render()`

[shortcuts.render()](https://github.com/django/django/blob/c179ad9fe7e82dcb80261aa016f2fe18c8fcc181/django/shortcuts.py#L17)
[loader.render_to_string()](https://github.com/django/django/blob/c179ad9fe7e82dcb80261aa016f2fe18c8fcc181/django/template/loader.py#L52)