### PR TITLE
Fix crash when FK references unknown 'app_label'

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -344,7 +344,10 @@ class DjangoContext:
                 related_model_fullname = field.model.__module__ + "." + related_model_cls
                 related_model_cls = self.get_model_class_by_fullname(related_model_fullname)
             else:
-                related_model_cls = self.apps_registry.get_model(related_model_cls)
+                try:
+                    related_model_cls = self.apps_registry.get_model(related_model_cls)
+                except LookupError:
+                    return None
 
         return related_model_cls
 

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -928,3 +928,18 @@
 
                 class SalesMan(models.Model):
                     client = models.ManyToManyField(CustomUser)
+
+-   case: test_fails_if_app_label_is_unknown_in_relation_field
+    main: |
+        from installed.models import InstalledModel
+    installed_apps:
+      - installed
+    files:
+        -   path: installed/__init__.py
+        -   path: installed/models.py
+            content: |
+                from django.db import models
+                class InstalledModel(models.Model):
+                    non_installed = models.ForeignKey(  # E: Cannot find model 'not_installed.NonInstalledModel' referenced in field 'non_installed'
+                        "not_installed.NonInstalledModel", on_delete=models.CASCADE
+                    )


### PR DESCRIPTION
# I have made things!

Plugin previously crashed running the provided test case, now it yields an intended error message instead.

## Related issues

Ref: #1312 