### PR TITLE
Use `report_config_data` mypy plugin hook to reset cache on changes

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -112,3 +112,10 @@ class DjangoPluginConfig:
             self.strict_settings = parser.getboolean(section, "strict_settings", fallback=True)
         except ValueError:
             exit_with_error(INVALID_BOOL_SETTING.format(key="strict_settings"))
+
+    def to_json(self) -> dict[str, Any]:
+        """We use this method to reset mypy cache via `report_config_data` hook."""
+        return {
+            "django_settings_module": self.django_settings_module,
+            "strict_settings": self.strict_settings,
+        }

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -113,7 +113,7 @@ class DjangoPluginConfig:
         except ValueError:
             exit_with_error(INVALID_BOOL_SETTING.format(key="strict_settings"))
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> Dict[str, Any]:
         """We use this method to reset mypy cache via `report_config_data` hook."""
         return {
             "django_settings_module": self.django_settings_module,

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,7 +1,7 @@
 import itertools
 import sys
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
@@ -14,6 +14,7 @@ from mypy.plugin import (
     FunctionContext,
     MethodContext,
     Plugin,
+    ReportConfigContext,
 )
 from mypy.types import Type as MypyType
 
@@ -330,6 +331,10 @@ class NewSemanalDjangoPlugin(Plugin):
             if info and info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
                 return create_new_manager_class_from_as_manager_method
         return None
+
+    def report_config_data(self, ctx: ReportConfigContext) -> dict[str, Any]:
+        # Cache would be cleared if any settins do change.
+        return self.plugin_config.to_json()
 
 
 def plugin(version: str) -> Type[NewSemanalDjangoPlugin]:

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -332,7 +332,7 @@ class NewSemanalDjangoPlugin(Plugin):
                 return create_new_manager_class_from_as_manager_method
         return None
 
-    def report_config_data(self, ctx: ReportConfigContext) -> dict[str, Any]:
+    def report_config_data(self, ctx: ReportConfigContext) -> Dict[str, Any]:
         # Cache would be cleared if any settings do change.
         return self.plugin_config.to_json()
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -333,7 +333,7 @@ class NewSemanalDjangoPlugin(Plugin):
         return None
 
     def report_config_data(self, ctx: ReportConfigContext) -> dict[str, Any]:
-        # Cache would be cleared if any settins do change.
+        # Cache would be cleared if any settings do change.
         return self.plugin_config.to_json()
 
 


### PR DESCRIPTION
Now, when any of our settings will change, mypy will be clear the existing cache. This is especially useful for stateful checks: `incremental`, `dmypy`, etc.

However, I don't think that it is possible to easily test this. This is how it is tested in mypy itself:

```ini
[case testPluginConfigData]
# flags: --config-file tmp/mypy.ini
import a
import b
[file a.py]
[file b.py]
[file test.json]
{"a": false, "b": false}
[file test.json.2]
{"a": true, "b": false}

[file mypy.ini]
\[mypy]
plugins=<ROOT>/test-data/unit/plugins/config_data.py

# The config change will force a to be rechecked but not b.
[rechecked a]
```

The only testing I've done is manual. It seems to work.

Closes https://github.com/typeddjango/django-stubs/issues/1568