### PR TITLE
Add STORAGES setting

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -177,6 +177,8 @@ SECRET_KEY_FALLBACKS: list[str | bytes]
 # Default file storage mechanism that holds media.
 DEFAULT_FILE_STORAGE: str
 
+STORAGES: dict[str, dict[str, Any]]
+
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/var/www/example.com/media/"
 MEDIA_ROOT: str


### PR DESCRIPTION
STORAGES setting was [introduced](https://docs.djangoproject.com/en/4.2/releases/4.2/#id1) in Django 4.2.