### PR TITLE
Run apt-get update in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
-        run: sudo apt-get install binutils libproj-dev gdal-bin
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -76,7 +78,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
-        run: sudo apt-get install binutils libproj-dev gdal-bin
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
# I have made things!

Tests failed on #1243 just now with:

```
Run sudo apt-get install binutils libproj-dev gdal-bin
...
Err:37 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl4-gnutls-dev amd64 7.81.0-1ubuntu1.6
  404  Not Found [IP: 52.252.75.106 80]
Fetched 36.6 MB in 4s (9977 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-gnutls-dev_7.81.0-1ubuntu1.6_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

One should always `apt-get update` before running `apt-get install`, which this PR adds.