### PR TITLE
Remove unintentional GeoDjango re-exports

### DIFF
--- a/django-stubs/contrib/gis/admin/widgets.pyi
+++ b/django-stubs/contrib/gis/admin/widgets.pyi
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any
 
-from django.forms.widgets import Textarea as Textarea
+from django.forms.widgets import Textarea
 
 geo_context: Any
 logger: Logger

--- a/django-stubs/contrib/gis/db/backends/mysql/features.pyi
+++ b/django-stubs/contrib/gis/db/backends/mysql/features.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures as BaseSpatialFeatures
+from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.mysql.features import DatabaseFeatures as MySQLDatabaseFeatures
 
 class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):

--- a/django-stubs/contrib/gis/db/backends/mysql/introspection.pyi
+++ b/django-stubs/contrib/gis/db/backends/mysql/introspection.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.backends.mysql.introspection import DatabaseIntrospection as DatabaseIntrospection
+from django.db.backends.mysql.introspection import DatabaseIntrospection
 
 class MySQLIntrospection(DatabaseIntrospection):
     data_types_reverse: Any

--- a/django-stubs/contrib/gis/db/backends/mysql/operations.pyi
+++ b/django-stubs/contrib/gis/db/backends/mysql/operations.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Callable
 from typing import Any
 
-from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations as BaseSpatialOperations
+from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations
 from django.contrib.gis.db.backends.utils import SpatialOperator
 from django.contrib.gis.geos.geometry import GEOSGeometryBase
-from django.db.backends.mysql.operations import DatabaseOperations as DatabaseOperations
+from django.db.backends.mysql.operations import DatabaseOperations
 
 class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
     name: str

--- a/django-stubs/contrib/gis/db/backends/mysql/schema.pyi
+++ b/django-stubs/contrib/gis/db/backends/mysql/schema.pyi
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any
 
-from django.db.backends.mysql.schema import DatabaseSchemaEditor as DatabaseSchemaEditor
+from django.db.backends.mysql.schema import DatabaseSchemaEditor
 
 logger: Logger
 

--- a/django-stubs/contrib/gis/db/backends/oracle/features.pyi
+++ b/django-stubs/contrib/gis/db/backends/oracle/features.pyi
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures as BaseSpatialFeatures
+from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.oracle.features import DatabaseFeatures as OracleDatabaseFeatures
 
 class DatabaseFeatures(BaseSpatialFeatures, OracleDatabaseFeatures):

--- a/django-stubs/contrib/gis/db/backends/oracle/introspection.pyi
+++ b/django-stubs/contrib/gis/db/backends/oracle/introspection.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.backends.oracle.introspection import DatabaseIntrospection as DatabaseIntrospection
+from django.db.backends.oracle.introspection import DatabaseIntrospection
 
 class OracleIntrospection(DatabaseIntrospection):
     @property

--- a/django-stubs/contrib/gis/db/backends/oracle/operations.pyi
+++ b/django-stubs/contrib/gis/db/backends/oracle/operations.pyi
@@ -1,8 +1,8 @@
 from typing import Any
 
-from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations as BaseSpatialOperations
-from django.contrib.gis.db.backends.utils import SpatialOperator as SpatialOperator
-from django.db.backends.oracle.operations import DatabaseOperations as DatabaseOperations
+from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations
+from django.contrib.gis.db.backends.utils import SpatialOperator
+from django.db.backends.oracle.operations import DatabaseOperations
 
 DEFAULT_TOLERANCE: str
 

--- a/django-stubs/contrib/gis/db/backends/postgis/features.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/features.pyi
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures as BaseSpatialFeatures
+from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.postgresql.features import DatabaseFeatures as Psycopg2DatabaseFeatures
 
 class DatabaseFeatures(BaseSpatialFeatures, Psycopg2DatabaseFeatures):

--- a/django-stubs/contrib/gis/db/backends/postgis/introspection.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/introspection.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.backends.postgresql.introspection import DatabaseIntrospection as DatabaseIntrospection
+from django.db.backends.postgresql.introspection import DatabaseIntrospection
 
 class PostGISIntrospection(DatabaseIntrospection):
     postgis_oid_lookup: Any

--- a/django-stubs/contrib/gis/db/backends/postgis/models.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/models.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 
-from django.contrib.gis.db.backends.base.models import SpatialRefSysMixin as SpatialRefSysMixin
-from django.db import models as models
+from django.contrib.gis.db.backends.base.models import SpatialRefSysMixin
+from django.db import models
 
 class PostGISGeometryColumns(models.Model):
     f_table_catalog: Any

--- a/django-stubs/contrib/gis/db/backends/spatialite/adapter.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/adapter.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.db.backends.base.adapter import WKTAdapter as WKTAdapter
+from django.contrib.gis.db.backends.base.adapter import WKTAdapter
 
 class SpatiaLiteAdapter(WKTAdapter):
     def __conform__(self, protocol: Any) -> Any: ...

--- a/django-stubs/contrib/gis/db/backends/spatialite/client.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/client.pyi
@@ -1,4 +1,4 @@
-from django.db.backends.sqlite3.client import DatabaseClient as DatabaseClient
+from django.db.backends.sqlite3.client import DatabaseClient
 
 class SpatiaLiteClient(DatabaseClient):
     executable_name: str

--- a/django-stubs/contrib/gis/db/backends/spatialite/features.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/features.pyi
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures as BaseSpatialFeatures
+from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.sqlite3.features import DatabaseFeatures as SQLiteDatabaseFeatures
 
 class DatabaseFeatures(BaseSpatialFeatures, SQLiteDatabaseFeatures):

--- a/django-stubs/contrib/gis/db/backends/spatialite/introspection.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/introspection.pyi
@@ -1,7 +1,6 @@
 from typing import Any
 
-from django.db.backends.sqlite3.introspection import DatabaseIntrospection as DatabaseIntrospection
-from django.db.backends.sqlite3.introspection import FlexibleFieldLookupDict as FlexibleFieldLookupDict
+from django.db.backends.sqlite3.introspection import DatabaseIntrospection, FlexibleFieldLookupDict
 
 class GeoFlexibleFieldLookupDict(FlexibleFieldLookupDict):
     base_data_types_reverse: Any

--- a/django-stubs/contrib/gis/db/backends/spatialite/models.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/models.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 
-from django.contrib.gis.db.backends.base.models import SpatialRefSysMixin as SpatialRefSysMixin
-from django.db import models as models
+from django.contrib.gis.db.backends.base.models import SpatialRefSysMixin
+from django.db import models
 
 class SpatialiteGeometryColumns(models.Model):
     f_table_name: Any

--- a/django-stubs/contrib/gis/db/backends/spatialite/operations.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/operations.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 
 from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations
-from django.contrib.gis.db.backends.utils import SpatialOperator as SpatialOperator
+from django.contrib.gis.db.backends.utils import SpatialOperator
 from django.db.backends.sqlite3.operations import DatabaseOperations
 
 class SpatialiteNullCheckOperator(SpatialOperator): ...

--- a/django-stubs/contrib/gis/db/backends/spatialite/schema.pyi
+++ b/django-stubs/contrib/gis/db/backends/spatialite/schema.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.backends.sqlite3.schema import DatabaseSchemaEditor as DatabaseSchemaEditor
+from django.db.backends.sqlite3.schema import DatabaseSchemaEditor
 
 class SpatialiteSchemaEditor(DatabaseSchemaEditor):
     sql_add_geometry_column: str

--- a/django-stubs/contrib/gis/db/models/sql/conversion.pyi
+++ b/django-stubs/contrib/gis/db/models/sql/conversion.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db import models as models
+from django.db import models
 
 class AreaField(models.FloatField):
     geo_field: Any

--- a/django-stubs/contrib/gis/forms/widgets.pyi
+++ b/django-stubs/contrib/gis/forms/widgets.pyi
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any
 
-from django.forms.widgets import Widget as Widget
+from django.forms.widgets import Widget
 
 logger: Logger
 

--- a/django-stubs/contrib/gis/gdal/base.pyi
+++ b/django-stubs/contrib/gis/gdal/base.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.ptr import CPointerBase as CPointerBase
+from django.contrib.gis.ptr import CPointerBase
 
 class GDALBase(CPointerBase):
     null_ptr_exception_class: Any

--- a/django-stubs/contrib/gis/geos/__init__.pyi
+++ b/django-stubs/contrib/gis/geos/__init__.pyi
@@ -1,3 +1,5 @@
+from ..geometry import hex_regex as hex_regex
+from ..geometry import wkt_regex as wkt_regex
 from .collections import GeometryCollection as GeometryCollection
 from .collections import MultiLineString as MultiLineString
 from .collections import MultiPoint as MultiPoint
@@ -6,8 +8,6 @@ from .error import GEOSException as GEOSException
 from .factory import fromfile as fromfile
 from .factory import fromstr as fromstr
 from .geometry import GEOSGeometry as GEOSGeometry
-from .geometry import hex_regex as hex_regex
-from .geometry import wkt_regex as wkt_regex
 from .io import WKBReader as WKBReader
 from .io import WKBWriter as WKBWriter
 from .io import WKTReader as WKTReader

--- a/django-stubs/contrib/gis/geos/base.pyi
+++ b/django-stubs/contrib/gis/geos/base.pyi
@@ -1,5 +1,5 @@
 from django.contrib.gis.geos.error import GEOSException
-from django.contrib.gis.ptr import CPointerBase as CPointerBase
+from django.contrib.gis.ptr import CPointerBase
 
 class GEOSBase(CPointerBase):
     null_ptr_exception_class: type[GEOSException]

--- a/django-stubs/contrib/gis/geos/geometry.pyi
+++ b/django-stubs/contrib/gis/geos/geometry.pyi
@@ -3,8 +3,6 @@ from typing import Any
 from _typeshed import Self
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.gdal.geometries import OGRGeometry
-from django.contrib.gis.geometry import hex_regex as hex_regex  # noqa: F401
-from django.contrib.gis.geometry import wkt_regex as wkt_regex
 from django.contrib.gis.geos.base import GEOSBase
 from django.contrib.gis.geos.coordseq import GEOSCoordSeq
 from django.contrib.gis.geos.mutable_list import ListMixin

--- a/django-stubs/contrib/gis/geos/prototypes/coordseq.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/coordseq.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 def check_cs_op(result: Any, func: Any, cargs: Any) -> Any: ...
 def check_cs_get(result: Any, func: Any, cargs: Any) -> Any: ...

--- a/django-stubs/contrib/gis/geos/prototypes/geom.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/geom.pyi
@@ -1,7 +1,7 @@
 from ctypes import c_char_p
 from typing import Any
 
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 c_uchar_p: Any
 

--- a/django-stubs/contrib/gis/geos/prototypes/io.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/io.pyi
@@ -2,8 +2,8 @@ import threading
 from ctypes import Structure
 from typing import Any
 
-from django.contrib.gis.geos.base import GEOSBase as GEOSBase
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.base import GEOSBase
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 class WKTReader_st(Structure): ...
 class WKTWriter_st(Structure): ...

--- a/django-stubs/contrib/gis/geos/prototypes/predicates.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/predicates.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 class UnaryPredicate(GEOSFuncFactory):
     argtypes: Any

--- a/django-stubs/contrib/gis/geos/prototypes/prepared.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/prepared.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 geos_prepare: Any
 prepared_destroy: Any

--- a/django-stubs/contrib/gis/geos/prototypes/threadsafe.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/threadsafe.pyi
@@ -1,7 +1,7 @@
 import threading
 from typing import Any
 
-from django.contrib.gis.geos.base import GEOSBase as GEOSBase
+from django.contrib.gis.geos.base import GEOSBase
 
 class GEOSContextHandle(GEOSBase):
     ptr_type: Any

--- a/django-stubs/contrib/gis/geos/prototypes/topology.pyi
+++ b/django-stubs/contrib/gis/geos/prototypes/topology.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.gis.geos.libgeos import GEOSFuncFactory as GEOSFuncFactory
+from django.contrib.gis.geos.libgeos import GEOSFuncFactory
 
 class Topology(GEOSFuncFactory):
     argtypes: Any

--- a/django-stubs/contrib/gis/sitemaps/kml.pyi
+++ b/django-stubs/contrib/gis/sitemaps/kml.pyi
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.sitemaps import Sitemap as Sitemap
+from django.contrib.sitemaps import Sitemap
 
 class KMLSitemap(Sitemap):
     geo_format: str


### PR DESCRIPTION
Follow-up from discussion on #1299.

Stub files with `from ... import SomeSymbol as SomeSymbol` are explicit re-exports (https://typing.readthedocs.io/en/latest/source/stubs.html#imports)

Django does employ intentional re-exports to make imports shorter and more convenient (usually in `__init__.py` files). But many of these re-exports were under **longer** module paths. And these unintentional re-exports are likely to be less stable over Django releases. E.g.

```python
# Instead of:
from django.contrib.gis.geos.geometry import hex_regex
from django.contrib.gis.sitemaps.kml import Sitemap
# Use:
from django.contrib.gis.geometry import hex_regex
from django.contrib.sitemaps import Sitemap
```

Now mypy will warn users when using these re-exports.
