### PR TITLE
CI: Enable Ruff pyupgrade fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,6 @@ repos:
       - id: debug-statements
       - id: check-merge-conflict
       - id: end-of-file-fixer
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.270
     hooks:

--- a/django-stubs/conf/__init__.pyi
+++ b/django-stubs/conf/__init__.pyi
@@ -1,8 +1,7 @@
-from typing import Any
+from typing import Any, Literal
 
 from _typeshed import Self
 from django.utils.functional import LazyObject
-from typing_extensions import Literal
 
 # explicit dependency on standard settings to make it loaded
 from . import global_settings  # noqa: F401

--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -3,9 +3,9 @@ from re import Pattern
 
 # This is defined here as a do-nothing function because we can't import
 # django.utils.translation -- that module depends on the settings.
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 _Admins: TypeAlias = list[tuple[str, str]]
 

--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -1,5 +1,12 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Generic, Literal, TypeVar, Union  # noqa: Y037  # https://github.com/python/mypy/issues/12211
+from typing import (  # noqa: Y037  # https://github.com/python/mypy/issues/12211
+    Any,
+    Generic,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 from django import forms
 from django.contrib.admin.filters import FieldListFilter, ListFilter
@@ -81,7 +88,7 @@ class BaseModelAdmin(Generic[_ModelT]):
     raw_id_fields: Sequence[str]
     fields: _FieldGroups | None
     exclude: Sequence[str] | None
-    fieldsets: _FieldsetSpec | None
+    fieldsets: Optional[_FieldsetSpec]  # noqa: UP007
     form: type[forms.ModelForm[_ModelT]]
     filter_vertical: Sequence[str]
     filter_horizontal: Sequence[str]

--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Generic, Optional, TypeVar, Union  # noqa: Y037  # https://github.com/python/mypy/issues/12211
+from typing import Any, Generic, Literal, TypeVar, Union  # noqa: Y037  # https://github.com/python/mypy/issues/12211
 
 from django import forms
 from django.contrib.admin.filters import FieldListFilter, ListFilter
@@ -33,7 +33,7 @@ from django.urls.resolvers import URLPattern
 from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _StrOrPromise
 from django.utils.safestring import SafeString
-from typing_extensions import Literal, TypeAlias, TypedDict
+from typing_extensions import TypeAlias, TypedDict
 
 IS_POPUP_VAR: str
 TO_FIELD_VAR: str
@@ -81,7 +81,7 @@ class BaseModelAdmin(Generic[_ModelT]):
     raw_id_fields: Sequence[str]
     fields: _FieldGroups | None
     exclude: Sequence[str] | None
-    fieldsets: Optional[_FieldsetSpec]  # noqa: UP007
+    fieldsets: _FieldsetSpec | None
     form: type[forms.ModelForm[_ModelT]]
     filter_vertical: Sequence[str]
     filter_horizontal: Sequence[str]

--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -81,7 +81,7 @@ class BaseModelAdmin(Generic[_ModelT]):
     raw_id_fields: Sequence[str]
     fields: _FieldGroups | None
     exclude: Sequence[str] | None
-    fieldsets: Optional[_FieldsetSpec]
+    fieldsets: Optional[_FieldsetSpec]  # noqa: UP007
     form: type[forms.ModelForm[_ModelT]]
     filter_vertical: Sequence[str]
     filter_horizontal: Sequence[str]

--- a/django-stubs/contrib/admin/utils.pyi
+++ b/django-stubs/contrib/admin/utils.pyi
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, overload
+from typing import Any, Literal, overload
 from uuid import UUID
 
 from django.contrib.admin.options import BaseModelAdmin
@@ -15,7 +15,7 @@ from django.forms.forms import BaseForm
 from django.forms.formsets import BaseFormSet
 from django.http.request import HttpRequest
 from django.utils.datastructures import _IndexableCollection
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 class FieldIsAForeignKeyColumnName(Exception): ...
 

--- a/django-stubs/contrib/admin/views/main.pyi
+++ b/django-stubs/contrib/admin/views/main.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from django.contrib.admin.filters import ListFilter
 from django.contrib.admin.options import ModelAdmin, _DisplayT, _ListFilterT
@@ -9,7 +9,6 @@ from django.db.models.options import Options
 from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
 from django.http.request import HttpRequest
-from typing_extensions import Literal
 
 ALL_VAR: str
 ORDER_VAR: str

--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -1,10 +1,9 @@
-from typing import Any, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 from django.db import models
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable
 from django.db.models.fields import BooleanField
-from typing_extensions import Literal
 
 _T = TypeVar("_T", bound=Model)
 

--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from django.contrib.auth.base_user import AbstractBaseUser as AbstractBaseUser
 from django.contrib.auth.base_user import BaseUserManager as BaseUserManager
@@ -10,7 +10,7 @@ from django.db.models import QuerySet
 from django.db.models.base import Model
 from django.db.models.manager import EmptyManager
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 _AnyUser: TypeAlias = Model | AnonymousUser
 

--- a/django-stubs/contrib/gis/db/backends/postgis/operations.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/operations.pyi
@@ -1,10 +1,9 @@
-from typing import Any
+from typing import Any, Literal
 
 from django.contrib.gis.db.backends.base.operations import BaseSpatialOperations
 from django.contrib.gis.db.backends.utils import SpatialOperator
 from django.db.backends.postgresql.operations import DatabaseOperations
 from django.db.models import Func
-from typing_extensions import Literal
 
 BILATERAL: Literal["bilateral"]
 

--- a/django-stubs/contrib/gis/gdal/layer.pyi
+++ b/django-stubs/contrib/gis/gdal/layer.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, AnyStr, overload
+from typing import Any, AnyStr, Literal, overload
 
 from django.contrib.gis.gdal.base import GDALBase
 from django.contrib.gis.gdal.envelope import Envelope
@@ -9,7 +9,6 @@ from django.contrib.gis.gdal.geometries import OGRGeometry
 from django.contrib.gis.gdal.geomtype import OGRGeomType
 from django.contrib.gis.gdal.srs import SpatialReference
 from django.contrib.gis.geos.geometry import GEOSGeometry
-from typing_extensions import Literal
 
 class Layer(GDALBase):
     ptr: Any

--- a/django-stubs/contrib/gis/gdal/raster/band.pyi
+++ b/django-stubs/contrib/gis/gdal/raster/band.pyi
@@ -1,7 +1,6 @@
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from django.contrib.gis.gdal.raster.base import GDALRasterBase
-from typing_extensions import Literal
 
 class GDALBand(GDALRasterBase):
     source: Any

--- a/django-stubs/contrib/postgres/fields/ranges.pyi
+++ b/django-stubs/contrib/postgres/fields/ranges.pyi
@@ -1,9 +1,8 @@
-from typing import Any
+from typing import Any, Literal
 
 from django.db import models
 from django.db.models.lookups import PostgresOperatorLookup
 from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
-from typing_extensions import Literal
 
 class RangeBoundary(models.Expression):
     lower: str

--- a/django-stubs/contrib/postgres/operations.pyi
+++ b/django-stubs/contrib/postgres/operations.pyi
@@ -1,7 +1,8 @@
+from typing import Literal
+
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations import AddConstraint, AddIndex, RemoveIndex
 from django.db.migrations.operations.base import Operation
-from typing_extensions import Literal
 
 class CreateExtension(Operation):
     reversible: bool

--- a/django-stubs/contrib/staticfiles/finders.pyi
+++ b/django-stubs/contrib/staticfiles/finders.pyi
@@ -1,9 +1,8 @@
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.files.storage import FileSystemStorage, Storage
-from typing_extensions import Literal
 
 searched_locations: Any
 

--- a/django-stubs/core/exceptions.pyi
+++ b/django-stubs/core/exceptions.pyi
@@ -1,8 +1,7 @@
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Literal
 
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal
 
 class FieldDoesNotExist(Exception): ...
 class AppRegistryNotReady(Exception): ...

--- a/django-stubs/core/management/base.pyi
+++ b/django-stubs/core/management/base.pyi
@@ -1,12 +1,11 @@
 from argparse import ArgumentParser, HelpFormatter, Namespace
 from collections.abc import Callable, Iterable, Sequence
 from io import TextIOBase
-from typing import Any, TextIO
+from typing import Any, Literal, TextIO
 
 from django.apps.config import AppConfig
 from django.core.management.color import Style
 from django.utils.datastructures import _ListOrTuple
-from typing_extensions import Literal
 
 class CommandError(Exception):
     def __init__(self, *args: Any, returncode: int = ..., **kwargs: Any) -> None: ...

--- a/django-stubs/db/backends/mysql/base.pyi
+++ b/django-stubs/db/backends/mysql/base.pyi
@@ -1,8 +1,7 @@
 from collections.abc import Container, Iterator
-from typing import Any
+from typing import Any, Literal
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from typing_extensions import Literal
 
 from .client import DatabaseClient
 from .creation import DatabaseCreation

--- a/django-stubs/db/backends/utils.pyi
+++ b/django-stubs/db/backends/utils.pyi
@@ -4,11 +4,11 @@ from contextlib import contextmanager
 from decimal import Decimal
 from logging import Logger
 from types import TracebackType
-from typing import Any, Protocol, overload
+from typing import Any, Literal, Protocol, overload
 from uuid import UUID
 
 from _typeshed import Self
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 logger: Logger
 

--- a/django-stubs/db/migrations/operations/special.pyi
+++ b/django-stubs/db/migrations/operations/special.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, Optional, Protocol
+from typing import Any, Literal, Protocol
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
@@ -16,18 +16,14 @@ class SeparateDatabaseAndState(Operation):
 
 class RunSQL(Operation):
     noop: Literal[""]
-    sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]  # noqa: UP007
-    reverse_sql: str | None | _ListOrTuple[
-        str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]  # noqa: UP007
-    ]
+    sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | _ListOrTuple[str] | None]]
+    reverse_sql: str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | _ListOrTuple[str] | None]]
     state_operations: Sequence[Operation]
     hints: Mapping[str, Any]
     def __init__(
         self,
-        sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]],  # noqa: UP007
-        reverse_sql: (
-            str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]  # noqa: UP007
-        ) = ...,
+        sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | _ListOrTuple[str] | None]],
+        reverse_sql: str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | _ListOrTuple[str] | None]] = ...,
         state_operations: Sequence[Operation] = ...,
         hints: Mapping[str, Any] | None = ...,
         elidable: bool = ...,

--- a/django-stubs/db/migrations/operations/special.pyi
+++ b/django-stubs/db/migrations/operations/special.pyi
@@ -1,10 +1,9 @@
 from collections.abc import Mapping, Sequence
-from typing import Any, Optional, Protocol  # noqa: Y037  # https://github.com/python/mypy/issues/12211
+from typing import Any, Literal, Optional, Protocol
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 from django.utils.datastructures import _ListOrTuple
-from typing_extensions import Literal
 
 from .base import Operation
 
@@ -17,14 +16,18 @@ class SeparateDatabaseAndState(Operation):
 
 class RunSQL(Operation):
     noop: Literal[""]
-    sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]
-    reverse_sql: str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]
+    sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]  # noqa: UP007
+    reverse_sql: str | None | _ListOrTuple[
+        str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]  # noqa: UP007
+    ]
     state_operations: Sequence[Operation]
     hints: Mapping[str, Any]
     def __init__(
         self,
-        sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]],
-        reverse_sql: str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]] = ...,
+        sql: str | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]],  # noqa: UP007
+        reverse_sql: (
+            str | None | _ListOrTuple[str | tuple[str, dict[str, Any] | Optional[_ListOrTuple[str]]]]  # noqa: UP007
+        ) = ...,
         state_operations: Sequence[Operation] = ...,
         hints: Mapping[str, Any] | None = ...,
         elidable: bool = ...,

--- a/django-stubs/db/migrations/operations/utils.pyi
+++ b/django-stubs/db/migrations/operations/utils.pyi
@@ -1,9 +1,9 @@
 from collections import namedtuple
 from collections.abc import Iterator
+from typing import Literal
 
 from django.db.migrations.state import ModelState, ProjectState
 from django.db.models import Field, Model
-from typing_extensions import Literal
 
 def resolve_relation(
     model: str | type[Model], app_label: str | None = ..., model_name: str | None = ...

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 
 from _typeshed import Self
 from django.core.checks.messages import CheckMessage
@@ -8,7 +8,6 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import BaseConstraint, Field
 from django.db.models.manager import BaseManager
 from django.db.models.options import Options
-from typing_extensions import Final
 
 _Self = TypeVar("_Self", bound=Model)
 

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -1,7 +1,7 @@
 import datetime
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from _typeshed import Self
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -11,7 +11,7 @@ from django.db.models.lookups import Lookup, Transform
 from django.db.models.query import QuerySet
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from django.db.models.sql.query import Query
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 class SQLiteNumericMixin:
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 from uuid import UUID
 
 from django.core import validators  # due to weird mypy.stubtest error
@@ -21,7 +21,7 @@ from django.db.models.fields.reverse_related import OneToOneRel as OneToOneRel
 from django.db.models.manager import RelatedManager
 from django.db.models.query_utils import FilteredRelation, PathInfo, Q
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal, Self
+from typing_extensions import Self
 
 RECURSIVE_RELATIONSHIP_CONSTANT: Literal["self"]
 

--- a/django-stubs/db/models/fields/reverse_related.pyi
+++ b/django-stubs/db/models/fields/reverse_related.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from django.db.models.base import Model
 from django.db.models.fields import AutoField, Field, _AllLimitChoicesTo, _ChoicesList, _LimitChoicesTo
@@ -7,7 +7,6 @@ from django.db.models.fields.related import ForeignKey, ForeignObject, ManyToMan
 from django.db.models.lookups import Lookup, StartsWith
 from django.db.models.query_utils import FilteredRelation, PathInfo
 from django.db.models.sql.where import WhereNode
-from typing_extensions import Literal
 
 from .mixins import FieldCacheMixin
 

--- a/django-stubs/db/models/lookups.pyi
+++ b/django-stubs/db/models/lookups.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from _typeshed import Self
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -7,7 +7,6 @@ from django.db.models.expressions import Expression, Func
 from django.db.models.query_utils import RegisterLookupMixin
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType, _ParamT
 from django.utils.datastructures import OrderedSet
-from typing_extensions import Literal
 
 _T = TypeVar("_T")
 

--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -1,5 +1,12 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, Generic, TypeVar, Union, overload  # noqa: Y037   # https://github.com/python/mypy/issues/12211
+from typing import (  # noqa: Y037   # https://github.com/python/mypy/issues/12211
+    Any,
+    Generic,
+    Literal,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from django.apps.config import AppConfig
 from django.apps.registry import Apps
@@ -14,7 +21,7 @@ from django.db.models.manager import Manager
 from django.db.models.query_utils import PathInfo
 from django.utils.datastructures import ImmutableList, _ListOrTuple
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 PROXY_PARENTS: object
 EMPTY_RELATION_TREE: Any

--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.base import Model
@@ -12,7 +12,6 @@ from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from django.db.models.sql.query import Query
 from django.db.models.sql.where import WhereNode
 from django.utils import tree
-from typing_extensions import Literal
 
 PathInfo = namedtuple(
     "PathInfo", ["from_opts", "to_opts", "target_fields", "join_field", "m2m", "direct", "filtered_relation"]

--- a/django-stubs/db/models/sql/compiler.pyi
+++ b/django-stubs/db/models/sql/compiler.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, overload
+from typing import Any, Literal, overload
 from uuid import UUID
 
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -10,7 +10,7 @@ from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression, Expression
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import AggregateQuery, DeleteQuery, InsertQuery, UpdateQuery
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 _ParamT: TypeAlias = str | int
 

--- a/django-stubs/db/models/sql/constants.pyi
+++ b/django-stubs/db/models/sql/constants.pyi
@@ -1,6 +1,5 @@
 from re import Pattern
-
-from typing_extensions import Final, Literal
+from typing import Final, Literal
 
 GET_ITERATOR_CHUNK_SIZE: Final[int]
 

--- a/django-stubs/db/models/sql/query.pyi
+++ b/django-stubs/db/models/sql/query.pyi
@@ -1,7 +1,7 @@
 import collections
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Iterator, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.utils import CursorWrapper
@@ -13,7 +13,6 @@ from django.db.models.query_utils import PathInfo
 from django.db.models.sql.compiler import SQLCompiler
 from django.db.models.sql.datastructures import BaseTable, Join
 from django.db.models.sql.where import WhereNode
-from typing_extensions import Literal
 
 JoinInfo = namedtuple("JoinInfo", ("final_field", "targets", "opts", "joins", "path", "transform_function"))
 

--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -3,6 +3,7 @@ from typing import (  # noqa: Y037  # https://github.com/python/mypy/issues/1221
     Any,
     ClassVar,
     Generic,
+    Literal,
     TypeVar,
     Union,
     overload,
@@ -23,7 +24,7 @@ from django.forms.utils import ErrorList, _DataT, _FilesT
 from django.forms.widgets import Widget
 from django.utils.datastructures import _IndexableCollection, _ListOrTuple, _PropertyDescriptor
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 ALL_FIELDS: Literal["__all__"]
 

--- a/django-stubs/forms/widgets.pyi
+++ b/django-stubs/forms/widgets.pyi
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from django.core.files.base import File
 from django.db.models.fields import _FieldChoices
@@ -9,7 +9,7 @@ from django.forms.utils import _DataT, _FilesT
 from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _Getter
 from django.utils.safestring import SafeString
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 _OptAttrs: TypeAlias = dict[str, Any]
 

--- a/django-stubs/http/multipartparser.pyi
+++ b/django-stubs/http/multipartparser.pyi
@@ -1,9 +1,8 @@
 from collections.abc import Iterator, Mapping
-from typing import IO, Any
+from typing import IO, Any, Literal
 
 from django.http.request import QueryDict
 from django.utils.datastructures import ImmutableList, MultiValueDict
-from typing_extensions import Literal
 
 class MultiPartParserError(Exception): ...
 class InputStreamExhausted(Exception): ...

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from re import Pattern
-from typing import Any, BinaryIO, NoReturn, TypeVar, overload
+from typing import Any, BinaryIO, Literal, NoReturn, TypeVar, overload
 
 from _typeshed import Self
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -11,7 +11,7 @@ from django.contrib.sites.models import Site
 from django.core.files import uploadedfile, uploadhandler
 from django.urls import ResolverMatch
 from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, MultiValueDict
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 RAISE_ERROR: object
 host_validation_re: Pattern[str]

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -2,11 +2,10 @@ import datetime
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from io import BytesIO
 from json import JSONEncoder
-from typing import Any, TypeVar, overload, type_check_only
+from typing import Any, Literal, TypeVar, overload, type_check_only
 
 from django.http.cookie import SimpleCookie
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
-from typing_extensions import Literal
 
 class BadHeaderError(ValueError): ...
 

--- a/django-stubs/shortcuts.pyi
+++ b/django-stubs/shortcuts.pyi
@@ -1,11 +1,10 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Protocol, TypeVar, overload
+from typing import Any, Literal, Protocol, TypeVar, overload
 
 from django.db.models import Manager, QuerySet
 from django.db.models.base import Model
 from django.http import HttpRequest
 from django.http.response import HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect
-from typing_extensions import Literal
 
 def render(
     request: HttpRequest | None,

--- a/django-stubs/test/runner.pyi
+++ b/django-stubs/test/runner.pyi
@@ -3,14 +3,13 @@ from argparse import ArgumentParser
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from io import StringIO
-from typing import Any
+from typing import Any, Literal
 from unittest import TestCase, TestLoader, TestSuite, TextTestResult, TextTestRunner
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.test.testcases import SimpleTestCase
 from django.test.utils import TimeKeeperProtocol
 from django.utils.datastructures import OrderedSet
-from typing_extensions import Literal
 
 class DebugSQLTextTestResult(TextTestResult):
     buffer: bool

--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -5,7 +5,7 @@ from decimal import Decimal
 from io import StringIO
 from logging import Logger
 from types import TracebackType
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, SupportsIndex, TypeVar
 
 from _typeshed import Self
 from django.apps.registry import Apps
@@ -16,7 +16,7 @@ from django.db.models.lookups import Lookup, Transform
 from django.db.models.query_utils import RegisterLookupMixin
 from django.test.runner import DiscoverRunner
 from django.test.testcases import SimpleTestCase
-from typing_extensions import SupportsIndex, TypeAlias
+from typing_extensions import TypeAlias
 
 _TestClass: TypeAlias = type[SimpleTestCase]
 

--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -1,8 +1,7 @@
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from django.urls.resolvers import ResolverMatch
-from typing_extensions import Literal
 
 def resolve(path: str, urlconf: str | None = ...) -> ResolverMatch: ...
 def reverse(

--- a/django-stubs/utils/dateformat.pyi
+++ b/django-stubs/utils/dateformat.pyi
@@ -2,10 +2,9 @@ from datetime import date
 from datetime import datetime as builtin_datetime
 from datetime import time as builtin_time
 from re import Pattern
-from typing import Any
+from typing import Any, Literal
 
 from django.utils.timezone import _TzInfoT
-from typing_extensions import Literal
 
 re_formatchars: Pattern[str]
 re_escaped: Pattern[str]

--- a/django-stubs/utils/encoding.pyi
+++ b/django-stubs/utils/encoding.pyi
@@ -1,9 +1,9 @@
 import datetime
 from decimal import Decimal
-from typing import Any, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 from django.utils.functional import Promise
-from typing_extensions import Literal, TypeGuard
+from typing_extensions import TypeGuard
 
 class DjangoUnicodeDecodeError(UnicodeDecodeError):
     obj: bytes

--- a/django-stubs/utils/functional.pyi
+++ b/django-stubs/utils/functional.pyi
@@ -1,9 +1,9 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Generic, Protocol, TypeVar, overload
+from typing import Any, Generic, Protocol, SupportsIndex, TypeVar, overload
 
 from _typeshed import Self
 from django.db.models.base import Model
-from typing_extensions import SupportsIndex, TypeAlias
+from typing_extensions import TypeAlias
 
 _T = TypeVar("_T")
 

--- a/django-stubs/utils/timezone.pyi
+++ b/django-stubs/utils/timezone.pyi
@@ -1,11 +1,11 @@
 from contextlib import ContextDecorator
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from types import TracebackType
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 import pytz
 from pytz import BaseTzInfo
-from typing_extensions import Literal, TypeAlias, TypeGuard
+from typing_extensions import TypeAlias, TypeGuard
 
 _PytzTzInfoT: TypeAlias = pytz.tzinfo.BaseTzInfo | pytz._FixedOffset
 

--- a/django-stubs/utils/translation/trans_real.pyi
+++ b/django-stubs/utils/translation/trans_real.pyi
@@ -4,10 +4,10 @@ from gettext import NullTranslations
 from re import Pattern
 
 # switch to tuple once https://github.com/python/mypy/issues/11098 is fixed
-from typing import Any, Protocol, Tuple, TypeVar  # noqa: Y022
+from typing import Any, Literal, Protocol, Tuple, TypeVar  # noqa: Y022
 
 from django.http.request import HttpRequest
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 CONTEXT_SEPARATOR: Literal["\x04"]
 accept_language_re: Pattern[str]

--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from django.db import models
 from django.forms.forms import BaseForm
@@ -7,7 +7,6 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.datastructures import _ListOrTuple
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
-from typing_extensions import Literal
 
 _FormT = TypeVar("_FormT", bound=BaseForm)
 _ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ target-version = "py38"
 select = [
     "I",    # isort
     "F401", # Unused imports
+    "UP",   # pyupgrade
 ]
 
 [tool.ruff.isort]

--- a/tests/typecheck/db/migrations/test_operations.yml
+++ b/tests/typecheck/db/migrations/test_operations.yml
@@ -16,5 +16,5 @@
 
      RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])], reverse_sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])])
 
-     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "Tuple[str, Dict[<nothing>, <nothing>]]"; expected "Union[str, Union[List[Union[str, Tuple[str, Union[Dict[str, Any], List[str], Tuple[str, ...], Tuple[], None]]]], Tuple[Union[str, Tuple[str, Union[Dict[str, Any], List[str], Tuple[str, ...], Tuple[], None]]], ...], Tuple[]]]"
+     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "Tuple[str, Dict[<nothing>, <nothing>]]"; expected "Union[str, Union[List[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[]], None]]]], Tuple[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[]], None]]], ...], Tuple[]]]"
      RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", [object(), "ANOTHER PARAM"])]) # E: List item 0 has incompatible type "object"; expected "str"


### PR DESCRIPTION
As mentioned in https://github.com/typeddjango/djangorestframework-stubs/pull/399#issuecomment-1531053894, previously `pre-commit` was only running `pyupgrade` on `.py` files and not `.pyi` files.

Running via Ruff will apply to all files.
