### PR TITLE
Fix crash when filtering on implicit `pk` field on abstract model

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -384,7 +384,7 @@ class DjangoContext:
 
     def resolve_lookup_expected_type(self, ctx: MethodContext, model_cls: Type[Model], lookup: str) -> MypyType:
         query = Query(model_cls)
-        if lookup.startswith("pk") and query.get_meta().pk is None:
+        if lookup == "pk" or lookup.startswith("pk__") and query.get_meta().pk is None:
             # Primary key lookup when no primary key field is found, model is presumably
             # abstract and we can't say anything about 'pk'.
             return AnyType(TypeOfAny.implementation_artifact)

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -384,6 +384,10 @@ class DjangoContext:
 
     def resolve_lookup_expected_type(self, ctx: MethodContext, model_cls: Type[Model], lookup: str) -> MypyType:
         query = Query(model_cls)
+        if lookup.startswith("pk") and query.get_meta().pk is None:
+            # Primary key lookup when no primary key field is found, model is presumably
+            # abstract and we can't say anything about 'pk'.
+            return AnyType(TypeOfAny.implementation_artifact)
         try:
             lookup_parts, field_parts, is_expression = query.solve_lookup_type(lookup)
             if is_expression:

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -1,0 +1,7 @@
+- case: test_filter_on_abstract_user_pk
+  main: |
+    from django.contrib.auth.models import AbstractUser
+    AbstractUser.objects.get(pk=1)
+    reveal_type(AbstractUser().pk)  # N: Revealed type is "Any"
+  installed_apps:
+    - django.contrib.auth

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -2,6 +2,8 @@
   main: |
     from django.contrib.auth.models import AbstractUser
     AbstractUser.objects.get(pk=1)
+    AbstractUser.objects.get(pk__in=[1])
     reveal_type(AbstractUser().pk)  # N: Revealed type is "Any"
+    AbstractUser.objects.get(pkey=1)  # ER: Cannot resolve keyword 'pkey' into field..*
   installed_apps:
     - django.contrib.auth


### PR DESCRIPTION
# I have made things!

Avoid crashing when queryset filters on an implicit `pk` field for a model, when model is abstract.

I tried to figure out #1261 and while type checking Django's test suite I came across the same error as in #1189. But reproduced when filtering on `django.contrib.auth.models.AbstractUser`.

## Related issues

Closes #1189 

I wasn't able to reproduce with the example found in the linked issue though.