### PR TITLE
fix typo in mypy.ini error message

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -13,7 +13,7 @@ else:
 INI_USAGE = """
 (config)
 ...
-[mypy.plugins.django_stubs]
+[mypy.plugins.django-stubs]
     django_settings_module: str (required)
 ...
 """

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -10,7 +10,7 @@ from mypy_django_plugin.config import DjangoPluginConfig
 TEMPLATE = """
 (config)
 ...
-[mypy.plugins.django_stubs]
+[mypy.plugins.django-stubs]
     django_settings_module: str (required)
 ...
 (django-stubs) mypy: error: {}


### PR DESCRIPTION
copy pasting the error message leads to the same error message again -- only after changing it to a dash does it work correctly