### PR TITLE
Use Mapping instead of dict for test Client headers, add missing RequestFactory parameter

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -70,7 +70,9 @@ class _RequestFactory(Generic[_T]):
     defaults: dict[str, str]
     cookies: SimpleCookie
     errors: BytesIO
-    def __init__(self, *, json_encoder: type[JSONEncoder] = ..., **defaults: Any) -> None: ...
+    def __init__(
+        self, *, json_encoder: type[JSONEncoder] = ..., headers: Mapping[str, Any] | None = ..., **defaults: Any
+    ) -> None: ...
     def request(self, **request: Any) -> _T: ...
     def get(
         self,
@@ -78,7 +80,7 @@ class _RequestFactory(Generic[_T]):
         data: _GetDataType = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def post(
@@ -88,13 +90,13 @@ class _RequestFactory(Generic[_T]):
         content_type: str = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def head(
-        self, path: str, data: Any = ..., secure: bool = ..., *, headers: dict[str, Any] | None = ..., **extra: Any
+        self, path: str, data: Any = ..., secure: bool = ..., *, headers: Mapping[str, Any] | None = ..., **extra: Any
     ) -> _T: ...
-    def trace(self, path: str, secure: bool = ..., *, headers: dict[str, Any] | None = ..., **extra: Any) -> _T: ...
+    def trace(self, path: str, secure: bool = ..., *, headers: Mapping[str, Any] | None = ..., **extra: Any) -> _T: ...
     def options(
         self,
         path: str,
@@ -102,7 +104,7 @@ class _RequestFactory(Generic[_T]):
         content_type: str = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def put(
@@ -112,7 +114,7 @@ class _RequestFactory(Generic[_T]):
         content_type: str = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def patch(
@@ -122,7 +124,7 @@ class _RequestFactory(Generic[_T]):
         content_type: str = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def delete(
@@ -132,7 +134,7 @@ class _RequestFactory(Generic[_T]):
         content_type: str = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
     def generic(
@@ -143,7 +145,7 @@ class _RequestFactory(Generic[_T]):
         content_type: str | None = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _T: ...
 
@@ -192,7 +194,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         enforce_csrf_checks: bool = ...,
         raise_request_exception: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **defaults: Any
     ) -> None: ...
     def request(self, **request: Any) -> _MonkeyPatchedWSGIResponse: ...
@@ -203,7 +205,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def post(  # type: ignore
@@ -214,7 +216,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def head(  # type: ignore
@@ -224,7 +226,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def trace(  # type: ignore
@@ -234,7 +236,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def put(  # type: ignore
@@ -245,7 +247,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def patch(  # type: ignore
@@ -256,7 +258,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
     def delete(  # type: ignore
@@ -267,7 +269,7 @@ class Client(ClientMixin, _RequestFactory[_MonkeyPatchedWSGIResponse]):
         follow: bool = ...,
         secure: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **extra: Any
     ) -> _MonkeyPatchedWSGIResponse: ...
 
@@ -282,7 +284,7 @@ class AsyncClient(ClientMixin, _AsyncRequestFactory[Awaitable[_MonkeyPatchedASGI
         enforce_csrf_checks: bool = ...,
         raise_request_exception: bool = ...,
         *,
-        headers: dict[str, Any] | None = ...,
+        headers: Mapping[str, Any] | None = ...,
         **defaults: Any
     ) -> None: ...
     async def request(self, **request: Any) -> _MonkeyPatchedASGIResponse: ...


### PR DESCRIPTION
Since there is currently a lack of consensus about headers dict values type in #1534, I split out the uncontroversial parts into this PR, so this one can be merged and unblock djangorestframework-stubs CI ([djangorestframework-stubs#425](https://github.com/typeddjango/djangorestframework-stubs/pull/425)).

* Added missing `headers=` parameter to `RequestFactory`
* Changed from `dict[]` to `Mapping[]`, immutable ABCs are preferred for parameter types due to https://mypy.readthedocs.io/en/stable/common_issues.html#variance. This solves [djangorestframework-stubs#425](https://github.com/typeddjango/djangorestframework-stubs/pull/425) issue.

## Related issues

* Split out from #1534
* Extends https://github.com/typeddjango/django-stubs/pull/1529
* Fixes djangorestframework-stubs CI: [djangorestframework-stubs#425](https://github.com/typeddjango/djangorestframework-stubs/pull/425)
