### PR TITLE
Revert `ArrayField` changes to fix crash when psycopg2 is not installed

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Literal, Optional, Sequence, Set, Tuple, Type, Union
 
-from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 from django.db.models.base import Model
@@ -24,6 +23,15 @@ from mypy.types import Type as MypyType
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.lib.fullnames import WITH_ANNOTATIONS_FULLNAME
+
+# This import fails when `psycopg2` is not installed, avoid crashing the plugin.
+try:
+    from django.contrib.postgres.fields import ArrayField
+except ImportError:
+
+    class ArrayField:  # type: ignore
+        pass
+
 
 if TYPE_CHECKING:
     from django.apps.registry import Apps  # noqa: F401


### PR DESCRIPTION
This wasn't obvious from the code, but the conditional import is still necessary. I've added a code comment to clarify the reason.

It caused the following error:

> pyproject.toml:1:1: error: Error importing plugin "mypy_django_plugin.main": No module named 'psycopg2'  [misc]

Reverts PR "Remove try-except around import of `ArrayField` (#1558)", commit cecef21b26531474807d89389a77d8f330f6056f.

## Related issues

* Reverts #1558
