### PR TITLE
Run tests in multiple shards and all Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -47,6 +48,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         shard: [0, 1, 2, 3]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
@@ -71,6 +73,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
@@ -92,6 +95,7 @@ jobs:
   matrix-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10']
         django-version: ['3.2', '4.2']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        shard: [1, 2, 3, 4]
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
@@ -61,8 +62,9 @@ jobs:
           pip install -U pip setuptools wheel
           pip install -r ./requirements.txt
 
+      # Must match `shard` definition in the test matrix:
       - name: Run tests
-        run: PYTHONPATH='.' pytest
+        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }}
 
   stubtest:
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black==23.3.0
 pre-commit==3.3.3
 pytest==7.4.0
 pytest-mypy-plugins==1.11.1
-pytest-shards==0.1.2
+pytest-shard==0.1.2
 
 # Django deps:
 psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+# Dev tools:
 black==23.3.0
 pre-commit==3.3.3
 pytest==7.4.0
 pytest-mypy-plugins==1.11.1
+pytest-shards==0.1.2
+
+# Django deps:
 psycopg2-binary
 Django==4.2.2
 -e ./django_stubs_ext

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -1,13 +1,13 @@
 - case: test_checks_register
   main: |
-    from typing import Any, Sequence, Optional, Union
+    from typing import Any, Sequence, Optional, Union, List
 
     from django.apps.config import AppConfig
     from django.core.checks import register, Warning, CheckMessage
 
 
     @register("foo", deploy=True)
-    def check_foo(app_configs: Union[Sequence[AppConfig], None], databases: Optional[Sequence[str]], **kwargs: Any) -> list[Warning]:
+    def check_foo(app_configs: Union[Sequence[AppConfig], None], databases: Optional[Sequence[str]], **kwargs: Any) -> List[Warning]:
         if databases and 'databass' in databases:
             return [Warning("Naughty list")]
         return []

--- a/tests/typecheck/db/models/test_query.yml
+++ b/tests/typecheck/db/models/test_query.yml
@@ -36,7 +36,7 @@
         class NonTupleValuesListIterable(ValuesListIterable[int]):
             pass
     out: |
-        main:10: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"
+        main:11: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"
 
 
 -   case: django_db_models_query_module_has_NamedValuesListIterable

--- a/tests/typecheck/db/models/test_query.yml
+++ b/tests/typecheck/db/models/test_query.yml
@@ -19,25 +19,32 @@
             pass
     out: |
         main:4: error: Type argument "int" of "ModelIterable" must be a subtype of "Model"
+
+
 -   case: django_db_models_query_module_has_ValuesListIterable
     main: |
+        from typing import Tuple
         from django.db.models.query import ValuesListIterable
 
-        class IntValuesListIterable(ValuesListIterable[tuple[int,int]]):
+        class IntValuesListIterable(ValuesListIterable[Tuple[int,int]]):
             pass
-        class StringsValuesListIterable(ValuesListIterable[tuple[str,str,str]]):
+        class StringsValuesListIterable(ValuesListIterable[Tuple[str,str,str]]):
             pass
-        class MultiTypeValuesListIterable(ValuesListIterable[tuple[str,int,float]]):
+        class MultiTypeValuesListIterable(ValuesListIterable[Tuple[str,int,float]]):
             pass
 
         class NonTupleValuesListIterable(ValuesListIterable[int]):
             pass
     out: |
         main:10: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"
+
+
 -   case: django_db_models_query_module_has_NamedValuesListIterable
     main: |
         from django.db.models.query import NamedValuesListIterable
     out: |
+
+
 -   case: QuerySet_has__iterable_class_defined
     main: |
         from django.db.models.query import QuerySet, ValuesIterable, ModelIterable


### PR DESCRIPTION
Now we can tests all python version (it won't be too long, but can catch a lot of potential bugs).

We will have additional 15 (16 - 1 existing) new CI jobs, but my experience in `typeshed` prooves that it is fine.

Or we can increase the number of shards to make this even faster.