### PR TITLE
Fix base Field and GenericIPAddressField attribute default_error_messages type

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -148,7 +148,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     creation_counter: int
     auto_creation_counter: int
     default_validators: Sequence[validators._ValidatorCallable]
-    default_error_messages: dict[str, str]
+    default_error_messages: _ErrorMessagesT
     hidden: bool
     system_check_removed_details: Any | None
     system_check_deprecated_details: Any | None
@@ -427,7 +427,7 @@ class GenericIPAddressField(Field[_ST, _GT]):
     _pyi_private_set_type: str | int | Callable[..., Any] | Combinable
     _pyi_private_get_type: str
 
-    default_error_messages: dict[str, str]
+    default_error_messages: _ErrorMessagesT
     unpack_ipv4: bool
     protocol: str
     def __init__(


### PR DESCRIPTION
the actual implementation has `dict[str, _StrPromise]` and subclasses matching that produce an error:

```
src/sentry/db/models/fields/jsonfield.py:53: error: Dict entry 0 has incompatible type "str": "_StrPromise"; expected "str": "str"  [dict-item]
```
