### PR TITLE
Allow lazy translation strings for constraint 'violation_error_message' arguments, attributes

### DIFF
--- a/django-stubs/contrib/postgres/constraints.pyi
+++ b/django-stubs/contrib/postgres/constraints.pyi
@@ -4,6 +4,7 @@ from django.db.models import Deferrable
 from django.db.models.constraints import BaseConstraint
 from django.db.models.expressions import Combinable
 from django.db.models.query_utils import Q
+from django.utils.functional import _StrOrPromise
 
 class ExclusionConstraint(BaseConstraint):
     expressions: Sequence[tuple[str | Combinable, str]]
@@ -19,5 +20,5 @@ class ExclusionConstraint(BaseConstraint):
         deferrable: Deferrable | None = ...,
         include: list[str] | tuple[str] | None = ...,
         opclasses: list[str] | tuple[str] = ...,
-        violation_error_message: str | None = ...
+        violation_error_message: _StrOrPromise | None = ...
     ) -> None: ...

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -7,6 +7,7 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression, Combinable
 from django.db.models.query_utils import Q
+from django.utils.functional import _StrOrPromise
 
 class Deferrable(Enum):
     DEFERRED: str
@@ -14,8 +15,8 @@ class Deferrable(Enum):
 
 class BaseConstraint:
     name: str
-    violation_error_message: str | None
-    def __init__(self, name: str, violation_error_message: str | None = ...) -> None: ...
+    violation_error_message: _StrOrPromise | None
+    def __init__(self, name: str, violation_error_message: _StrOrPromise | None = ...) -> None: ...
     def constraint_sql(self, model: type[Model] | None, schema_editor: BaseDatabaseSchemaEditor | None) -> str: ...
     def create_sql(self, model: type[Model] | None, schema_editor: BaseDatabaseSchemaEditor | None) -> str: ...
     def remove_sql(self, model: type[Model] | None, schema_editor: BaseDatabaseSchemaEditor | None) -> str: ...
@@ -24,7 +25,7 @@ class BaseConstraint:
 
 class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
-    def __init__(self, *, check: Q | BaseExpression, name: str, violation_error_message: str | None = ...) -> None: ...
+    def __init__(self, *, check: Q | BaseExpression, name: str, violation_error_message: _StrOrPromise | None = ...) -> None: ...
 
 class UniqueConstraint(BaseConstraint):
     expressions: tuple[Combinable, ...]
@@ -42,7 +43,7 @@ class UniqueConstraint(BaseConstraint):
         deferrable: Deferrable | None = ...,
         include: Sequence[str] | None = ...,
         opclasses: Sequence[Any] = ...,
-        violation_error_message: str | None = ...
+        violation_error_message: _StrOrPromise | None = ...
     ) -> None: ...
     @overload
     def __init__(
@@ -54,5 +55,5 @@ class UniqueConstraint(BaseConstraint):
         deferrable: Deferrable | None = ...,
         include: Sequence[str] | None = ...,
         opclasses: Sequence[Any] = ...,
-        violation_error_message: str | None = ...
+        violation_error_message: _StrOrPromise | None = ...
     ) -> None: ...

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -25,7 +25,9 @@ class BaseConstraint:
 
 class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
-    def __init__(self, *, check: Q | BaseExpression, name: str, violation_error_message: _StrOrPromise | None = ...) -> None: ...
+    def __init__(
+        self, *, check: Q | BaseExpression, name: str, violation_error_message: _StrOrPromise | None = ...
+    ) -> None: ...
 
 class UniqueConstraint(BaseConstraint):
     expressions: tuple[Combinable, ...]


### PR DESCRIPTION
# I have made things!


## Related issues

- Improvement on https://github.com/typeddjango/django-stubs/pull/1263
