### PR TITLE
Don't require tomli on Python>=3.11

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -5,7 +5,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Dict, NoReturn, Optional
 
-if sys.version_info >= (3, 11):
+if sys.version_info[:2] >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -1,10 +1,14 @@
 import configparser
+import sys
 import textwrap
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Dict, NoReturn, Optional
 
-import tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 INI_USAGE = """
 (config)
@@ -64,8 +68,8 @@ class DjangoPluginConfig:
         toml_exit: Callable[[str], NoReturn] = partial(exit_with_error, is_toml=True)
         try:
             with filepath.open(mode="rb") as f:
-                data = tomli.load(f)
-        except (tomli.TOMLDecodeError, OSError):
+                data = tomllib.load(f)
+        except (tomllib.TOMLDecodeError, OSError):
             toml_exit(COULD_NOT_LOAD_FILE)
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ dependencies = [
     "mypy>=0.980",
     "django",
     "django-stubs-ext>=0.8.0",
-    "tomli",
+    "tomli; python_version < '3.11'",
     # Types:
     "typing-extensions",
     "types-pytz",


### PR DESCRIPTION
Closes #1408
