### PR TITLE
Restore django.test.signals.setting_changed

### DIFF
--- a/django-stubs/test/signals.pyi
+++ b/django-stubs/test/signals.pyi
@@ -1,5 +1,7 @@
 from typing import Any
 
+from django.core.signals import setting_changed as setting_changed  # noqa: F401
+
 template_rendered: Any
 COMPLEX_OVERRIDE_SETTINGS: Any
 


### PR DESCRIPTION
# I have made things!

Django documents this signal as living in `django.test` primarily, and also available in `django.core`: https://docs.djangoproject.com/en/4.2/ref/signals/#django.test.signals.setting_changed

The re-export was removed in #1309, but that was a bit zealous since we want to remain in sync with Django documentation.

## Related issues

n/a
