### PR TITLE
Add _body attribute to HttpRequest

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -39,6 +39,7 @@ class HttpRequest(BytesIO):
     resolver_match: ResolverMatch | None
     content_type: str | None
     content_params: dict[str, str] | None
+    _body: bytes
     _stream: BinaryIO
     # Attributes added by optional parts of Django
     # django.contrib.admin views:


### PR DESCRIPTION
this is created on access to self.body -- or usable as a shortcut to create a request body in tests


