### PR TITLE
Add PASSWORD_RESET_TIMEOUT_DAYS

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -383,8 +383,8 @@ LOGIN_REDIRECT_URL: str
 
 LOGOUT_REDIRECT_URL: str | None
 
-# The number of days a password reset link is valid for
-PASSWORD_RESET_TIMEOUT_DAYS: int
+# The number of seconds a password reset link is valid for
+PASSWORD_RESET_TIMEOUT: int
 
 # the first hasher in this list is the preferred algorithm.  any
 # password using different algorithms will be converted automatically


### PR DESCRIPTION
Problem: `PASSWORD_RESET_TIMEOUT` was added in 3.1, `PASSWORD_RESET_TIMEOUT_DAYS` was removed in 4.0

Solution: Add the new one, remove the old one.

Links:

- https://docs.djangoproject.com/en/4.0/ref/settings/#password-reset-timeout
- https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0