### PR TITLE
Sync settings filtering customization with changes in Django

### DIFF
--- a/django-stubs/views/debug.pyi
+++ b/django-stubs/views/debug.pyi
@@ -1,13 +1,12 @@
 from collections.abc import Callable, ItemsView, Iterator
 from pathlib import Path
 from types import TracebackType
-from typing import Any
+from typing import Any, Pattern
 
 from django.http.request import HttpRequest, QueryDict
 from django.http.response import Http404, HttpResponse
 from django.utils.safestring import SafeString
 
-CLEANSED_SUBSTITUTE: str
 CURRENT_DIR: Path
 
 class CallableSettingWrapper:
@@ -24,6 +23,8 @@ def get_default_exception_reporter_filter() -> SafeExceptionReporterFilter: ...
 def get_exception_reporter_filter(request: HttpRequest | None) -> SafeExceptionReporterFilter: ...
 
 class SafeExceptionReporterFilter:
+    cleansed_substitute: str
+    hidden_settings: Pattern[str]
     def cleanse_setting(self, key: int | str, value: Any) -> Any: ...
     def get_safe_settings(self) -> dict[str, Any]: ...
     def is_active(self, request: HttpRequest | None) -> bool: ...


### PR DESCRIPTION
Since Django 3.1, the module-level `CLEANSED_SUBSTITUTE` has been replaced by `SafeExceptionReporterFilter.cleansed_substitute`.

Also the module-level `HIDDEN_SETTINGS` has been replaced by `SafeExceptionReporterFilter.hidden_settings`, but this variable wasn't included in the stubs before.

This PR removes the module-level `CLEANSED_SUBSTITUTE` and adds the two new attributes to `SafeExceptionReporterFilter`.

## Related issues

Django commit: https://github.com/django/django/commit/581ba5a9486ed73cb81031d85b3ce1b27a960109
