### PR TITLE
Rename BaseModelMeta to TypedModelMeta and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ We rely on different `django` and `mypy` versions:
 | 1.1.0        | 0.720 | 2.2.x | ^3.6
 | 0.12.x       | old semantic analyzer (<0.711), dmypy support | 2.1.x | ^3.6
 
+## Features
+
+### Type checking of Model Meta attributes
+
+By inheriting from the `TypedModelMeta` class, you can ensure you're using correct types for
+attributes:
+
+```python
+from django.db import models
+from django_stubs_ext.db.models import TypedModelMeta
+
+class MyModel(models.Model):
+    example = models.CharField(max_length=100)
+
+    class Meta(TypedModelMeta):
+        ordering = ["example"]
+        constraints = [
+            models.UniqueConstraint(fields=["example"], name="unique_example"),
+        ]
+```
+
+
 ## FAQ
 
 ### Is this an official Django project?

--- a/django_stubs_ext/django_stubs_ext/db/models.py
+++ b/django_stubs_ext/django_stubs_ext/db/models.py
@@ -8,23 +8,12 @@ if TYPE_CHECKING:
 
     from django_stubs_ext import StrOrPromise
 
-    class BaseModelMeta:
+    class TypedModelMeta:
         """
-        Typed base class for Django Model `class Meta:` inner class.
+        Typed base class for Django Model `class Meta:` inner class. At runtime this is just an alias to `object`.
 
         Most attributes are the same as `django.db.models.options.Options`. Options has some additional attributes and
         some values are normalized by Django.
-
-        Usage::
-
-            from django.db import models
-            from django_stubs_ext.db.models import BaseModelMeta
-
-            class MyModel(models.Model):
-                example = models.CharField(max_length=100)
-
-                class Meta(BaseModelMeta):
-                    ordering = ["example"]
         """
 
         abstract: ClassVar[bool]  # default: False
@@ -53,4 +42,4 @@ if TYPE_CHECKING:
         verbose_name_plural: ClassVar[StrOrPromise]
 
 else:
-    BaseModelMeta = object
+    TypedModelMeta = object

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -110,7 +110,7 @@
             content: |
                 from typing import TypeVar
                 from django.db import models
-                from django_stubs_ext.db.models import BaseModelMeta
+                from django_stubs_ext.db.models import TypedModelMeta
 
                 _T = TypeVar('_T', bound=models.Model)
                 class Manager1(models.Manager[_T]):
@@ -118,7 +118,7 @@
                 class Manager2(models.Manager[_T]):
                     pass
                 class MyModel(models.Model):
-                    class Meta(BaseModelMeta):
+                    class Meta(TypedModelMeta):
                         default_manager_name = 'm2'
                     m1 = Manager1['MyModel']()
                     m2 = Manager2['MyModel']()

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -49,9 +49,9 @@
             content: |
                 from django.db import models
                 from django.contrib.postgres.fields import ArrayField
-                from django_stubs_ext.db.models import BaseModelMeta
+                from django_stubs_ext.db.models import TypedModelMeta
                 class AbstractModel(models.Model):
-                    class Meta(BaseModelMeta):
+                    class Meta(TypedModelMeta):
                         abstract = True
                 class MyModel(AbstractModel):
                     field = ArrayField(models.IntegerField(), default=[])
@@ -59,12 +59,12 @@
     main: |
         from django.db import models
         from django.contrib.postgres.fields import ArrayField
-        from django_stubs_ext.db.models import BaseModelMeta
+        from django_stubs_ext.db.models import TypedModelMeta
 
         class MyModel(models.Model):
             example = models.CharField(max_length=100)
-            class Meta(BaseModelMeta):
-                abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "BaseModelMeta" defined the type as "bool")
-                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "BaseModelMeta" defined the type as "Union[str, _StrPromise]")
-                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "BaseModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
+            class Meta(TypedModelMeta):
+                abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")
+                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")
+                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
                 unknown_attr = True  # can't check this

--- a/tests/typecheck/models/test_proxy_models.yml
+++ b/tests/typecheck/models/test_proxy_models.yml
@@ -12,12 +12,12 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
-                from django_stubs_ext.db.models import BaseModelMeta
+                from django_stubs_ext.db.models import TypedModelMeta
 
                 class Publisher(models.Model):
                     pass
                 class PublisherProxy(Publisher):
-                    class Meta(BaseModelMeta):
+                    class Meta(TypedModelMeta):
                         proxy = True
                 class Blog(models.Model):
                     publisher = models.ForeignKey(to=PublisherProxy, on_delete=models.CASCADE)


### PR DESCRIPTION
Changes and documents the feature added in #1375.

@sobolevn I've actually changed my mind and I now prefer the name `TypedModelMeta`, what do you think?

I think this way it's more explicit what it means -- it's not actually a "base class" (it's only an alias of `object` at runtime) -- and this one more clearly describes its function.

Refs #1450.