### PR TITLE
Drop Django 4.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
           - python-version: '3.8'
             django-version: '2.2'
           - python-version: '3.11'
-            django-version: '4.0'
-          - python-version: '3.11'
             django-version: '4.1'
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ This fully working [typed boilerplate](https://github.com/wemake-services/wemake
 
 We rely on different `django` and `mypy` versions:
 
-| django-stubs | Mypy version | Django version | Django partial support | Python version |
-|--------------|--------------|----------------|------------------------|----------------|
-| 4.2.0        | 1.2.x        | 4.2            | 4.1, 4.0, 3.2          | 3.7 - 3.11     |
-| 1.16.0       | 1.1.x        | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
-| 1.15.0       | 1.0.x        | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
-| 1.14.0       | 0.990+       | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
+| django-stubs   | Mypy version | Django version | Django partial support | Python version |
+|----------------|--------------|----------------|------------------------|----------------|
+| (next release) | 1.2.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
+| 4.2.0          | 1.2.x        | 4.2            | 4.1, 4.0, 3.2          | 3.7 - 3.11     |
+| 1.16.0         | 1.1.x        | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
+| 1.15.0         | 1.0.x        | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
+| 1.14.0         | 0.990+       | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |
 
 ## Features
 

--- a/django_stubs_ext/setup.py
+++ b/django_stubs_ext/setup.py
@@ -44,7 +44,6 @@ setup(
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
     ],

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -15,7 +15,6 @@ from scripts.paths import DJANGO_SOURCE_DIRECTORY, PROJECT_DIRECTORY
 DJANGO_COMMIT_REFS = {
     "2.2": "2a62cdcfec85938f40abb2e9e6a9ff497e02afe8",
     "3.2": "007e46d815063d598e0d3db78bfb371100e5c61c",
-    "4.0": "ef62a3a68c9d558486145a42c0d71ea9a76add9e",
     "4.1": "491dccec1aa10e829539e4e4fcd8cca606a57ebc",
     "4.2": "879e5d587b84e6fc961829611999431778eb9f6a",
 }

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
     ],


### PR DESCRIPTION
Django 4.0 has been EOL for 3 weeks, no reason to keep running CI for it (https://endoflife.date/django)

But since we still support Django LTS 3.2, the 4.0 support is likely to continue being functional anyway.
