### PR TITLE
Add ModelAdmin.search_help_text

### DIFF
--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -149,6 +149,7 @@ class ModelAdmin(BaseModelAdmin[_ModelT]):
     list_max_show_all: int
     list_editable: Sequence[str]
     search_fields: Sequence[str]
+    search_help_text: _StrOrPromise | None
     date_hierarchy: str | None
     save_as: bool
     save_as_continue: bool


### PR DESCRIPTION
# I have made things!

Added to Django in 4.0, https://github.com/django/django/commit/1143f3bb5ecaa2be58f2cd9077f147040291659d , [release note](https://docs.djangoproject.com/en/4.0/releases/4.0/#django-contrib-admin):

> The new [ModelAdmin.search_help_text](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_help_text) attribute allows specifying a descriptive text for the search box.

## Related issues

Adding something else I spotted in the release notes whilst working on #1545.
