### PR TITLE
django-stubs-ext: Add TypedDatabaseRouter as database router base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ class MyModel(models.Model):
         ]
 ```
 
+### Other typed base classes
+
+* `django_stubs_ext.db.router.TypedDatabaseRouter` can be used as base when implementing custom database routers.
 
 ## FAQ
 

--- a/django_stubs_ext/django_stubs_ext/db/router.py
+++ b/django_stubs_ext/django_stubs_ext/db/router.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.db.models import Model
+
+    class TypedDatabaseRouter:
+        """
+        Typed base class for Django's DATABASE_ROUTERS setting. At runtime this is just an alias to `object`.
+
+        All methods are optional.
+
+        Django documentation: https://docs.djangoproject.com/en/dev/topics/db/multi-db/#automatic-database-routing
+        """
+
+        def db_for_read(self, model: type[Model], **hints: Any) -> str | None:
+            ...
+
+        def db_for_write(self, model: type[Model], **hints: Any) -> str | None:
+            ...
+
+        def allow_relation(self, obj1: type[Model], obj2: type[Model], **hints: Any) -> bool | None:
+            ...
+
+        def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints: Any) -> bool | None:
+            ...
+
+else:
+    TypedDatabaseRouter = object

--- a/django_stubs_ext/django_stubs_ext/db/router.py
+++ b/django_stubs_ext/django_stubs_ext/db/router.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
         All methods are optional.
 
-        Django documentation: https://docs.djangoproject.com/en/dev/topics/db/multi-db/#automatic-database-routing
+        Django documentation: https://docs.djangoproject.com/en/stable/topics/db/multi-db/#automatic-database-routing
         """
 
         def db_for_read(self, model: Type[Model], **hints: Any) -> Optional[str]:

--- a/django_stubs_ext/django_stubs_ext/db/router.py
+++ b/django_stubs_ext/django_stubs_ext/db/router.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Type
 
 if TYPE_CHECKING:
     from typing import Any
@@ -14,16 +14,18 @@ if TYPE_CHECKING:
         Django documentation: https://docs.djangoproject.com/en/dev/topics/db/multi-db/#automatic-database-routing
         """
 
-        def db_for_read(self, model: type[Model], **hints: Any) -> str | None:
+        def db_for_read(self, model: Type[Model], **hints: Any) -> Optional[str]:
             ...
 
-        def db_for_write(self, model: type[Model], **hints: Any) -> str | None:
+        def db_for_write(self, model: Type[Model], **hints: Any) -> Optional[str]:
             ...
 
-        def allow_relation(self, obj1: type[Model], obj2: type[Model], **hints: Any) -> bool | None:
+        def allow_relation(self, obj1: Type[Model], obj2: Type[Model], **hints: Any) -> Optional[bool]:
             ...
 
-        def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints: Any) -> bool | None:
+        def allow_migrate(
+            self, db: str, app_label: str, model_name: Optional[str] = None, **hints: Any
+        ) -> Optional[bool]:
             ...
 
 else:


### PR DESCRIPTION
Base class for Django database routers. Django documentation: https://docs.djangoproject.com/en/dev/topics/db/multi-db/#automatic-database-routing

Modeled after the `TypedModelMeta` feature implemented in #1375, #1456.
