### PR TITLE
Implement GDAL-related updates in Django 4.2

### DIFF
--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -120,7 +120,7 @@ class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):
     arity: int
     geom_param_pos: Any
 
-class IsEmpty(GeoFuncMixin, Transform):
+class IsEmpty(GeoFuncMixin, StandardTransform):
     lookup_name: str
     output_field: Any
 

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -96,6 +96,14 @@ class Envelope(GeomOutputGeoFunc):
 class ForcePolygonCW(GeomOutputGeoFunc):
     arity: int
 
+class FromWKB(GeoFunc):
+    output_field: Any
+    arity: int
+
+class FromWKT(GeoFunc):
+    output_field: Any
+    arity: int
+
 class GeoHash(GeoFunc):
     output_field: Any
     def __init__(self, expression: Any, precision: Any | None = ..., **extra: Any) -> None: ...
@@ -111,6 +119,10 @@ class GeometryDistance(GeoFunc):
 class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):
     arity: int
     geom_param_pos: Any
+
+class IsEmpty(GeoFuncMixin, Transform):
+    lookup_name: str
+    output_field: Any
 
 class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
     lookup_name: str

--- a/django-stubs/contrib/gis/gdal/raster/source.pyi
+++ b/django-stubs/contrib/gis/gdal/raster/source.pyi
@@ -1,4 +1,6 @@
 from collections.abc import Sequence
+from ctypes import c_void_p
+from pathlib import Path
 from typing import Any
 
 from django.contrib.gis.gdal.driver import Driver
@@ -20,7 +22,7 @@ class TransformPoint(list[Sequence[float]]):
 
 class GDALRaster(GDALRasterBase):
     destructor: Any
-    def __init__(self, ds_input: Any, write: bool = ...) -> None: ...
+    def __init__(self, ds_input: str | Path | bytes | dict | c_void_p, write: bool = ...) -> None: ...
     def __del__(self) -> None: ...
     @property
     def vsi_buffer(self) -> bytes | None: ...
@@ -57,6 +59,7 @@ class GDALRaster(GDALRasterBase):
     @property
     def bands(self) -> BandList: ...
     def warp(self, ds_input: Any, resampling: str = ..., max_error: float = ...) -> GDALRaster: ...
+    def clone(self, name: str | None = ...) -> GDALRaster: ...
     def transform(
         self,
         srs: SpatialReference | int | str,


### PR DESCRIPTION
This is the implementation of the Django 4.2 updates related to GIS. 
I feel this is not the most useful PR, because the GIS module is overall mostly not typed (except some places, it’s a lot of `Any`, but at least it’s adding the new class and methods.

Also, because I very rarely used this module, I didn’t try to get fancy with the typing.

## Related issues
- Refs #1519 (GIS-related points)
