### PR TITLE
Fix stub for `send_mass_email` (issue #1515)

### DIFF
--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -26,7 +26,7 @@ def send_mail(
     html_message: str | None = ...,
 ) -> int: ...
 def send_mass_mail(
-    datatuple: Iterable[tuple[str, str, str, list[str]]],
+    datatuple: Iterable[tuple[str, str, str | None, list[str]]],
     fail_silently: bool = ...,
     auth_user: str | None = ...,
     auth_password: str | None = ...,


### PR DESCRIPTION
# I have made things!

Fix the type stub to allow `None` as From email in `send_mass_mail`.

## Related issues

- Closes #1515 

## Notes

I couldn't run the pre-commit script... It fails and prints
```
An unexpected error has occurred: CalledProcessError: command: ('/home/dorian/Programs/github/django-stubs/venv/bin/python3', '-mvirtualenv', '/home/dorian/.cache/pre-commit/repogfv8g2v3/py_env-python3.9', '-p', 'python3.9')
return code: 1
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.9'
stderr: (none)
```

