### PR TITLE
CI: Run tests and pre-commit using newest Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.9
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
The choice of Python 3.9 was arbitrary. As agreed in other pull request https://github.com/typeddjango/django-stubs/pull/1560#discussion_r1237101876, we should use the newest supported Python version.

Python 3.11 is also slightly faster.
