### PR TITLE
django-stubs-ext: Add BaseModelMeta for typing Model inner Meta class

### DIFF
--- a/django_stubs_ext/django_stubs_ext/db/models.py
+++ b/django_stubs_ext/django_stubs_ext/db/models.py
@@ -1,0 +1,50 @@
+from typing import ClassVar, Literal, Sequence
+
+from django.db.models import BaseConstraint, Index
+
+from django_stubs_ext import StrOrPromise
+
+
+class BaseModelMeta:
+    """
+    Typed base class for Django Model `class Meta:` inner class.
+
+    Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and some
+    values are normalized by Django.
+
+    Usage::
+
+        from django.db import models
+        from django_stubs_ext.db.models import BaseModelMeta
+
+        class MyModel(models.Model):
+            example = models.CharField(max_length=100)
+
+            class Meta(BaseModelMeta):
+                ordering = ["example"]
+    """
+
+    abstract: ClassVar[bool]  # default: False
+    app_label: ClassVar[str]
+    base_manager_name: ClassVar[str]
+    db_table: ClassVar[str]
+    db_table_comment: ClassVar[str]
+    db_tablespace: ClassVar[str]
+    default_manager_name: ClassVar[str]
+    default_related_name: ClassVar[str]
+    get_latest_by: ClassVar[str | Sequence[str]]
+    managed: ClassVar[bool]  # default: True
+    order_with_respect_to: ClassVar[str]
+    ordering: ClassVar[ClassVar[Sequence[str]]]
+    permissions: ClassVar[list[tuple[str, str]]]
+    default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
+    proxy: ClassVar[bool]  # default: False
+    required_db_features: ClassVar[list[str]]
+    required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
+    select_on_save: ClassVar[bool]  # default: False
+    indexes: ClassVar[list[Index]]
+    unique_together: ClassVar[Sequence[Sequence[str]] | Sequence[str]]
+    index_together: ClassVar[Sequence[Sequence[str]] | Sequence[str]]  # Deprecated in Django 4.2
+    constraints: ClassVar[list[BaseConstraint]]
+    verbose_name: ClassVar[StrOrPromise]
+    verbose_name_plural: ClassVar[StrOrPromise]

--- a/django_stubs_ext/django_stubs_ext/db/models.py
+++ b/django_stubs_ext/django_stubs_ext/db/models.py
@@ -1,51 +1,56 @@
-from typing import ClassVar, List, Sequence, Tuple, Union
+from typing import TYPE_CHECKING
 
-from django.db.models import BaseConstraint, Index
-from typing_extensions import Literal
+if TYPE_CHECKING:
+    from typing import ClassVar, List, Sequence, Tuple, Union
 
-from django_stubs_ext import StrOrPromise
+    from django.db.models import BaseConstraint, Index
+    from typing_extensions import Literal
 
+    from django_stubs_ext import StrOrPromise
 
-class BaseModelMeta:
-    """
-    Typed base class for Django Model `class Meta:` inner class.
+    class BaseModelMeta:
+        """
+        Typed base class for Django Model `class Meta:` inner class.
 
-    Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and some
-    values are normalized by Django.
+        Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and some
+        values are normalized by Django.
 
-    Usage::
+        Usage::
 
-        from django.db import models
-        from django_stubs_ext.db.models import BaseModelMeta
+            from django.db import models
+            from django_stubs_ext.db.models import BaseModelMeta
 
-        class MyModel(models.Model):
-            example = models.CharField(max_length=100)
+            class MyModel(models.Model):
+                example = models.CharField(max_length=100)
 
-            class Meta(BaseModelMeta):
-                ordering = ["example"]
-    """
+                class Meta(BaseModelMeta):
+                    ordering = ["example"]
+        """
 
-    abstract: ClassVar[bool]  # default: False
-    app_label: ClassVar[str]
-    base_manager_name: ClassVar[str]
-    db_table: ClassVar[str]
-    db_table_comment: ClassVar[str]
-    db_tablespace: ClassVar[str]
-    default_manager_name: ClassVar[str]
-    default_related_name: ClassVar[str]
-    get_latest_by: ClassVar[Union[str, Sequence[str]]]
-    managed: ClassVar[bool]  # default: True
-    order_with_respect_to: ClassVar[str]
-    ordering: ClassVar[Sequence[str]]
-    permissions: ClassVar[List[Tuple[str, str]]]
-    default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
-    proxy: ClassVar[bool]  # default: False
-    required_db_features: ClassVar[List[str]]
-    required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
-    select_on_save: ClassVar[bool]  # default: False
-    indexes: ClassVar[List[Index]]
-    unique_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]
-    index_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]  # Deprecated in Django 4.2
-    constraints: ClassVar[List[BaseConstraint]]
-    verbose_name: ClassVar[StrOrPromise]
-    verbose_name_plural: ClassVar[StrOrPromise]
+        abstract: ClassVar[bool]  # default: False
+        app_label: ClassVar[str]
+        base_manager_name: ClassVar[str]
+        db_table: ClassVar[str]
+        db_table_comment: ClassVar[str]
+        db_tablespace: ClassVar[str]
+        default_manager_name: ClassVar[str]
+        default_related_name: ClassVar[str]
+        get_latest_by: ClassVar[Union[str, Sequence[str]]]
+        managed: ClassVar[bool]  # default: True
+        order_with_respect_to: ClassVar[str]
+        ordering: ClassVar[Sequence[str]]
+        permissions: ClassVar[List[Tuple[str, str]]]
+        default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
+        proxy: ClassVar[bool]  # default: False
+        required_db_features: ClassVar[List[str]]
+        required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
+        select_on_save: ClassVar[bool]  # default: False
+        indexes: ClassVar[List[Index]]
+        unique_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]
+        index_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]  # Deprecated in Django 4.2
+        constraints: ClassVar[List[BaseConstraint]]
+        verbose_name: ClassVar[StrOrPromise]
+        verbose_name_plural: ClassVar[StrOrPromise]
+
+else:
+    BaseModelMeta = object

--- a/django_stubs_ext/django_stubs_ext/db/models.py
+++ b/django_stubs_ext/django_stubs_ext/db/models.py
@@ -1,6 +1,7 @@
-from typing import ClassVar, Literal, Sequence
+from typing import ClassVar, List, Sequence, Tuple, Union
 
 from django.db.models import BaseConstraint, Index
+from typing_extensions import Literal
 
 from django_stubs_ext import StrOrPromise
 
@@ -32,19 +33,19 @@ class BaseModelMeta:
     db_tablespace: ClassVar[str]
     default_manager_name: ClassVar[str]
     default_related_name: ClassVar[str]
-    get_latest_by: ClassVar[str | Sequence[str]]
+    get_latest_by: ClassVar[Union[str, Sequence[str]]]
     managed: ClassVar[bool]  # default: True
     order_with_respect_to: ClassVar[str]
-    ordering: ClassVar[ClassVar[Sequence[str]]]
-    permissions: ClassVar[list[tuple[str, str]]]
+    ordering: ClassVar[Sequence[str]]
+    permissions: ClassVar[List[Tuple[str, str]]]
     default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
     proxy: ClassVar[bool]  # default: False
-    required_db_features: ClassVar[list[str]]
+    required_db_features: ClassVar[List[str]]
     required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
     select_on_save: ClassVar[bool]  # default: False
-    indexes: ClassVar[list[Index]]
-    unique_together: ClassVar[Sequence[Sequence[str]] | Sequence[str]]
-    index_together: ClassVar[Sequence[Sequence[str]] | Sequence[str]]  # Deprecated in Django 4.2
-    constraints: ClassVar[list[BaseConstraint]]
+    indexes: ClassVar[List[Index]]
+    unique_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]
+    index_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]  # Deprecated in Django 4.2
+    constraints: ClassVar[List[BaseConstraint]]
     verbose_name: ClassVar[StrOrPromise]
     verbose_name_plural: ClassVar[StrOrPromise]

--- a/django_stubs_ext/django_stubs_ext/db/models.py
+++ b/django_stubs_ext/django_stubs_ext/db/models.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
         """
         Typed base class for Django Model `class Meta:` inner class.
 
-        Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and some
-        values are normalized by Django.
+        Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and
+        some values are normalized by Django.
 
         Usage::
 

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -141,7 +141,6 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
-
                 class AuthMixin(models.Model):
                     class Meta:
                         abstract = True

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -141,10 +141,9 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
-                from django_stubs_ext.db.models import BaseModelMeta
 
                 class AuthMixin(models.Model):
-                    class Meta(BaseModelMeta):
+                    class Meta:
                         abstract = True
                     username = models.CharField(max_length=100)
 

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -141,8 +141,10 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
+                from django_stubs_ext.db.models import BaseModelMeta
+
                 class AuthMixin(models.Model):
-                    class Meta:
+                    class Meta(BaseModelMeta):
                         abstract = True
                     username = models.CharField(max_length=100)
 

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -110,6 +110,7 @@
             content: |
                 from typing import TypeVar
                 from django.db import models
+                from django_stubs_ext.db.models import BaseModelMeta
 
                 _T = TypeVar('_T', bound=models.Model)
                 class Manager1(models.Manager[_T]):
@@ -117,7 +118,7 @@
                 class Manager2(models.Manager[_T]):
                     pass
                 class MyModel(models.Model):
-                    class Meta:
+                    class Meta(BaseModelMeta):
                         default_manager_name = 'm2'
                     m1 = Manager1['MyModel']()
                     m2 = Manager2['MyModel']()

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -49,8 +49,22 @@
             content: |
                 from django.db import models
                 from django.contrib.postgres.fields import ArrayField
+                from django_stubs_ext.db.models import BaseModelMeta
                 class AbstractModel(models.Model):
-                    class Meta:
+                    class Meta(BaseModelMeta):
                         abstract = True
                 class MyModel(AbstractModel):
                     field = ArrayField(models.IntegerField(), default=[])
+-   case: base_model_meta_incompatible_types
+    main: |
+        from django.db import models
+        from django.contrib.postgres.fields import ArrayField
+        from django_stubs_ext.db.models import BaseModelMeta
+
+        class MyModel(models.Model):
+            example = models.CharField(max_length=100)
+            class Meta(BaseModelMeta):
+                abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "BaseModelMeta" defined the type as "bool")
+                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "BaseModelMeta" defined the type as "Union[str, _StrPromise]")
+                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "BaseModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
+                unknown_attr = True  # can't check this

--- a/tests/typecheck/models/test_proxy_models.yml
+++ b/tests/typecheck/models/test_proxy_models.yml
@@ -12,10 +12,12 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
+                from django_stubs_ext.db.models import BaseModelMeta
+
                 class Publisher(models.Model):
                     pass
                 class PublisherProxy(Publisher):
-                    class Meta:
+                    class Meta(BaseModelMeta):
                         proxy = True
                 class Blog(models.Model):
                     publisher = models.ForeignKey(to=PublisherProxy, on_delete=models.CASCADE)


### PR DESCRIPTION
I've had some thoughts about how to expand `django-stubs-ext`.

We can provide a base class for the Model inner `class Meta`. This inner class provides type hints for all available attributes, and thus mypy can check whether actual usages have valid types or not.

Example usage:

```python
from django.db import models
from django_stubs_ext.db.models import BaseModelMeta

class MyModel(models.Model):
    example = models.CharField(max_length=100)

    class Meta(BaseModelMeta):
        #     ^^^^^^^^^^^^^^^ This needs to be added
        ordering = ["example"]
        unique_together = {}  # E: Incompatible types in assignment (expression has type "Dict[<nothing>, <nothing>]", base class "BaseModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
```
