### PR TITLE
Set `python_version` and fix uppercase builtins

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -15,7 +15,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 show_error_codes = false
 disable_error_code = empty-body
-python_version = 3.8
+python_version = 3.11
 
 plugins =
     mypy_django_plugin.main

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,9 @@ disallow_incomplete_defs = true
 show_error_codes = false
 disable_error_code = empty-body
 python_version = 3.11
+# TODO: update our output assertions to match a new syntax
+force_union_syntax = true
+
 
 plugins =
     mypy_django_plugin.main

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,10 +15,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 show_error_codes = false
 disable_error_code = empty-body
-# TODO: update our output assertions to match a new syntax
-force_uppercase_builtins = true
-force_union_syntax = true
-
+python_version = 3.8
 
 plugins =
     mypy_django_plugin.main

--- a/tests/typecheck/contrib/admin/test_options.yml
+++ b/tests/typecheck/contrib/admin/test_options.yml
@@ -126,7 +126,7 @@
 
       class A(admin.ModelAdmin):
           formfield_overrides = {
-              "not a field": {  # E: Dict entry 0 has incompatible type "str": "Dict[str, Any]"; expected "Type[Field[Any, Any]]": "Mapping[str, Any]"
+              "not a field": {  # E: Dict entry 0 has incompatible type "str": "dict[str, Any]"; expected "type[Field[Any, Any]]": "Mapping[str, Any]"
                   "widget": Textarea
               }
           }
@@ -150,4 +150,4 @@
           pass
 
       class A(ModelAdmin[TestModel]):
-          model = int  # E: Incompatible types in assignment (expression has type "Type[int]", base class "ModelAdmin" defined the type as "Type[TestModel]")
+          model = int  # E: Incompatible types in assignment (expression has type "type[int]", base class "ModelAdmin" defined the type as "type[TestModel]")

--- a/tests/typecheck/contrib/postgres/test_fields.yml
+++ b/tests/typecheck/contrib/postgres/test_fields.yml
@@ -3,9 +3,9 @@
         from typing import List
         from myapp.models import MyModel
         array_val: List[int] = [1]
-        MyModel(array=array_val)  # E: Incompatible type for "array" of "MyModel" (got "List[int]", expected "Union[Sequence[str], Combinable]")
+        MyModel(array=array_val)  # E: Incompatible type for "array" of "MyModel" (got "list[int]", expected "Union[Sequence[str], Combinable]")
         non_init = MyModel()
-        non_init.array = array_val  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[Sequence[str], Combinable]")
+        non_init.array = array_val  # E: Incompatible types in assignment (expression has type "list[int]", variable has type "Union[Sequence[str], Combinable]")
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/contrib/sitemaps/test_generic_sitemap.yml
+++ b/tests/typecheck/contrib/sitemaps/test_generic_sitemap.yml
@@ -49,7 +49,7 @@
         main:26: error: Argument 1 of "location" is incompatible with supertype "Sitemap"; supertype defines the argument type as "Offer"
         main:26: note: This violates the Liskov substitution principle
         main:26: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-        main:40: error: Argument 1 to "GenericSitemap" has incompatible type "Dict[str, List[int]]"; expected "Mapping[str, Union[datetime, _QuerySet[Offer, Offer], str]]"
+        main:40: error: Argument 1 to "GenericSitemap" has incompatible type "dict[str, list[int]]"; expected "Mapping[str, Union[datetime, _QuerySet[Offer, Offer], str]]"
 
     installed_apps:
         - myapp

--- a/tests/typecheck/db/migrations/test_operations.yml
+++ b/tests/typecheck/db/migrations/test_operations.yml
@@ -16,5 +16,5 @@
 
      RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])], reverse_sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])])
 
-     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "Tuple[str, Dict[<nothing>, <nothing>]]"; expected "Union[str, Union[List[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[]], None]]]], Tuple[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[]], None]]], ...], Tuple[]]]"
+     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "tuple[str, dict[<nothing>, <nothing>]]"; expected "Union[str, Union[list[Union[str, tuple[str, Union[dict[str, Any], Union[list[str], tuple[str, ...], tuple[]], None]]]], tuple[Union[str, tuple[str, Union[dict[str, Any], Union[list[str], tuple[str, ...], tuple[]], None]]], ...], tuple[]]]"
      RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", [object(), "ANOTHER PARAM"])]) # E: List item 0 has incompatible type "object"; expected "str"

--- a/tests/typecheck/db/models/test_constraints.yml
+++ b/tests/typecheck/db/models/test_constraints.yml
@@ -31,7 +31,7 @@
         )
     regex: true
     out: |
-        main:4: error: No overload variant of "UniqueConstraint" matches argument types "Lower", "List\[str\]", "str"
+        main:4: error: No overload variant of "UniqueConstraint" matches argument types "Lower", "list\[str\]", "str"
         main:4: note: Possible overload variants:
         main:4: note:     .*
         main:4: note:     .*

--- a/tests/typecheck/db/models/test_query.yml
+++ b/tests/typecheck/db/models/test_query.yml
@@ -33,7 +33,7 @@
         class NonTupleValuesListIterable(ValuesListIterable[int]):
             pass
     out: |
-        main:10: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"
+        main:10: error: Type argument "int" of "ValuesListIterable" must be a subtype of "tuple[Any, ...]"
 -   case: django_db_models_query_module_has_NamedValuesListIterable
     main: |
         from django.db.models.query import NamedValuesListIterable
@@ -46,4 +46,4 @@
         QuerySet._iterable_class = ModelIterable
         QuerySet._iterable_class = int
     out: |
-        main:5: error: Incompatible types in assignment (expression has type "Type[int]", variable has type "Type[BaseIterable[Any]]")
+        main:5: error: Incompatible types in assignment (expression has type "type[int]", variable has type "type[BaseIterable[Any]]")

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -47,7 +47,7 @@
         reveal_type(book.publisher_id)  # N: Revealed type is "uuid.UUID"
         book.publisher_id = '821850bb-c105-426f-b340-3974419d00ca'
         book.publisher_id = UUID('821850bb-c105-426f-b340-3974419d00ca')
-        book.publisher_id = [1]  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[str, UUID]")
+        book.publisher_id = [1]  # E: Incompatible types in assignment (expression has type "list[int]", variable has type "Union[str, UUID]")
         book.publisher_id = Publisher()  # E: Incompatible types in assignment (expression has type "Publisher", variable has type "Union[str, UUID]")
     installed_apps:
         - myapp
@@ -391,9 +391,9 @@
 
         reveal_type(Book2().publisher_id)  # N: Revealed type is "builtins.int"
         Book2(publisher_id=1)
-        Book2(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        Book2(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "list[Any]", expected "Union[float, int, str, Combinable]")
         Book2.objects.create(publisher_id=1)
-        Book2.objects.create(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        Book2.objects.create(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "list[Any]", expected "Union[float, int, str, Combinable]")
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -269,11 +269,11 @@
         from django.db.models.expressions import F
 
         values_list_double_annotate = Blog.objects.annotate(foo=F('id')).annotate(bar=F('id')).values_list('foo', 'bar').get()
-        reveal_type(values_list_double_annotate)  # N: Revealed type is "Tuple[Any, Any]"
+        reveal_type(values_list_double_annotate)  # N: Revealed type is "tuple[Any, Any]"
 
         values_list_named = Blog.objects.annotate(foo=F('id'), bar=F('isad')).values_list('foo', 'text', named=True).get()
         # We have to assume we don't know any of the tuple member types.
-        reveal_type(values_list_named)  # N: Revealed type is "Tuple[Any, builtins.str, fallback=main.Row]"
+        reveal_type(values_list_named)  # N: Revealed type is "tuple[Any, builtins.str, fallback=main.Row]"
         values_list_named.unknown # E: "Row" has no attribute "unknown"
         reveal_type(values_list_named.foo) # N: Revealed type is "Any"
         reveal_type(values_list_named.text) # N: Revealed type is "builtins.str"

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -13,10 +13,10 @@
         reveal_type(qs[0]) # N: Revealed type is "myapp.models.Blog"
         reveal_type(qs[:9]) # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Blog, myapp.models.Blog]"
         reveal_type(qs.create()) # N: Revealed type is "myapp.models.Blog"
-        reveal_type(qs.get_or_create()) # N: Revealed type is "Tuple[myapp.models.Blog, builtins.bool]"
+        reveal_type(qs.get_or_create()) # N: Revealed type is "tuple[myapp.models.Blog, builtins.bool]"
         reveal_type(qs.exists()) # N: Revealed type is "builtins.bool"
         reveal_type(qs.none()) # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Blog, myapp.models.Blog]"
-        reveal_type(qs.update_or_create()) # N: Revealed type is "Tuple[myapp.models.Blog, builtins.bool]"
+        reveal_type(qs.update_or_create()) # N: Revealed type is "tuple[myapp.models.Blog, builtins.bool]"
         reveal_type(qs.explain()) # N: Revealed type is "builtins.str"
         reveal_type(qs.raw(qs.explain())) # N: Revealed type is "django.db.models.query.RawQuerySet[Any]"
         # .dates / .datetimes
@@ -32,7 +32,7 @@
         reveal_type(qs.in_bulk()) # N: Revealed type is "builtins.dict[Any, myapp.models.Blog]"
         reveal_type(qs.bulk_update(list(qs), fields=["created_at"]))  # N: Revealed type is "builtins.int"
         reveal_type(qs.bulk_create([]))  # N: Revealed type is "builtins.list[myapp.models.Blog]"
-        reveal_type(qs.delete()) # N: Revealed type is "Tuple[builtins.int, builtins.dict[builtins.str, builtins.int]]"
+        reveal_type(qs.delete()) # N: Revealed type is "tuple[builtins.int, builtins.dict[builtins.str, builtins.int]]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -1,8 +1,8 @@
 -   case: values_list_simple_field_returns_queryset_of_tuples
     main: |
         from myapp.models import MyUser
-        reveal_type(MyUser.objects.values_list('name').get())  # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(MyUser.objects.values_list('id', 'name').get())  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
+        reveal_type(MyUser.objects.values_list('name').get())  # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(MyUser.objects.values_list('id', 'name').get())  # N: Revealed type is "tuple[builtins.int, builtins.str]"
 
         values_tuple = MyUser.objects.values_list('name', 'age').get()
         reveal_type(values_tuple[0])  # N: Revealed type is "builtins.str"
@@ -10,11 +10,11 @@
 
         # no fields specified return all fields
         all_values_tuple = MyUser.objects.values_list().get()
-        reveal_type(all_values_tuple)  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.int]"
+        reveal_type(all_values_tuple)  # N: Revealed type is "tuple[builtins.int, builtins.str, builtins.int]"
 
         # pk as field
         pk_values = MyUser.objects.values_list('pk').get()
-        reveal_type(pk_values)  # N: # N: Revealed type is "Tuple[builtins.int]"
+        reveal_type(pk_values)  # N: # N: Revealed type is "tuple[builtins.int]"
     installed_apps:
         - myapp
     files:
@@ -32,7 +32,7 @@
 
         # Values tuples can have the same field repeated
         values_tuple = MyUser.objects.values_list('name', 'age', 'name').get()
-        reveal_type(values_tuple)  # N: Revealed type is "Tuple[builtins.str, builtins.int, builtins.str]"
+        reveal_type(values_tuple)  # N: Revealed type is "tuple[builtins.str, builtins.int, builtins.str]"
         reveal_type(values_tuple[0])  # N: Revealed type is "builtins.str"
         reveal_type(values_tuple[1])  # N: Revealed type is "builtins.int"
         reveal_type(values_tuple[2])  # N: Revealed type is "builtins.str"
@@ -52,12 +52,12 @@
         from myapp.models import MyUser
         from django.db.models.functions import Length
         query = MyUser.objects.values_list('name')
-        reveal_type(query.order_by("name").get())  # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(query.distinct("name").get()) # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(query.distinct().get()) # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(query.all().get()) # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(query.filter(age__gt=16).get()) # N: Revealed type is "Tuple[builtins.str]"
-        reveal_type(query.exclude(age__lte=16).get()) # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(query.order_by("name").get())  # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(query.distinct("name").get()) # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(query.distinct().get()) # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(query.all().get()) # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(query.filter(age__gt=16).get()) # N: Revealed type is "tuple[builtins.str]"
+        reveal_type(query.exclude(age__lte=16).get()) # N: Revealed type is "tuple[builtins.str]"
         reveal_type(query.annotate(name_length=Length("name")).get()) # N: Revealed type is "builtins.tuple[Any, ...]"
     installed_apps:
         - myapp
@@ -80,7 +80,7 @@
         reveal_type(values_tuple[3])  # N: Revealed type is "builtins.str"
 
         reverse_fields_list = Blog.objects.values_list('post__text').get()
-        reveal_type(reverse_fields_list)  # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(reverse_fields_list)  # N: Revealed type is "tuple[builtins.str]"
     installed_apps:
         - myapp
     files:
@@ -126,7 +126,7 @@
     main: |
         from myapp.models import MyUser
         values_named_tuple = MyUser.objects.values_list('name', 'age', named=True).get()
-        reveal_type(values_named_tuple)  # N: Revealed type is "Tuple[builtins.str, builtins.int, fallback=main.Row]"
+        reveal_type(values_named_tuple)  # N: Revealed type is "tuple[builtins.str, builtins.int, fallback=main.Row]"
         reveal_type(values_named_tuple.name)  # N: Revealed type is "builtins.str"
         reveal_type(values_named_tuple.age)  # N: Revealed type is "builtins.int"
 
@@ -139,13 +139,13 @@
 
         # pk as field
         pk_values = MyUser.objects.values_list('pk', named=True).get()
-        reveal_type(pk_values)  # N: Revealed type is "Tuple[builtins.int, fallback=main.Row2]"
+        reveal_type(pk_values)  # N: Revealed type is "tuple[builtins.int, fallback=main.Row2]"
         reveal_type(pk_values.pk)  # N: # N: Revealed type is "builtins.int"
 
         # values_list(named=True) inside function
         def func() -> None:
             from myapp.models import MyUser
-            reveal_type(MyUser.objects.values_list('name', named=True).get())  # N: Revealed type is "Tuple[builtins.str, fallback=main.Row3]"
+            reveal_type(MyUser.objects.values_list('name', named=True).get())  # N: Revealed type is "tuple[builtins.str, fallback=main.Row3]"
     installed_apps:
         - myapp
     files:
@@ -189,7 +189,7 @@
         main:3: note: Revealed type is "Any"
         main:4: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id
         main:4: note: Revealed type is "Any"
-        main:5: note: Revealed type is "Tuple[Any]"
+        main:5: note: Revealed type is "tuple[Any]"
     installed_apps:
         - myapp
     files:
@@ -257,7 +257,7 @@
         from myapp.models import TransactionQuerySet
         reveal_type(TransactionQuerySet())  # N: Revealed type is "myapp.models.TransactionQuerySet"
         reveal_type(TransactionQuerySet().values())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Transaction, TypedDict({'id': builtins.int, 'total': builtins.int})]"
-        reveal_type(TransactionQuerySet().values_list())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Transaction, Tuple[builtins.int, builtins.int]]"
+        reveal_type(TransactionQuerySet().values_list())  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Transaction, tuple[builtins.int, builtins.int]]"
     installed_apps:
         - myapp
     files:
@@ -273,8 +273,8 @@
 -   case: values_list_of_many_to_many_field
     main: |
         from myapp.models import Author, Book
-        reveal_type(Book.objects.values_list('authors'))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Book, Tuple[builtins.int]]"
-        reveal_type(Author.objects.values_list('books'))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Author, Tuple[builtins.int]]"
+        reveal_type(Book.objects.values_list('authors'))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Book, tuple[builtins.int]]"
+        reveal_type(Author.objects.values_list('books'))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.Author, tuple[builtins.int]]"
     installed_apps:
         - myapp
     files:
@@ -290,7 +290,7 @@
     main: |
         from myapp.models import Blog
         values = Blog.objects.values_list('text').get()
-        reveal_type(values)  # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(values)  # N: Revealed type is "tuple[builtins.str]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -29,7 +29,7 @@
                     abstract = True
 
                 def lock(self) -> None:
-                    reveal_type(type(self).objects.values_list("pk"))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.BaseModel, Tuple[Any]]"
+                    reveal_type(type(self).objects.values_list("pk"))  # N: Revealed type is "django.db.models.query._QuerySet[myapp.models.BaseModel, tuple[Any]]"
 
             class MyModel(BaseModel):
                 field = models.IntegerField()

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -2,7 +2,7 @@
     main: |
         from myapp.models import User
         User.objects.create(pk=1, name='Max', age=10)
-        User.objects.create(age=[])  # E: Incompatible type for "age" of "User" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        User.objects.create(age=[])  # E: Incompatible type for "age" of "User" (got "list[Any]", expected "Union[float, int, str, Combinable]")
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -37,7 +37,7 @@
         from myapp.models import MyUser
         user = MyUser(name='hello', age=[])
     out: |
-        main:2: error: Incompatible type for "age" of "MyUser" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        main:2: error: Incompatible type for "age" of "MyUser" (got "list[Any]", expected "Union[float, int, str, Combinable]")
     installed_apps:
         - myapp
     files:
@@ -107,7 +107,7 @@
 -   case: typechecking_of_pk
     main: |
         from myapp.models import MyUser1
-        user = MyUser1(pk=[])  # E: Incompatible type for "pk" of "MyUser1" (got "List[Any]", expected "Union[float, int, str, Combinable, None]")
+        user = MyUser1(pk=[])  # E: Incompatible type for "pk" of "MyUser1" (got "list[Any]", expected "Union[float, int, str, Combinable, None]")
     installed_apps:
         - myapp
     files:
@@ -126,7 +126,7 @@
 
         from myapp.models import Publisher, PublisherDatetime, Book
         Book(publisher_id=1, publisher_dt_id=now)
-        Book(publisher_id=[], publisher_dt_id=now)  # E: Incompatible type for "publisher_id" of "Book" (got "List[Any]", expected "Union[Combinable, int, str]")
+        Book(publisher_id=[], publisher_dt_id=now)  # E: Incompatible type for "publisher_id" of "Book" (got "list[Any]", expected "Union[Combinable, int, str]")
         Book(publisher_id=1, publisher_dt_id=1)  # E: Incompatible type for "publisher_dt_id" of "Book" (got "int", expected "Union[str, datetime, date, Combinable]")
     installed_apps:
         - myapp
@@ -148,18 +148,18 @@
     main: |
         from typing import List, Tuple
         from myapp.models import MyModel
-        array_val: Tuple[int, ...] = (1,)
+        array_val: tuple[int, ...] = (1,)
         MyModel(array=array_val)
         array_val2: List[int] = [1]
         MyModel(array=array_val2)
         class NotAValid:
             pass
         array_val3: List[NotAValid] = [NotAValid()]
-        MyModel(array=array_val3)  # E: Incompatible type for "array" of "MyModel" (got "List[NotAValid]", expected "Union[Sequence[Union[float, int, str]], Combinable]")
+        MyModel(array=array_val3)  # E: Incompatible type for "array" of "MyModel" (got "list[NotAValid]", expected "Union[Sequence[Union[float, int, str]], Combinable]")
         non_init = MyModel()
         non_init.array = array_val
         non_init.array = array_val2
-        non_init.array = array_val3  # E: Incompatible types in assignment (expression has type "List[NotAValid]", variable has type "Union[Sequence[Union[float, int, str]], Combinable]")
+        non_init.array = array_val3  # E: Incompatible types in assignment (expression has type "list[NotAValid]", variable has type "Union[Sequence[Union[float, int, str]], Combinable]")
     installed_apps:
         - myapp
     files:
@@ -191,7 +191,7 @@
         from myapp.models import MyModel, MyModel2
         MyModel(1)
         MyModel2(1, 12)
-        MyModel2(1, [])  # E: Incompatible type for "name" of "MyModel2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        MyModel2(1, [])  # E: Incompatible type for "name" of "MyModel2" (got "list[Any]", expected "Union[float, int, str, Combinable]")
     installed_apps:
         - myapp
     files:
@@ -290,12 +290,12 @@
         main:8: note: Revealed type is "Any"
         main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
         main:10: error: Incompatible types in assignment (expression has type "str", variable has type "Union[int, float]")
-        main:12: error: Incompatible types in assignment (expression has type "List[str]", variable has type "Sequence[Union[int, float]]")
-        main:13: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "Union[float, int, str, Combinable]")
+        main:12: error: Incompatible types in assignment (expression has type "list[str]", variable has type "Sequence[Union[int, float]]")
+        main:13: error: Incompatible types in assignment (expression has type "list[<nothing>]", variable has type "Union[float, int, str, Combinable]")
         main:15: error: Incompatible type for "redefined_set_type" of "MyModel" (got "str", expected "int")
         main:15: error: Incompatible type for "redefined_union_set_type" of "MyModel" (got "str", expected "Union[int, float]")
         main:15: error: Incompatible type for "redefined_array_set_type" of "MyModel" (got "int", expected "Sequence[Union[int, float]]")
-        main:15: error: Incompatible type for "default_set_type" of "MyModel" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        main:15: error: Incompatible type for "default_set_type" of "MyModel" (got "list[Any]", expected "Union[float, int, str, Combinable]")
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -65,6 +65,6 @@
             example = models.CharField(max_length=100)
             class Meta(TypedModelMeta):
                 abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")
-                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")
-                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
+                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "list[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")
+                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
                 unknown_attr = True  # can't check this

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -9,7 +9,7 @@
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
-      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+      reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[tuple[builtins.str, builtins.int]]"
       response.json()
 -   case: async_client_methods
     main: |
@@ -23,7 +23,7 @@
         reveal_type(response.client)  # N: Revealed type is "django.test.client.AsyncClient"
         reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
         reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
-        reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
+        reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[tuple[builtins.str, builtins.int]]"
         response.json()
 -   case: request_factories
     main: |

--- a/tests/typecheck/utils/test_datastructures.yml
+++ b/tests/typecheck/utils/test_datastructures.yml
@@ -40,7 +40,7 @@
 
       # iterators
       # actually [('foo', 'Foo'), ('bar', [])]
-      reveal_type(list(d.items()))  # N: Revealed type is "builtins.list[Tuple[builtins.str, Union[builtins.str, builtins.list[builtins.object]]]]"
+      reveal_type(list(d.items()))  # N: Revealed type is "builtins.list[tuple[builtins.str, Union[builtins.str, builtins.list[builtins.object]]]]"
       reveal_type(list(d.keys()))  # N: Revealed type is "builtins.list[builtins.str]"
       # actually ['Foo', []]
       reveal_type(list(d.values()))  # N: Revealed type is "builtins.list[Union[builtins.str, builtins.list[builtins.object]]]"

--- a/tests/typecheck/utils/test_functional.yml
+++ b/tests/typecheck/utils/test_functional.yml
@@ -15,7 +15,7 @@
 
       f = Foo()
       reveal_type(f.attr)        # N: Revealed type is "builtins.list[builtins.str]"
-      f.attr.name                # E: "List[str]" has no attribute "name"
+      f.attr.name                # E: "list[str]" has no attribute "name"
 
 -   case: str_promise_proxy
     main:  |
@@ -30,7 +30,7 @@
       reveal_type(s.format("asd"))   # N: Revealed type is "builtins.str"
       reveal_type(s.capitalize())    # N: Revealed type is "builtins.str"
       reveal_type(s.swapcase)        # N: Revealed type is "def () -> builtins.str"
-      reveal_type(s.__getnewargs__)  # N: Revealed type is "def () -> Tuple[builtins.str]"
+      reveal_type(s.__getnewargs__)  # N: Revealed type is "def () -> tuple[builtins.str]"
       s.nonsense                     # E: "_StrPromise" has no attribute "nonsense"
       f: Union[_StrPromise, str]
       reveal_type(f.format("asd"))   # N: Revealed type is "builtins.str"

--- a/tests/typecheck/views/generic/test_detail.yml
+++ b/tests/typecheck/views/generic/test_detail.yml
@@ -49,7 +49,7 @@
                 class Other(models.Model):
                     ...
     out: |
-      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "SingleObjectMixin" defined the type as "Type[Other]")
+      main:7: error: Incompatible types in assignment (expression has type "type[MyModel]", base class "SingleObjectMixin" defined the type as "type[Other]")
       main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "SingleObjectMixin" defined the type as "Optional[_QuerySet[Other, Other]]")
       main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_QuerySet[Other, Other]" in supertype "SingleObjectMixin"
       main:12: error: Incompatible return value type (got "_QuerySet[Other, Other]", expected "_QuerySet[MyModel, MyModel]")

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -83,7 +83,7 @@
             def some(self) -> None:
                 reveal_type(self.get_form())  # N: Revealed type is "main.ArticleModelForm"
                 reveal_type(self.get_form(SubArticleModelForm))  # N: Revealed type is "main.SubArticleModelForm"
-                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.AnotherArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "Type[AnotherArticleModelForm]"; expected "Optional[Type[ArticleModelForm]]"
+                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.AnotherArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "type[AnotherArticleModelForm]"; expected "Optional[type[ArticleModelForm]]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/views/generic/test_list.yml
+++ b/tests/typecheck/views/generic/test_list.yml
@@ -47,6 +47,6 @@
                 class Other(models.Model):
                     ...
     out: |
-      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[Type[Other]]")
+      main:7: error: Incompatible types in assignment (expression has type "type[MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[type[Other]]")
       main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[_SupportsPagination[Other]]")
       main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_SupportsPagination[Other]" in supertype "MultipleObjectMixin"


### PR DESCRIPTION
**Problem**

When upgrading to Mypy 1.4 (#1572) I added a setting to force uppercase builtins to ensure that tests would pass. In [a comment](https://github.com/typeddjango/django-stubs/pull/1572#issuecomment-1605606030) I highlighted that we may not be able to remove this setting without changing `python_version` otherwise tests would only pass on some versions of Python.

I tried setting `python_version = 3.8`, but that caused [test failures](https://github.com/typeddjango/django-stubs/actions/runs/5365122788). Candidly, I didn't take very much time to investigate these.

**Solution**

Configure `python_version = 3.11` to match our highest supported Python version, and fix uppercase builtins. I can fix the union types in a future PR, but I want to keep this one as minimal as possible. If this is the direction we want to go, we can merge this PR, but I'm open to other options.