### PR TITLE
CI: Run django-stubs-ext tests in full build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip setuptools wheel
-          sed -i -E "s/^Django==.+$/Django==${{ matrix.django-version }}.*/" ./requirements.txt
           pip install -r ./requirements.txt
+          pip install "Django==${{ matrix.django-version }}"
+          pip check
 
       - name: Run django-stubs-ext tests
         run: PYTHONPATH='.' pytest django_stubs_ext

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip setuptools wheel
+          sed -i -E "s/^Django==.+$/Django==${{ matrix.django-version }}.*/" ./requirements.txt
           pip install -r ./requirements.txt
 
       - name: Run django-stubs-ext tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         run: PYTHONPATH='.' pytest
 
-  typecheck:
+  matrix-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -90,5 +90,8 @@ jobs:
           pip install -U pip setuptools wheel
           pip install -r ./requirements.txt
 
-      - name: Run tests
+      - name: Run django-stubs-ext tests
+        run: PYTHONPATH='.' pytest django_stubs_ext
+
+      - name: Run typecheck
         run: python ./scripts/typecheck_tests.py --django_version="${{ matrix.django-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,6 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         django-version: ['3.2', '4.2']
         include:
-          - python-version: '3.8'
-            django-version: '2.2'
           - python-version: '3.11'
             django-version: '4.1'
     steps:

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -13,7 +13,6 @@ from scripts.git_helpers import checkout_django_branch
 from scripts.paths import DJANGO_SOURCE_DIRECTORY, PROJECT_DIRECTORY
 
 DJANGO_COMMIT_REFS = {
-    "2.2": "2a62cdcfec85938f40abb2e9e6a9ff497e02afe8",
     "3.2": "007e46d815063d598e0d3db78bfb371100e5c61c",
     "4.1": "491dccec1aa10e829539e4e4fcd8cca606a57ebc",
     "4.2": "879e5d587b84e6fc961829611999431778eb9f6a",


### PR DESCRIPTION
This would help detect some issues earlier, such as adding imports to django-stubs-ext that don't exist in all Django or Python versions. This happened in https://github.com/typeddjango/django-stubs/pull/1536/files#r1233319757 and caught me by surprise that it wasn't being tested.

* Renamed 'typecheck' job to 'matrix-test' as it now runs both django-stubs-ext test suite and typecheck in full Django/Python version matrix.
* Dropped long-EOL Django 2.2 from CI. Our readme didn't claim to support 2.2 and django-stubs-ext monkeypatching didn't work with it.
