### PR TITLE
Allow setting SECRET_KEY to be str or bytes, add SECRET_KEY_FALLBACKS, update PasswordResetTokenGenerator

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -168,7 +168,11 @@ IGNORABLE_404_URLS: list[Pattern[str]]
 # A secret key for this particular Django installation. Used in secret-key
 # hashing algorithms. Set this in your settings, or Django will complain
 # loudly.
-SECRET_KEY: str
+SECRET_KEY: str | bytes
+
+# A list of fallback secret keys for a particular Django installation. These
+# are used to allow rotation of the SECRET_KEY.
+SECRET_KEY_FALLBACKS: list[str | bytes]
 
 # Default file storage mechanism that holds media.
 DEFAULT_FILE_STORAGE: str

--- a/django-stubs/contrib/auth/tokens.pyi
+++ b/django-stubs/contrib/auth/tokens.pyi
@@ -5,7 +5,8 @@ from django.contrib.auth.base_user import AbstractBaseUser
 
 class PasswordResetTokenGenerator:
     key_salt: str
-    secret: Any
+    secret: str | bytes
+    secret_fallbacks: list[str | bytes]
     algorithm: str
     def make_token(self, user: AbstractBaseUser) -> str: ...
     def check_token(self, user: AbstractBaseUser | None, token: str | None) -> bool: ...


### PR DESCRIPTION
Problem: `SECRET_KEY` could be either `str` or `bytes`, and it doesn't look like we have any support for `SECRET_KEY_FALLBACKS`.

Solution: Fix type annotation and add `SECRET_KEY_FALLBACKS`. Also update usages in `PasswordResetTokenGenerator`.

See-also: https://github.com/django/django/pull/15198/files