### PR TITLE
Fixed type of AdminSite.site_url to allow None

### DIFF
--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -33,7 +33,7 @@ class AdminSite:
     site_title: _StrOrPromise
     site_header: _StrOrPromise
     index_title: _StrOrPromise
-    site_url: str
+    site_url: str | None
     login_form: type[AuthenticationForm] | None
     index_template: str | None
     app_index_template: str | None


### PR DESCRIPTION
This is allowed to be None as per the docs
https://docs.djangoproject.com/en/dev/ref/contrib/admin#django.contrib.admin.AdminSite.site_url
