### PR TITLE
Fix ForeignKey queryset filters for cases where the to argument is a …

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional, Sequence, Set, Tuple, Type, Union
 
-from django.core.exceptions import FieldError, FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 from django.db.models.base import Model
 from django.db.models.expressions import Expression

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -943,3 +943,29 @@
                     non_installed = models.ForeignKey(  # E: Cannot find model 'not_installed.NonInstalledModel' referenced in field 'non_installed'
                         "not_installed.NonInstalledModel", on_delete=models.CASCADE
                     )
+-   case: test_foreign_key_to_as_string
+    main: |
+        from myapp.models import Book, Publisher
+        publisher = Publisher.objects.create(name="Example Publisher")
+        book = Book.objects.create(name="Book", publisher=publisher)
+        Book.objects.filter(publisher=publisher)
+    installed_apps:
+        -   myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models/__init__.py
+            content: |
+                from django.db import models
+                from django.db.models.query import QuerySet
+
+                class Publisher(models.Model):
+                    name = models.CharField()
+
+                class PrintedGood(models.Model):
+                    publisher = models.ForeignKey(to="myapp.Publisher", on_delete=models.CASCADE)
+
+                    class Meta:
+                        abstract = True
+
+                class Book(PrintedGood):
+                    name = models.CharField()


### PR DESCRIPTION
…string like 'app_label.model_name'.

# I have made things!

## Related issues

Refs #626 (probably closes, but my use case is only similar, not exactly the same.

This fixes lookups for related_cls where it was assumed the `to` field on a foreign key would always be a class. If it is a string however (using `app_label.model_name` notation), this breaks some things.