### PR TITLE
Skip executing `apps.ready` for installed apps

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -1,9 +1,8 @@
 import os
 import sys
 from collections import defaultdict
-from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, MutableMapping, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, Iterator, Optional, Set, Tuple, Type, Union
 from unittest import mock
 
 from django.core.exceptions import FieldError
@@ -51,14 +50,14 @@ def temp_environ() -> Iterator[None]:
         os.environ.update(environ)
 
 
-class AppConfigs(dict, MutableMapping[str, "AppConfig"]):  # type: ignore[type-arg]
+class AppConfigs(Dict[str, "AppConfig"]):
     """
     A mapping for 'AppConfig' that monkey patches 'ready' method on insert
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.patches: dict[str, mock._patch[mock.MagicMock]] = {}
+        self.patches: Dict[str, mock._patch[mock.MagicMock]] = {}
 
     def __setitem__(self, key: str, value: "AppConfig") -> None:
         self.patches[key] = mock.patch.object(value, "ready", autospec=True)

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -1,8 +1,10 @@
 import os
 import sys
 from collections import defaultdict
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional, Set, Tuple, Type, Union
+from unittest import mock
 
 from django.core.exceptions import FieldError
 from django.db import models
@@ -32,6 +34,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
+    from django.apps.config import AppConfig
     from django.apps.registry import Apps  # noqa: F401
     from django.conf import LazySettings  # noqa: F401
     from django.contrib.contenttypes.fields import GenericForeignKey
@@ -46,6 +49,42 @@ def temp_environ() -> Iterator[None]:
     finally:
         os.environ.clear()
         os.environ.update(environ)
+
+
+class AppConfigs(dict[str, "AppConfig"]):
+    """
+    A mapping for 'AppConfig' that monkey patches 'ready' method on insert
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.patches: dict[str, mock._patch[mock.MagicMock]] = {}
+
+    def __setitem__(self, key: str, value: "AppConfig") -> None:
+        self.patches[key] = mock.patch.object(value, "ready", autospec=True)
+        super().__setitem__(key, value)
+        self.patches[key].start()
+
+
+@contextmanager
+def skip_apps_ready(apps: "Apps") -> Generator[None, None, None]:
+    """
+    Context manager that monkey patches the apps registry's container for app configs so
+    that we avoid executing custom 'ready' methods. This both saves time but more
+    importantly avoids executing custom runtime code for arbitrary apps. There should be
+    no need for django-stubs plugin to have triggered 'ready' in order to type check
+    correctly.
+    """
+    if apps.ready:
+        # Don't overwrite a readied apps instance. Calling '.ready' will be a noop.
+        yield None
+    else:
+        apps.app_configs = AppConfigs()
+        try:
+            yield None
+        finally:
+            for patch in apps.app_configs.patches.values():
+                patch.stop()
 
 
 def initialize_django(settings_module: str) -> Tuple["Apps", "LazySettings"]:
@@ -64,7 +103,8 @@ def initialize_django(settings_module: str) -> Tuple["Apps", "LazySettings"]:
         if not settings.configured:
             settings._setup()  # type: ignore
 
-        apps.populate(settings.INSTALLED_APPS)
+        with skip_apps_ready(apps):
+            apps.populate(settings.INSTALLED_APPS)
 
     assert apps.apps_ready, "Apps are not ready"
     assert settings.configured, "Settings are not configured"

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -3,7 +3,7 @@ import sys
 from collections import defaultdict
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, MutableMapping, Optional, Set, Tuple, Type, Union
 from unittest import mock
 
 from django.core.exceptions import FieldError
@@ -51,7 +51,7 @@ def temp_environ() -> Iterator[None]:
         os.environ.update(environ)
 
 
-class AppConfigs(Dict[str, "AppConfig"]):
+class AppConfigs(dict, MutableMapping[str, "AppConfig"]):  # type: ignore[type-arg]
     """
     A mapping for 'AppConfig' that monkey patches 'ready' method on insert
     """

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -51,7 +51,7 @@ def temp_environ() -> Iterator[None]:
         os.environ.update(environ)
 
 
-class AppConfigs(dict[str, "AppConfig"]):
+class AppConfigs(Dict[str, "AppConfig"]):
     """
     A mapping for 'AppConfig' that monkey patches 'ready' method on insert
     """

--- a/tests/typecheck/test_config.yml
+++ b/tests/typecheck/test_config.yml
@@ -63,3 +63,20 @@
             content: |
                 def extra_fn() -> None:
                   pass
+
+-   case: test_skips_executing_custom_app_config_ready
+    main:
+    installed_apps:
+      - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/apps.py
+            content: |
+              from typing import NoReturn
+              from django.apps.config import AppConfig
+              class MyAppConfig(AppConfig):
+                  name = "myapp"
+                  default = True
+
+                  def ready(self) -> NoReturn:
+                      raise Exception("Don't execute ready")


### PR DESCRIPTION
# I have made things!

I got an idea from reading https://github.com/typeddjango/django-stubs/issues/1337#issuecomment-1401668445, that it'd be possible and also preferable to avoid triggering `AppConfig.ready` for `INSTALLED_APPS`. For multiple reasons:

- It'll avoid reporting of issues of `django-stubs` crashing for reasons unrelated to `django-stubs` (https://github.com/typeddjango/django-stubs/issues?q=is%3Aissue+%22in+ready%22).
- I don't think there should ever be a mypy plugin requirement existing in an `AppConfig.ready`. It should work without it.
- It should (in the general case) make startup time of `django-stubs` shorter

The approach taken here is quite invasive(i.e. monkey patching with `unittest.mock`), it could be done in multiple ways. Consider it a PoC.

## Related issues

Closes #1312