### PR TITLE
Add support for `django.core.cache.backends.memcached.PyMemcacheCache`

### DIFF
--- a/django-stubs/core/cache/backends/memcached.pyi
+++ b/django-stubs/core/cache/backends/memcached.pyi
@@ -18,3 +18,6 @@ class MemcachedCache(BaseMemcachedCache):
 
 class PyLibMCCache(BaseMemcachedCache):
     def __init__(self, server: str | Sequence[str], params: dict[str, Any]) -> None: ...
+
+class PyMemcacheCache(BaseMemcachedCache):
+    def __init__(self, server: str | Sequence[str], params: dict[str, Any]) -> None: ...


### PR DESCRIPTION
Fixes #1284.