### PR TITLE
Update compatible-mypy to 1.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
+| (next release) | 1.4.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.1          | 1.3.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.0          | 1.2.x        | 4.2            | 4.1, 4.0, 3.2          | 3.7 - 3.11     |
 | 1.16.0         | 1.1.x        | 4.1            | 4.0, 3.2               | 3.7 - 3.11     |

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Django==4.2.2
 -e .[compatible-mypy]
 
 # Overrides:
-mypy==1.4.0
+mypy==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,9 @@ dependencies = [
     "types-PyYAML",
 ]
 
+# Keep compatible-mypy major.minor version pinned to what we use in CI (requirements.txt)
 extras_require = {
-    "compatible-mypy": ["mypy>=1.4.0,<1.5"],
+    "compatible-mypy": ["mypy==1.4.*"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy>=1.3.0,<1.5"],
+    "compatible-mypy": ["mypy>=1.4.0,<1.5"],
 }
 
 setup(


### PR DESCRIPTION
The lower bound of `compatible-mypy` was not bumped in #1572.

While at it, I've also updated CI to use mypy 1.4.1.

----

Honestly the `compatible-mypy` requirement has never made much sense to me. I don't use it in any of my projects. I update mypy as soon as a new version comes out and usually it works fine.

How can we determine which mypy versions are compatible? We currently run one mypy version in CI, and our test suite almost always needs changes for newer mypy versions, because it's sensitive to mypy's error messages that change frequently. If we wanted to test with multiple mypy versions in a test matrix, that would require rethinking our testing approach.

So my approach has been to pin `compatible-mypy` to the major.minor version we run in CI, at least we know for a fact that it works.

----

So @sobolevn @christianbundy or other maintainers, please chime in, what should `compatible-mypy` mean? Or should we just punt and carry on pinning to latest mypy minor like before?
