### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: pyupgrade
         args: ["--py37-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Prior to this change, the pre-commit hooks could no longer install the
specified version of isort due to a breaking change from poetry. See
https://github.com/PyCQA/isort/issues/2077 for more details of the
issue.

This change bumps isort to the latest version (5.12.0), which results in
no changes to the imports.

I have submitted this PR as it was blocking pre-commit from another fix,
but I'm happy to drop it, since it looks like these dependencies are
normally updated via Github actions.