### PR TITLE
Update patch.py to fix generic UserCreationForm

### DIFF
--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -4,7 +4,6 @@ from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 from django import VERSION
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
-from django.contrib.auth.forms import UserCreationForm
 from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
@@ -20,6 +19,10 @@ from django.utils.connection import BaseConnectionHandler
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
+
+from django.utils.module_loading import import_string
+
+UserCreationForm = import_string("django.contrib.auth.forms.UserCreationForm")
 
 __all__ = ["monkeypatch"]
 

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -2,8 +2,10 @@ import builtins
 from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 
 from django import VERSION
+from django.conf import settings
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
+from django.contrib.auth.forms import UserCreationForm
 from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
@@ -19,9 +21,7 @@ from django.utils.connection import BaseConnectionHandler
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
-from django.contrib.auth.forms import UserCreationForm
 
-from django.conf import settings
 settings.configure()
 
 __all__ = ["monkeypatch"]

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -3,6 +3,9 @@ from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 
 from django import VERSION
 from django.conf import settings
+
+settings.configure()
+
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
 from django.contrib.auth.forms import UserCreationForm
@@ -21,8 +24,6 @@ from django.utils.connection import BaseConnectionHandler
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
-
-settings.configure()
 
 __all__ = ["monkeypatch"]
 

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 from django import VERSION
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
+from django.contrib.auth.forms import UserCreationForm
 from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
@@ -66,6 +67,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(FileProxyMixin),
     MPGeneric(Lookup),
     MPGeneric(BaseConnectionHandler),
+    MPGeneric(UserCreationForm),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -16,11 +16,10 @@ from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseModelForm, BaseModelFormSet
 from django.utils.connection import BaseConnectionHandler
+from django.utils.module_loading import import_string
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
-
-from django.utils.module_loading import import_string
 
 UserCreationForm = import_string("django.contrib.auth.forms.UserCreationForm")
 

--- a/django_stubs_ext/django_stubs_ext/patch.py
+++ b/django_stubs_ext/django_stubs_ext/patch.py
@@ -16,12 +16,13 @@ from django.db.models.query import QuerySet
 from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseModelForm, BaseModelFormSet
 from django.utils.connection import BaseConnectionHandler
-from django.utils.module_loading import import_string
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
+from django.contrib.auth.forms import UserCreationForm
 
-UserCreationForm = import_string("django.contrib.auth.forms.UserCreationForm")
+from django.conf import settings
+settings.configure()
 
 __all__ = ["monkeypatch"]
 


### PR DESCRIPTION
# I have made things!

This fixes the below error I'm getting:

```
 | apps_tenants/ticket_system/forms.py:41: error: Missing type parameters for generic type "UserCreationForm"  [type-arg]
mypy      | apps_tenants/ticket_system/forms.py:103: error: Missing type parameters for generic type "UserCreationForm"  [type-arg]
mypy      | 
mypy      | See https://zulip.readthedocs.io/en/latest/testing/mypy.html for debugging tips.
```