### PR TITLE
Forbid instantiating abstract models

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -231,9 +231,11 @@ class NewSemanalDjangoPlugin(Plugin):
             if info and info.has_base(fullnames.OPTIONS_CLASS_FULLNAME):
                 return partial(meta.return_proper_field_type_from_get_field, django_context=self.django_context)
 
-        elif class_fullname in manager_classes and method_name == "create":
-            return partial(init_create.redefine_and_typecheck_model_create, django_context=self.django_context)
-        elif class_fullname in manager_classes and method_name in {"filter", "get", "exclude"}:
+        elif method_name == "create":
+            # We need `BASE_MANAGER_CLASS_FULLNAME` to check abstract models.
+            if class_fullname in manager_classes or class_fullname == fullnames.BASE_MANAGER_CLASS_FULLNAME:
+                return partial(init_create.redefine_and_typecheck_model_create, django_context=self.django_context)
+        elif method_name in {"filter", "get", "exclude"} and class_fullname in manager_classes:
             return partial(
                 mypy_django_plugin.transformers.orm_lookups.typecheck_queryset_filter,
                 django_context=self.django_context,

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -50,9 +50,8 @@ def typecheck_model_method(
         )
 
     if model_cls._meta.abstract:
-        ctx.api.expr_checker.msg.cannot_instantiate_abstract_class(
-            model_cls.__name__,
-            {"Meta.abstract": False},
+        ctx.api.fail(
+            f'Cannot instantiate abstract model "{model_cls.__name__}"',
             ctx.context,
         )
 

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -49,6 +49,11 @@ def typecheck_model_method(
             error_message=f'Incompatible type for "{actual_name}" of "{model_cls.__name__}"',
         )
 
+    if model_cls._meta.abstract:
+        ctx.api.expr_checker.msg.cannot_instantiate_abstract_class(
+            model_cls.__name__, {"Meta.abstract": False}, ctx.context,
+        )
+
     return ctx.default_return_type
 
 

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -51,7 +51,9 @@ def typecheck_model_method(
 
     if model_cls._meta.abstract:
         ctx.api.expr_checker.msg.cannot_instantiate_abstract_class(
-            model_cls.__name__, {"Meta.abstract": False}, ctx.context,
+            model_cls.__name__,
+            {"Meta.abstract": False},
+            ctx.context,
         )
 
     return ctx.default_return_type

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -194,6 +194,7 @@
 
 -   case: managers_inherited_from_abstract_classes_multiple_inheritance
     main: |
+        from myapp.models import Child
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -3,7 +3,15 @@
     from django.contrib.auth.models import AbstractUser
     AbstractUser.objects.get(pk=1)
     AbstractUser.objects.get(pk__in=[1])
-    reveal_type(AbstractUser().pk)  # N: Revealed type is "Any"
+
+    au: AbstractUser
+    reveal_type(au.pk)  # N: Revealed type is "Any"
+  installed_apps:
+    - django.contrib.auth
+
+- case: test_filter_on_abstract_user_pk_wrong_name
+  main: |
+    from django.contrib.auth.models import AbstractUser
     AbstractUser.objects.get(pkey=1)  # ER: Cannot resolve keyword 'pkey' into field..*
   installed_apps:
     - django.contrib.auth

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -71,7 +71,7 @@
 -   case: fields_from_abstract_user_propagate_to_init
     main: |
         from myapp.models import MyUser
-        user = MyUser(name='Maxim')
+        user = MyUser(name='Maxim', number=1)
     installed_apps:
         - myapp
     files:
@@ -84,7 +84,7 @@
                         abstract = True
                     name = models.CharField(max_length=100)
                 class MyUser(AbstractUser):
-                    pass
+                    number = models.IntegerField()
 
 -   case: pk_refers_to_primary_key_and_could_be_passed_to_init
     main: |

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -248,12 +248,13 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
+                from typing_extensions import Self
                 class AbstractModel(models.Model):
                     class Meta:
                         abstract = True
                     text = models.CharField(max_length=100)
                     @classmethod
-                    def base_init(cls) -> 'AbstractModel':
+                    def base_init(cls) -> Self:
                         return cls(text='mytext')
                 class MyModel(AbstractModel):
                     pass

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -68,3 +68,29 @@
                 verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")
                 unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
                 unknown_attr = True  # can't check this
+
+
+-   case: instantiate_abstract_model
+    main: |
+        from myapp.models import AbstractModel, MyModel
+
+        # Should not raise:
+        MyModel(field=1)
+        MyModel.objects.create(field=2)
+
+        # Errors:
+        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attribute "Meta.abstract"
+        AbstractModel.objects.create()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attribute "Meta.abstract"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class AbstractModel(models.Model):
+                    class Meta:
+                        abstract = True
+                    base = models.TextField()
+                class MyModel(AbstractModel):
+                    field = models.IntegerField()

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -79,8 +79,8 @@
         MyModel.objects.create(field=2)
 
         # Errors:
-        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attribute "Meta.abstract"
-        AbstractModel.objects.create()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attribute "Meta.abstract"
+        AbstractModel()  # E: Cannot instantiate abstract model "AbstractModel"
+        AbstractModel.objects.create()  # E: Cannot instantiate abstract model "AbstractModel"
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
I went ahead with another approach, because setting `TypeInfo.is_abstract` can have different side-effects, because it is widely used in mypy itself.

I think that checking `.create` and `__init__` is good enough for our use-case.

Closes https://github.com/typeddjango/django-stubs/issues/1624