### PR TITLE
Fix type of field attribute descriptors on Model classes (not instance)

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -6,7 +6,6 @@ from datetime import datetime as real_datetime
 from datetime import time, timedelta
 from typing import Any, Generic, Protocol, TypeVar, overload
 
-from _typeshed import Self
 from django.core import validators  # due to weird mypy.stubtest error
 from django.core.checks import CheckMessage
 from django.core.exceptions import FieldDoesNotExist as FieldDoesNotExist
@@ -19,7 +18,7 @@ from django.forms import Field as FormField
 from django.forms import Widget
 from django.utils.datastructures import DictWrapper
 from django.utils.functional import _Getter, _StrOrPromise
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 class Empty: ...
 class NOT_PROVIDED: ...
@@ -33,17 +32,19 @@ _FieldChoices: TypeAlias = Iterable[_Choice | _ChoiceNamedGroup]
 _ChoicesList: TypeAlias = Sequence[_Choice] | Sequence[_ChoiceNamedGroup]
 _LimitChoicesTo: TypeAlias = Q | dict[str, Any]
 
+_F = TypeVar("_F", bound=Field, covariant=True)
+
 class _ChoicesCallable(Protocol):
     def __call__(self) -> _FieldChoices: ...
 
-class _FieldDescriptor(Protocol):
+class _FieldDescriptor(Protocol[_F]):
     """
     Accessing fields of a model class (not instance) returns an object conforming to this protocol.
     Depending on field type this could be DeferredAttribute, ForwardManyToOneDescriptor, FileDescriptor, etc.
     """
 
     @property
-    def field(self) -> Field: ...
+    def field(self) -> _F: ...
 
 _AllLimitChoicesTo: TypeAlias = _LimitChoicesTo | _ChoicesCallable  # noqa: Y047
 _ErrorMessagesT: TypeAlias = dict[str, Any]
@@ -181,7 +182,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     def __set__(self, instance: Any, value: _ST) -> None: ...
     # class access
     @overload
-    def __get__(self: Self, instance: None, owner: Any) -> _FieldDescriptor: ...
+    def __get__(self: Self, instance: None, owner: Any) -> _FieldDescriptor[Self]: ...
     # Model instance access
     @overload
     def __get__(self, instance: Model, owner: Any) -> _GT: ...

--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -36,6 +36,15 @@ _LimitChoicesTo: TypeAlias = Q | dict[str, Any]
 class _ChoicesCallable(Protocol):
     def __call__(self) -> _FieldChoices: ...
 
+class _FieldDescriptor(Protocol):
+    """
+    Accessing fields of a model class (not instance) returns an object conforming to this protocol.
+    Depending on field type this could be DeferredAttribute, ForwardManyToOneDescriptor, FileDescriptor, etc.
+    """
+
+    @property
+    def field(self) -> Field: ...
+
 _AllLimitChoicesTo: TypeAlias = _LimitChoicesTo | _ChoicesCallable  # noqa: Y047
 _ErrorMessagesT: TypeAlias = dict[str, Any]
 
@@ -172,7 +181,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     def __set__(self, instance: Any, value: _ST) -> None: ...
     # class access
     @overload
-    def __get__(self: Self, instance: None, owner: Any) -> Self: ...
+    def __get__(self: Self, instance: None, owner: Any) -> _FieldDescriptor: ...
     # Model instance access
     @overload
     def __get__(self, instance: Model, owner: Any) -> _GT: ...

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -2,7 +2,6 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, TypeVar, overload
 from uuid import UUID
 
-from _typeshed import Self
 from django.core import validators  # due to weird mypy.stubtest error
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable
@@ -22,7 +21,7 @@ from django.db.models.fields.reverse_related import OneToOneRel as OneToOneRel
 from django.db.models.manager import RelatedManager
 from django.db.models.query_utils import FilteredRelation, PathInfo, Q
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal
+from typing_extensions import Literal, Self
 
 RECURSIVE_RELATIONSHIP_CONSTANT: Literal["self"]
 
@@ -94,6 +93,15 @@ class ForeignObject(RelatedField[_ST, _GT]):
         validators: Iterable[validators._ValidatorCallable] = ...,
         error_messages: _ErrorMessagesT | None = ...,
     ) -> None: ...
+    # class access
+    @overload
+    def __get__(self, instance: None, owner: Any) -> ForwardManyToOneDescriptor[Self]: ...
+    # Model instance access
+    @overload
+    def __get__(self, instance: Model, owner: Any) -> _GT: ...
+    # non-Model instances
+    @overload
+    def __get__(self: Self, instance: Any, owner: Any) -> Self: ...
     def resolve_related_fields(self) -> list[tuple[Field, Field]]: ...
     @property
     def related_fields(self) -> list[tuple[Field, Field]]: ...
@@ -143,15 +151,6 @@ class ForeignKey(ForeignObject[_ST, _GT]):
         validators: Iterable[validators._ValidatorCallable] = ...,
         error_messages: _ErrorMessagesT | None = ...,
     ) -> None: ...
-    # class access
-    @overload
-    def __get__(self, instance: None, owner: Any) -> ForwardManyToOneDescriptor: ...
-    # Model instance access
-    @overload
-    def __get__(self, instance: Model, owner: Any) -> _GT: ...
-    # non-Model instances
-    @overload
-    def __get__(self: Self, instance: Any, owner: Any) -> Self: ...
 
 class OneToOneField(ForeignKey[_ST, _GT]):
     _pyi_private_set_type: Any | Combinable
@@ -194,7 +193,7 @@ class OneToOneField(ForeignKey[_ST, _GT]):
     ) -> None: ...
     # class access
     @overload
-    def __get__(self, instance: None, owner: Any) -> ForwardOneToOneDescriptor: ...
+    def __get__(self, instance: None, owner: Any) -> ForwardOneToOneDescriptor[Self]: ...
     # Model instance access
     @overload
     def __get__(self, instance: Model, owner: Any) -> _GT: ...
@@ -254,7 +253,7 @@ class ManyToManyField(RelatedField[_ST, _GT]):
     ) -> None: ...
     # class access
     @overload
-    def __get__(self, instance: None, owner: Any) -> ManyToManyDescriptor: ...
+    def __get__(self, instance: None, owner: Any) -> ManyToManyDescriptor[Self]: ...
     # Model instance access
     @overload
     def __get__(self, instance: Model, owner: Any) -> _GT: ...

--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -5,20 +5,21 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.base import Model
 from django.db.models.fields import Field
 from django.db.models.fields.mixins import FieldCacheMixin
-from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField, RelatedField
+from django.db.models.fields.related import ForeignKey, ForeignObject, ManyToManyField, OneToOneField, RelatedField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel, OneToOneRel
 from django.db.models.manager import RelatedManager
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import DeferredAttribute
 
 _T = TypeVar("_T")
+_F = TypeVar("_F", bound=Field)
 
 class ForeignKeyDeferredAttribute(DeferredAttribute):
     field: RelatedField
 
-class ForwardManyToOneDescriptor:
-    field: ForeignKey
-    def __init__(self, field_with_rel: ForeignKey) -> None: ...
+class ForwardManyToOneDescriptor(Generic[_F]):
+    field: _F
+    def __init__(self, field_with_rel: _F) -> None: ...
     @property
     def RelatedObjectDoesNotExist(self) -> type[ObjectDoesNotExist]: ...
     def is_cached(self, instance: Model) -> bool: ...
@@ -33,8 +34,7 @@ class ForwardManyToOneDescriptor:
     def __set__(self, instance: Model, value: Model | None) -> None: ...
     def __reduce__(self) -> tuple[Callable, tuple[type[Model], str]]: ...
 
-class ForwardOneToOneDescriptor(ForwardManyToOneDescriptor):
-    field: OneToOneField
+class ForwardOneToOneDescriptor(ForwardManyToOneDescriptor[_F]):
     def get_object(self, instance: Model) -> Model: ...
 
 class ReverseOneToOneDescriptor:
@@ -62,8 +62,8 @@ class ReverseManyToOneDescriptor:
 
 def create_reverse_many_to_one_manager(superclass: type, rel: Any) -> type[RelatedManager]: ...
 
-class ManyToManyDescriptor(ReverseManyToOneDescriptor):
-    field: ManyToManyField  # type: ignore[assignment]
+class ManyToManyDescriptor(ReverseManyToOneDescriptor, Generic[_F]):
+    field: _F  # type: ignore[assignment]
     rel: ManyToManyRel  # type: ignore[assignment]
     reverse: bool
     def __init__(self, rel: ManyToManyRel, reverse: bool = ...) -> None: ...

--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -5,7 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.base import Model
 from django.db.models.fields import Field
 from django.db.models.fields.mixins import FieldCacheMixin
-from django.db.models.fields.related import ForeignKey, ForeignObject, ManyToManyField, OneToOneField, RelatedField
+from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField, RelatedField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel, OneToOneRel
 from django.db.models.manager import RelatedManager
 from django.db.models.query import QuerySet

--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -44,7 +44,6 @@ class Q(tree.Node):
     def deconstruct(self) -> tuple[str, tuple, dict[str, str]]: ...
 
 class DeferredAttribute:
-    field_name: str
     field: Field
     def __init__(self, field: Field) -> None: ...
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.980",
+    "mypy>=1.0.0",
     "django",
     "django-stubs-ext>=4.2.0",
     "tomli; python_version < '3.11'",

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -111,7 +111,7 @@
 -   case: if_field_called_on_class_return_field_itself
     main: |
         from myapp.models import MyUser
-        reveal_type(MyUser.name)  # N: Revealed type is "django.db.models.fields.CharField[Union[builtins.str, builtins.int, django.db.models.expressions.Combinable], builtins.str]"
+        reveal_type(MyUser.name.field)  # N: Revealed type is "django.db.models.fields.CharField[Union[builtins.str, builtins.int, django.db.models.expressions.Combinable], builtins.str]"
     installed_apps:
         - myapp
     files:
@@ -127,7 +127,8 @@
         from django.db import models
         class MyClass:
             myfield: models.IntegerField[int, int]
-        reveal_type(MyClass.myfield)  # N: Revealed type is "django.db.models.fields.IntegerField[builtins.int, builtins.int]"
+        reveal_type(MyClass.myfield)  # N: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.IntegerField[builtins.int, builtins.int]]"
+        reveal_type(MyClass.myfield.field)  # N: Revealed type is "django.db.models.fields.IntegerField[builtins.int, builtins.int]"
         reveal_type(MyClass().myfield)  # N: Revealed type is "django.db.models.fields.IntegerField[builtins.int, builtins.int]"
 
 -   case: fields_inside_mixins_used_in_model_subclasses_resolved_as_primitives

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -583,6 +583,8 @@
         reveal_type(Author.blogs)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[django.db.models.fields.related.ManyToManyField[typing.Sequence[myapp.models.Blog], django.db.models.manager.RelatedManager[myapp.models.Blog]]]"
         reveal_type(Blog.publisher)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor[django.db.models.fields.related.ForeignKey[Union[myapp.models.Publisher, django.db.models.expressions.Combinable], myapp.models.Publisher]]"
         reveal_type(Publisher.profile)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardOneToOneDescriptor[django.db.models.fields.related.OneToOneField[Union[myapp.models.Profile, django.db.models.expressions.Combinable], myapp.models.Profile]]"
+        reveal_type(Author.file)  # N: Revealed type is "django.db.models.fields.files.FileDescriptor"
+
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -223,6 +223,7 @@
         from myapp2.models import Profile
         reveal_type(Profile().user)  # N: Revealed type is "myapp.models.user.User"
         reveal_type(Profile().user.profile)  # N: Revealed type is "myapp2.models.Profile"
+        reveal_type(Profile.user.field)  # N: Revealed type is "django.db.models.fields.related.OneToOneField[Union[myapp.models.user.User, django.db.models.expressions.Combinable], myapp.models.user.User]"
     installed_apps:
         - myapp
         - myapp2
@@ -279,6 +280,9 @@
         from myapp.models import App, Member
         reveal_type(Member().apps)  # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.App]"
         reveal_type(App().members)  # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Member]"
+        reveal_type(Member.apps.field)  # N: Revealed type is "django.db.models.fields.related.ManyToManyField[typing.Sequence[myapp.models.App], django.db.models.manager.RelatedManager[myapp.models.App]]"
+        # XXX the following is not correct:
+        reveal_type(App.members)  # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Member]"
     installed_apps:
         - myapp
     files:
@@ -576,9 +580,9 @@
 -   case: test_related_fields_returned_as_descriptors_from_model_class
     main: |
         from myapp.models import Author, Blog, Publisher, Profile
-        reveal_type(Author.blogs)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor"
-        reveal_type(Blog.publisher)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor"
-        reveal_type(Publisher.profile)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardOneToOneDescriptor"
+        reveal_type(Author.blogs)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[django.db.models.fields.related.ManyToManyField[typing.Sequence[myapp.models.Blog], django.db.models.manager.RelatedManager[myapp.models.Blog]]]"
+        reveal_type(Blog.publisher)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor[django.db.models.fields.related.ForeignKey[Union[myapp.models.Publisher, django.db.models.expressions.Combinable], myapp.models.Publisher]]"
+        reveal_type(Publisher.profile)  # N: Revealed type is "django.db.models.fields.related_descriptors.ForwardOneToOneDescriptor[django.db.models.fields.related.OneToOneField[Union[myapp.models.Profile, django.db.models.expressions.Combinable], myapp.models.Profile]]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_related_fields.yml
+++ b/tests/typecheck/models/test_related_fields.yml
@@ -92,7 +92,7 @@
     main: |
       from app1.models import Model1, Model2
 
-      reveal_type(Model2.model_1) # N: Revealed type is "django.db.models.fields.related.ForeignObject[app1.models.Model1, app1.models.Model1]"
+      reveal_type(Model2.model_1.field) # N: Revealed type is "django.db.models.fields.related.ForeignObject[app1.models.Model1, app1.models.Model1]"
       reveal_type(Model2().model_1) # N: Revealed type is "app1.models.Model1"
       reveal_type(Model1.model_2s) # N: Revealed type is "django.db.models.manager.RelatedManager[app1.models.Model2]"
       reveal_type(Model1().model_2s) # N: Revealed type is "django.db.models.manager.RelatedManager[app1.models.Model2]"


### PR DESCRIPTION
For example:

```python
from django.contrib.auth.models import User
User.username
```

Returns `DeferredAttribute` instance, but it was previously typehinted as `Self`, which would be `Field`.

Created a new `_FieldDescriptor` protocol that is compatible with all field descriptor implementations to use on the base `Field` class.

This unblocks mypy 1.3.0 upgrade -- mypy 1.3.0 no longer considered the `__get__` overloads of subclasses (ForeignKey, FileField, etc) compatible, which is correct.

## Related issues

* #1489
