### PR TITLE
Version 4.2.3 release (django-stubs only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
+| 4.2.3          | 1.4.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.2          | 1.4.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.1          | 1.3.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.0          | 1.2.x        | 4.2            | 4.1, 4.0, 3.2          | 3.7 - 3.11     |

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="4.2.2",
+    version="4.2.3",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This release has multiple bugfixes, fixing a significant regression from version 4.2.2.

I'll just release `django-stubs` this time and skip `django-stubs-ext` since there are no changes there (I explained this approach in https://github.com/typeddjango/django-stubs/issues/1450#issuecomment-1525851358)
