### PR TITLE
Allow using async StreamingHttpResponse

### DIFF
--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -105,6 +105,7 @@ class HttpResponse(HttpResponseBase, Iterable[bytes]):
     def getvalue(self) -> bytes: ...
 
 class StreamingHttpResponse(HttpResponseBase, Iterable[bytes], AsyncIterable[bytes]):
+    is_async: bool
     streaming_content = _PropertyDescriptor[
         Iterable[object] | AsyncIterable[object], Iterator[bytes] | AsyncIterator[bytes]
     ]()
@@ -114,7 +115,6 @@ class StreamingHttpResponse(HttpResponseBase, Iterable[bytes], AsyncIterable[byt
     def __iter__(self) -> Iterator[bytes]: ...
     def __aiter__(self) -> AsyncIterator[bytes]: ...
     def getvalue(self) -> bytes: ...
-    is_async: bool
 
 class FileResponse(StreamingHttpResponse):
     file_to_stream: BytesIO | None

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -1,8 +1,8 @@
 import datetime
-from collections.abc import Iterable, Iterator
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from io import BytesIO
 from json import JSONEncoder
-from typing import Any, TypeVar, overload, type_check_only
+from typing import Any, Generic, TypeVar, overload, type_check_only
 
 from django.http.cookie import SimpleCookie
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
@@ -104,10 +104,13 @@ class HttpResponse(HttpResponseBase, Iterable[bytes]):
     def __iter__(self) -> Iterator[bytes]: ...
     def getvalue(self) -> bytes: ...
 
-class StreamingHttpResponse(HttpResponseBase, Iterable[bytes]):
-    streaming_content = _PropertyDescriptor[Iterable[object], Iterator[bytes]]()
-    def __init__(self, streaming_content: Iterable[object] = ..., *args: Any, **kwargs: Any) -> None: ...
+_I = TypeVar("_I", Iterable[object], AsyncIterable[object])
+
+class StreamingHttpResponse(HttpResponseBase, Iterable[bytes], AsyncIterable[bytes], Generic[_I]):
+    streaming_content = _PropertyDescriptor[_I, Iterator[bytes] | AsyncIterator[bytes]]()
+    def __init__(self, streaming_content: _I = ..., *args: Any, **kwargs: Any) -> None: ...
     def __iter__(self) -> Iterator[bytes]: ...
+    def __aiter__(self) -> AsyncIterator[bytes]: ...
     def getvalue(self) -> bytes: ...
 
 class FileResponse(StreamingHttpResponse):

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from io import BytesIO
 from json import JSONEncoder
-from typing import Any, Generic, TypeVar, overload, type_check_only
+from typing import Any, TypeVar, overload, type_check_only
 
 from django.http.cookie import SimpleCookie
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
@@ -104,14 +104,17 @@ class HttpResponse(HttpResponseBase, Iterable[bytes]):
     def __iter__(self) -> Iterator[bytes]: ...
     def getvalue(self) -> bytes: ...
 
-_I = TypeVar("_I", Iterable[object], AsyncIterable[object])
-
-class StreamingHttpResponse(HttpResponseBase, Iterable[bytes], AsyncIterable[bytes], Generic[_I]):
-    streaming_content = _PropertyDescriptor[_I, Iterator[bytes] | AsyncIterator[bytes]]()
-    def __init__(self, streaming_content: _I = ..., *args: Any, **kwargs: Any) -> None: ...
+class StreamingHttpResponse(HttpResponseBase, Iterable[bytes], AsyncIterable[bytes]):
+    streaming_content = _PropertyDescriptor[
+        Iterable[object] | AsyncIterable[object], Iterator[bytes] | AsyncIterator[bytes]
+    ]()
+    def __init__(
+        self, streaming_content: Iterable[object] | AsyncIterable[object] = ..., *args: Any, **kwargs: Any
+    ) -> None: ...
     def __iter__(self) -> Iterator[bytes]: ...
     def __aiter__(self) -> AsyncIterator[bytes]: ...
     def getvalue(self) -> bytes: ...
+    is_async: bool
 
 class FileResponse(StreamingHttpResponse):
     file_to_stream: BytesIO | None

--- a/tests/typecheck/views/test_function_based_views.yml
+++ b/tests/typecheck/views/test_function_based_views.yml
@@ -1,5 +1,5 @@
--   case: http_response
-    main: |
+- case: http_response
+  main: |
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -16,8 +16,8 @@
       def object_response(request: HttpRequest) -> HttpResponse:
           return HttpResponse(_('It works!'))
 
--   case: http_response_content
-    main: |
+- case: http_response_content
+  main: |
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -45,8 +45,8 @@
           reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
           return response
 
--   case: streaming_http_response
-    main: |
+- case: streaming_http_response
+  main: |
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -66,8 +66,8 @@
       def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
           return StreamingHttpResponse([_('Yes'), '/', _('No')])
 
--   case: streaming_http_response_streaming_content
-    main: |
+- case: streaming_http_response_streaming_content
+  main: |
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -99,4 +99,74 @@
           response = StreamingHttpResponse()
           response.streaming_content = [_('Yes'), '/', _('No')]
           reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          return response
+
+- case: streaming_http_response_async
+  main: |
+      import typing
+      from django.http.request import HttpRequest
+      from django.http.response import StreamingHttpResponse
+      from django.utils.translation import gettext_lazy as _
+
+      def str_response(request: HttpRequest) -> StreamingHttpResponse:
+          async def str_iterator() -> typing.AsyncIterator[str]:
+              yield 'It works!'
+          return StreamingHttpResponse(str_iterator())
+
+      def bytes_response(request: HttpRequest) -> StreamingHttpResponse:
+          async def bytes_iterator() -> typing.AsyncIterator[bytes]:
+              yield b'It works!'
+          return StreamingHttpResponse(bytes_iterator())
+
+      def object_response(request: HttpRequest) -> StreamingHttpResponse:
+          async def object_iterator() -> typing.AsyncIterator[object]:
+              yield _('It works!')
+          return StreamingHttpResponse(object_iterator())
+
+      def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
+          async def mixed_iterator() -> typing.AsyncIterator[object]:
+              yield _('Yes')
+              yield '/'
+              yield _('No')
+          return StreamingHttpResponse(mixed_iterator())
+
+- case: streaming_http_response_async_streaming_content
+  main: |
+      import typing
+      from django.http.request import HttpRequest
+      from django.http.response import StreamingHttpResponse
+      from django.utils.translation import gettext_lazy as _
+
+      def str_response(request: HttpRequest) -> StreamingHttpResponse:
+          response = StreamingHttpResponse()
+          async def str_iterator() -> typing.AsyncIterator[str]:
+              yield 'It works!'
+          response.streaming_content = str_iterator()
+          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          return response
+
+      def bytes_response(request: HttpRequest) -> StreamingHttpResponse:
+          response = StreamingHttpResponse()
+          async def bytes_iterator() -> typing.AsyncIterator[bytes]:
+              yield b'It works!'
+          response.streaming_content = bytes_iterator()
+          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          return response
+
+      def object_response(request: HttpRequest) -> StreamingHttpResponse:
+          response = StreamingHttpResponse()
+          async def object_iterator() -> typing.AsyncIterator[object]:
+              yield _('It works!')
+          response.streaming_content = object_iterator()
+          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          return response
+
+      def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
+          response = StreamingHttpResponse()
+          async def mixed_iterator() -> typing.AsyncIterator[object]:
+              yield _('Yes')
+              yield '/'
+              yield _('No')
+          response.streaming_content = mixed_iterator()
+          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
           return response

--- a/tests/typecheck/views/test_function_based_views.yml
+++ b/tests/typecheck/views/test_function_based_views.yml
@@ -74,31 +74,31 @@
 
       def empty_response(request: HttpRequest) -> StreamingHttpResponse:
           response = StreamingHttpResponse()
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def str_response(request: HttpRequest) -> StreamingHttpResponse:
           response = StreamingHttpResponse()
           response.streaming_content = ['It works!']
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def bytes_response(request: HttpRequest) -> StreamingHttpResponse:
           response = StreamingHttpResponse()
           response.streaming_content = [b'It works!']
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def object_response(request: HttpRequest) -> StreamingHttpResponse:
           response = StreamingHttpResponse()
           response.streaming_content = [_('It works!')]
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
           response = StreamingHttpResponse()
           response.streaming_content = [_('Yes'), '/', _('No')]
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
 -   case: streaming_http_response_async
@@ -142,11 +142,11 @@
           async def str_iterator() -> typing.AsyncIterator[str]:
               yield 'It works!'
           response.streaming_content = str_iterator()
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def bytes_response(request: HttpRequest) -> StreamingHttpResponse:
-          response = StreamingHttpResponse()
+          response  = StreamingHttpResponse()
           async def bytes_iterator() -> typing.AsyncIterator[bytes]:
               yield b'It works!'
           response.streaming_content = bytes_iterator()
@@ -154,19 +154,19 @@
           return response
 
       def object_response(request: HttpRequest) -> StreamingHttpResponse:
-          response = StreamingHttpResponse()
+          response  = StreamingHttpResponse()
           async def object_iterator() -> typing.AsyncIterator[object]:
               yield _('It works!')
           response.streaming_content = object_iterator()
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response
 
       def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
-          response = StreamingHttpResponse()
+          response  = StreamingHttpResponse()
           async def mixed_iterator() -> typing.AsyncIterator[object]:
               yield _('Yes')
               yield '/'
               yield _('No')
           response.streaming_content = mixed_iterator()
-          reveal_type(response.streaming_content)  # N: Revealed type is "typing.AsyncIterator[builtins.bytes]"
+          reveal_type(response.streaming_content)  # N: Revealed type is "Union[typing.Iterator[builtins.bytes], typing.AsyncIterator[builtins.bytes]]"
           return response

--- a/tests/typecheck/views/test_function_based_views.yml
+++ b/tests/typecheck/views/test_function_based_views.yml
@@ -1,5 +1,5 @@
-- case: http_response
-  main: |
+-   case: http_response
+    main: |
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -16,8 +16,8 @@
       def object_response(request: HttpRequest) -> HttpResponse:
           return HttpResponse(_('It works!'))
 
-- case: http_response_content
-  main: |
+-   case: http_response_content
+    main: |
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -45,8 +45,8 @@
           reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
           return response
 
-- case: streaming_http_response
-  main: |
+-   case: streaming_http_response
+    main: |
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -66,8 +66,8 @@
       def mixed_response(request: HttpRequest) -> StreamingHttpResponse:
           return StreamingHttpResponse([_('Yes'), '/', _('No')])
 
-- case: streaming_http_response_streaming_content
-  main: |
+-   case: streaming_http_response_streaming_content
+    main: |
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -101,8 +101,8 @@
           reveal_type(response.streaming_content)  # N: Revealed type is "typing.Iterator[builtins.bytes]"
           return response
 
-- case: streaming_http_response_async
-  main: |
+-   case: streaming_http_response_async
+    main: |
       import typing
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
@@ -130,8 +130,8 @@
               yield _('No')
           return StreamingHttpResponse(mixed_iterator())
 
-- case: streaming_http_response_async_streaming_content
-  main: |
+-   case: streaming_http_response_async_streaming_content
+    main: |
       import typing
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse


### PR DESCRIPTION
# I have made things!
This is a first attempt at implementing types for async StreamingHttpResponse.

## Related issues
- Closes #1483 

Hello, this is a draft for https://github.com/typeddjango/django-stubs/issues/1483.
I don’t have more time to look at it today, and I don’t know how to properly implement the following:
- if the setter of the property, or the value passed to `__init__` is an `Iterable`, then the getter should be an `Iterator`, but if the setter or the value is an `AsyncIterable`, then the getter should be an `AsyncIterator`. 

I feel I want an overload, but those won’t work with `_PropertyDescriptor`, or a "linked TypeVar", but that doesn’t make sense.  If anyone knows how to do this, feel free to help me. Otherwise I’ll do more research a bit later this week.

