### PR TITLE
Syndication Feed items do not need to be Model instances

### DIFF
--- a/django-stubs/contrib/syndication/views.pyi
+++ b/django-stubs/contrib/syndication/views.pyi
@@ -10,7 +10,7 @@ def add_domain(domain: str, url: str, secure: bool = ...) -> str: ...
 
 class FeedDoesNotExist(ObjectDoesNotExist): ...
 
-_Item = TypeVar("_Item", bound=Model)
+_Item = TypeVar("_Item")
 _Object = TypeVar("_Object")
 
 class Feed(Generic[_Item, _Object]):


### PR DESCRIPTION
# I have made things!

I relaxed the `bound` in the `TypeVar` on `Feed` items as this type does not necessarily need to be a `Model` instance:

> items() is, a method that returns a list of objects that should be included in the feed as <item> elements. Although this example returns NewsItem objects using Django’s [object-relational mapper](https://docs.djangoproject.com/en/4.2/ref/models/querysets/), items() doesn’t have to return model instances. Although you get a few bits of functionality “for free” by using Django models, items() can return any type of object you want.

(ref: https://docs.djangoproject.com/en/4.2/ref/contrib/syndication/#a-simple-example)

## Related issues

N/A