### PR TITLE
fix: Fix override_settings decorator typing

### DIFF
--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -21,6 +21,7 @@ from typing_extensions import SupportsIndex, TypeAlias
 _TestClass: TypeAlias = type[SimpleTestCase]
 
 _DecoratedTest: TypeAlias = Callable | _TestClass
+_DT = TypeVar("_DT", bound=_DecoratedTest)
 _C = TypeVar("_C", bound=Callable)  # Any callable
 
 TZ_SUPPORT: bool
@@ -57,7 +58,7 @@ class TestContextDecorator:
     ) -> None: ...
     def decorate_class(self, cls: _TestClass) -> _TestClass: ...
     def decorate_callable(self, func: _C) -> _C: ...
-    def __call__(self, decorated: _DecoratedTest) -> Any: ...
+    def __call__(self, decorated: _DT) -> _DT: ...
 
 class override_settings(TestContextDecorator):
     options: dict[str, Any]

--- a/tests/typecheck/test/test_utils.yml
+++ b/tests/typecheck/test/test_utils.yml
@@ -1,0 +1,8 @@
+-   case: override_settings
+    main: |
+        from django.test import override_settings
+        from django.conf import settings
+        @override_settings(FOO='bar')
+        def test() -> None:
+            pass
+        reveal_type(test) # N: Revealed type is "def ()"


### PR DESCRIPTION
- My solution is quite simple, maybe some TestContextDecorators do change the class/function
