### PR TITLE
Update compatible-mypy & CI to mypy 1.2.0

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -144,7 +144,7 @@ class ForeignKey(ForeignObject[_ST, _GT]):
         error_messages: _ErrorMessagesT | None = ...,
     ) -> None: ...
     # class access
-    @overload  # type: ignore
+    @overload
     def __get__(self, instance: None, owner: Any) -> ForwardManyToOneDescriptor: ...
     # Model instance access
     @overload
@@ -193,7 +193,7 @@ class OneToOneField(ForeignKey[_ST, _GT]):
         error_messages: _ErrorMessagesT | None = ...,
     ) -> None: ...
     # class access
-    @overload  # type: ignore
+    @overload
     def __get__(self, instance: None, owner: Any) -> ForwardOneToOneDescriptor: ...
     # Model instance access
     @overload
@@ -253,7 +253,7 @@ class ManyToManyField(RelatedField[_ST, _GT]):
         error_messages: _ErrorMessagesT | None = ...,
     ) -> None: ...
     # class access
-    @overload  # type: ignore
+    @overload
     def __get__(self, instance: None, owner: Any) -> ManyToManyDescriptor: ...
     # Model instance access
     @overload

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ psycopg2-binary
 -e .[compatible-mypy]
 
 # Overrides:
-mypy==1.1.1
+mypy==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy>=1.1.1,<1.2"],
+    "compatible-mypy": ["mypy>=1.2.0,<1.3"],
 }
 
 setup(

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -88,7 +88,6 @@
         req.GET.setdefault('foo', 'bar')  # E: This QueryDict is immutable.
         x = 1  # E: Statement is unreachable
 
-# Will work after merging https://github.com/python/mypy/pull/12572
 -   case: request_get_post_unreachable
     main: |
         from django.http.request import HttpRequest
@@ -106,4 +105,3 @@
         reveal_type(req.GET)  # N: Revealed type is "django.http.request._ImmutableQueryDict"
         req.GET['foo'] = 'bar'  # E: This QueryDict is immutable.
         x = 1  # E: Statement is unreachable
-    expect_fail: true


### PR DESCRIPTION
* Remove unneeded "type: ignore" comments
* Test request_get_post_unreachable can now be enabled due to fix in mypy 1.2 (https://github.com/python/mypy/pull/12572)
* Closes #1428

Bumps [mypy](https://github.com/python/mypy) from 1.1.1 to 1.2.0.
- [Release notes](https://github.com/python/mypy/releases)
- [Commits](https://github.com/python/mypy/compare/v1.1.1...v1.2.0)
