### PR TITLE
CI: Stop testing with Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -71,7 +71,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0']
         include:
-          - python-version: '3.7'
+          - python-version: '3.8'
             django-version: '2.2'
           - python-version: '3.11'
             django-version: '4.1'


### PR DESCRIPTION
Python 3.7 will be officially EOL on 27 June 2023, that's in 2 months.

This simplifies updating to Django 4.2 (#1452), which no longer supports Python 3.7, and allows upgrading pre-commit (#1422).

I won't yet **require** Python 3.8, because the package is still compatible with 3.7, will update requirement after the 4.2.0 release.
