### PR TITLE
Make `django.conf` constants `Literal`s

### DIFF
--- a/django-stubs/conf/__init__.pyi
+++ b/django-stubs/conf/__init__.pyi
@@ -1,8 +1,8 @@
 from typing import Any
-from typing_extensions import Literal
 
 from _typeshed import Self
 from django.utils.functional import LazyObject
+from typing_extensions import Literal
 
 # explicit dependency on standard settings to make it loaded
 from . import global_settings

--- a/django-stubs/conf/__init__.pyi
+++ b/django-stubs/conf/__init__.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+from typing_extensions import Literal
 
 from _typeshed import Self
 from django.utils.functional import LazyObject
@@ -6,9 +7,9 @@ from django.utils.functional import LazyObject
 # explicit dependency on standard settings to make it loaded
 from . import global_settings
 
-ENVIRONMENT_VARIABLE: str
-PASSWORD_RESET_TIMEOUT_DAYS_DEPRECATED_MSG: str
-DEFAULT_HASHING_ALGORITHM_DEPRECATED_MSG: str
+ENVIRONMENT_VARIABLE: Literal["DJANGO_SETTINGS_MODULE"]
+DEFAULT_STORAGE_ALIASL Literal["default"]
+STATICFILES_STORAGE_ALIAS: Literal["staticfiles"]
 
 # required for plugin to be able to distinguish this specific instance of LazySettings from others
 class _DjangoConfLazyObject(LazyObject):

--- a/django-stubs/conf/__init__.pyi
+++ b/django-stubs/conf/__init__.pyi
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 from . import global_settings
 
 ENVIRONMENT_VARIABLE: Literal["DJANGO_SETTINGS_MODULE"]
-DEFAULT_STORAGE_ALIASL Literal["default"]
+DEFAULT_STORAGE_ALIAS: Literal["default"]
 STATICFILES_STORAGE_ALIAS: Literal["staticfiles"]
 
 # required for plugin to be able to distinguish this specific instance of LazySettings from others


### PR DESCRIPTION
Source: https://github.com/django/django/blob/4.2/django/conf/__init__.py