### PR TITLE
We do not need `mypy_extensions` anymore

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -319,8 +319,8 @@ def convert_any_to_type(typ: MypyType, referred_to_type: MypyType) -> MypyType:
 def make_typeddict(
     api: CheckerPluginInterface, fields: "OrderedDict[str, MypyType]", required_keys: Set[str]
 ) -> TypedDictType:
-    object_type = api.named_generic_type("mypy_extensions._TypedDict", [])
-    typed_dict_type = TypedDictType(fields, required_keys=required_keys, fallback=object_type)
+    fallback_type = api.named_generic_type("typing._TypedDict", [])
+    typed_dict_type = TypedDictType(fields, required_keys=required_keys, fallback=fallback_type)
     return typed_dict_type
 
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -130,7 +130,7 @@ class NewSemanalDjangoPlugin(Plugin):
 
         # for values / values_list
         if file.fullname == "django.db.models":
-            return [self._new_dependency("mypy_extensions"), self._new_dependency("typing")]
+            return [self._new_dependency("typing")]
 
         # for `get_user_model()`
         if self.django_context.settings:


### PR DESCRIPTION
`mypy_extensions` is a very old project that is mostly not used anymore (for this specific feature, there are others - that are still used).
It is especially not used for Python >= 3.8

So, here's how mypy creates `TypedDict` fallback: https://github.com/python/mypy/blob/7d031beb017450ac990c97e288d064290e3be55f/mypy/semanal_typeddict.py#L525-L529

Here's how `typeshed` defines it: https://github.com/python/typeshed/blob/4c1e94d8e0f212f3b611d06698427d77e696e636/stdlib/typing.pyi#LL877C1-L877C1

I think it is safe to drop this from our plugin and use `typing` directly: it is more reliable and a bit faster (less modules, smaller graph).