### PR TITLE
Add generic BaseConnectionHandler

### DIFF
--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -15,10 +15,10 @@ from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseModelForm, BaseModelFormSet
+from django.utils.connection import BaseConnectionHandler
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
-from django.utils.connection import BaseConnectionHandler
 
 __all__ = ["monkeypatch"]
 

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -18,6 +18,7 @@ from django.forms.models import BaseModelForm, BaseModelFormSet
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
+from django.utils.connection import BaseConnectionHandler
 
 __all__ = ["monkeypatch"]
 
@@ -64,6 +65,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(Sitemap),
     MPGeneric(FileProxyMixin),
     MPGeneric(Lookup),
+    MPGeneric(BaseConnectionHandler),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),


### PR DESCRIPTION
# I have made things!

Had an issue with BaseConnectionHandler not accepting a generic even though mypy said it needed one. Patching it fixed my issues locally.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
