### PR TITLE
Allow 'BaseExpression' in 'UniqueConstraint.expressions'

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -31,15 +31,15 @@ class CheckConstraint(BaseConstraint):
     ) -> None: ...
 
 class UniqueConstraint(BaseConstraint):
-    expressions: tuple[Combinable, ...]
-    fields: tuple[str, ...]
+    expressions: Sequence[BaseExpression | Combinable]
+    fields: Sequence[str]
     condition: Q | None
     deferrable: Deferrable | None
 
     @overload
     def __init__(
         self,
-        *expressions: str | Combinable,
+        *expressions: str | BaseExpression | Combinable,
         fields: None = ...,
         name: str,
         condition: Q | None = ...,


### PR DESCRIPTION
# I have made things!

Currently, `UniqueConstraint` does not allow entries such as `Lower()` (it should), I changed the typing so that it is compatible `Index`, which has similar structure.
