### PR TITLE
Handle repeated field lookups in calls to values_list

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -139,7 +139,10 @@ def get_values_list_row_type(
     elif named:
         row_type = helpers.make_oneoff_named_tuple(typechecker_api, "Row", column_types)
     else:
-        row_type = helpers.make_tuple(typechecker_api, list(column_types.values()))
+        # Since there may have been repeated field lookups, we cannot just use column_types.values here.
+        # This is not the case in named above, because Django will error if duplicate fields are requested.
+        resolved_column_types = [column_types[field_lookup] for field_lookup in field_lookups]
+        row_type = helpers.make_tuple(typechecker_api, resolved_column_types)
 
     return row_type
 

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -26,6 +26,27 @@
                     name = models.CharField(max_length=100)
                     age = models.IntegerField()
 
+-   case: values_list_field_repetition
+    main: |
+        from myapp.models import MyUser
+
+        # Values tuples can have the same field repeated
+        values_tuple = MyUser.objects.values_list('name', 'age', 'name').get()
+        reveal_type(values_tuple)  # N: Revealed type is "Tuple[builtins.str, builtins.int, builtins.str]"
+        reveal_type(values_tuple[0])  # N: Revealed type is "builtins.str"
+        reveal_type(values_tuple[1])  # N: Revealed type is "builtins.int"
+        reveal_type(values_tuple[2])  # N: Revealed type is "builtins.str"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyUser(models.Model):
+                    name = models.CharField(max_length=100)
+                    age = models.IntegerField()
+
 -   case: values_list_supports_queryset_methods
     main: |
         from myapp.models import MyUser


### PR DESCRIPTION
Prior to this change, if checked code was calling the values_list method
on a queryset with a repeated field lookup, for example
Model.objects.values_list("foo", "foo"), then we would fail to type the
resulting tuple correctly. The second argument would be untyped, and the
resulting tuple would have fewer fields than Django would actually give
it.

This problem only affects unnamed, non-flat tuples, as Django will error
if a repeating field lookups is attempted for these other variants.

This change ensures that when we type an unnamed tuple, we refer back to
the original field lookups when passing in the resolved values. We also
add a test to explain the issue, and prevent regressions.


## Related issues

I could not find a related issue for this, but I can raise one if that
would be helpful.