### PR TITLE
Fix logo URL with 'master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/typeddjango/django-stubs/main/logo.svg" alt="django-stubs">
+<img src="https://raw.githubusercontent.com/typeddjango/django-stubs/master/logo.svg" alt="django-stubs">
 
 [![Build status](https://github.com/typeddjango/django-stubs/workflows/test/badge.svg?branch=master&event=push)](https://github.com/typeddjango/django-stubs/actions?query=workflow%3Atest)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)


### PR DESCRIPTION
# I have made things!

Damn, in #1500 I missed that this project still uses a `master` branch not `main`.

## Related issues

#1398