### PR TITLE
fix(Options): pk cannot be None

### DIFF
--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -73,7 +73,7 @@ class Options(Generic[_M]):
     required_db_features: list[str]
     required_db_vendor: Literal["sqlite", "postgresql", "mysql", "oracle"] | None
     meta: type | None
-    pk: Field | None
+    pk: Field
     auto_field: AutoField | None
     abstract: bool
     managed: bool


### PR DESCRIPTION
Fix the `Options.pk` typing to always be a `Field`

# I have made things!

Hello, I am no Django expert so I may be wrong, but it seems to me a Model always define a primary key (either explicitly or implicitly), which means `Model._meta.pk` always references a `Field`
 

## Related issues

No issue, I can create one if needs be .
