### PR TITLE
Added stub for where method

### DIFF
--- a/django-stubs/db/models/sql/query.pyi
+++ b/django-stubs/db/models/sql/query.pyi
@@ -50,6 +50,7 @@ class Query(BaseExpression):
     default_ordering: bool
     standard_ordering: bool
     used_aliases: set[str]
+    where: type[WhereNode]
     filter_is_sticky: bool
     subquery: bool
     group_by: None | Sequence[Combinable] | Sequence[str] | Literal[True]

--- a/django-stubs/db/models/sql/query.pyi
+++ b/django-stubs/db/models/sql/query.pyi
@@ -50,7 +50,7 @@ class Query(BaseExpression):
     default_ordering: bool
     standard_ordering: bool
     used_aliases: set[str]
-    where: type[WhereNode]
+    where: WhereNode
     filter_is_sticky: bool
     subquery: bool
     group_by: None | Sequence[Combinable] | Sequence[str] | Literal[True]


### PR DESCRIPTION
# Added a stub for `Query.where`

Fixes #1399 

### Description

Added a new `where` attribute to the `Query` class definition. Hope it fixes this!