### PR TITLE
Add console EmailBackend.write_message()

### DIFF
--- a/django-stubs/core/mail/backends/console.pyi
+++ b/django-stubs/core/mail/backends/console.pyi
@@ -2,7 +2,9 @@ import threading
 from typing import TextIO
 
 from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import EmailMessage
 
 class EmailBackend(BaseEmailBackend):
     stream: TextIO
     _lock: threading.RLock
+    def write_message(self, message: EmailMessage) -> None: ...


### PR DESCRIPTION
# I have made things!

Today I'm creating a subclass of this backend that displays messages more prettily, and I realized the stub for this method was missing.

Source: https://github.com/django/django/blob/5d20e0207867615f6989714261ea3c0a3eb85d88/django/core/mail/backends/console.py#L16

## Related issues

None
