### PR TITLE
Update Model subclass DoesNotExist type

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, Final, TypeVar
+from typing import Any, TypeVar
 
 from _typeshed import Self
 from django.core.checks.messages import CheckMessage
@@ -7,6 +7,7 @@ from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObject
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models.manager import BaseManager
 from django.db.models.options import Options
+from typing_extensions import Final
 
 _Self = TypeVar("_Self", bound=Model)
 

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 
 from _typeshed import Self
 from django.core.checks.messages import CheckMessage
@@ -26,8 +26,8 @@ class ModelBase(type):
     def _base_manager(cls: type[_Self]) -> BaseManager[_Self]: ...  # type: ignore[misc]
 
 class Model(metaclass=ModelBase):
-    DoesNotExist: type[ObjectDoesNotExist]
-    MultipleObjectsReturned: type[BaseMultipleObjectsReturned]
+    DoesNotExist: Final[type[ObjectDoesNotExist]]
+    MultipleObjectsReturned: Final[type[BaseMultipleObjectsReturned]]
 
     class Meta: ...
     _meta: Options[Any]

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -26,8 +26,9 @@ class ModelBase(type):
     def _base_manager(cls: type[_Self]) -> BaseManager[_Self]: ...  # type: ignore[misc]
 
 class Model(metaclass=ModelBase):
-    class DoesNotExist(ObjectDoesNotExist): ...
-    class MultipleObjectsReturned(BaseMultipleObjectsReturned): ...
+    DoesNotExist: type[ObjectDoesNotExist]
+    MultipleObjectsReturned: type[BaseMultipleObjectsReturned]
+
     class Meta: ...
     _meta: Options[Any]
     pk: Any


### PR DESCRIPTION
# I have made things!

- Updates stub for `DoesNotExist` error on model subclass
- In VSCode, Pylance considers all DoesNotExist errors to be the same error, when the reality is that each model has its own independent DoesNotExist. This is discussed in the referenced issue on Pylance's GH, where they attribute it to the stub. This PR updates the stub using their suggestion.
```python
try:
    # some django code
except ModelA.DoesNotExist:
    # handle ModelA error
except ModelB.DoesNotExist:
    # pylance thinks this code is unreachable before this PR
```

## Related issues

- Refs: https://github.com/microsoft/pylance-release/issues/2770

## Notes
- In all honesty, I don't truly understand stubs – I just copied the suggestion from the folks at Pylance + formatting described in the contribution guide
- Formatting and testing went through smoothly, except for `tests/typecheck/models/test_ineritance.yml/django_contrib_gis_base_model_mixin_inheritance`, which errored because I don't have something called GDAL installed? Let me know if I truly caused this error, or if it's just a machine-specific thing.