### PR TITLE
Move ModelBase.objects declaration to Model.objects, for mypy 1.5.0

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -20,13 +20,13 @@ class ModelState:
 
 class ModelBase(type):
     @property
-    def objects(cls: type[_Self]) -> BaseManager[_Self]: ...  # type: ignore[misc]
-    @property
     def _default_manager(cls: type[_Self]) -> BaseManager[_Self]: ...  # type: ignore[misc]
     @property
     def _base_manager(cls: type[_Self]) -> BaseManager[_Self]: ...  # type: ignore[misc]
 
 class Model(metaclass=ModelBase):
+    objects: BaseManager[Self]
+
     # Note: these two metaclass generated attributes don't really exist on the 'Model'
     # class, runtime they are only added on concrete subclasses of 'Model'. The
     # metaclass also sets up correct inheritance from concrete parent models exceptions.

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -315,17 +315,13 @@ django.contrib.gis.db.backends.oracle.features.DatabaseFeatures.supports_toleran
 django.contrib.gis.db.backends.oracle.features.DatabaseFeatures.unsupported_geojson_options
 django.contrib.gis.db.backends.oracle.introspection
 django.contrib.gis.db.backends.oracle.models.OracleGeometryColumns.Meta
-django.contrib.gis.db.backends.oracle.models.OracleGeometryColumns.objects
 django.contrib.gis.db.backends.oracle.models.OracleSpatialRefSys.Meta
-django.contrib.gis.db.backends.oracle.models.OracleSpatialRefSys.objects
 django.contrib.gis.db.backends.oracle.operations
 django.contrib.gis.db.backends.postgis.adapter.PostGISAdapter.prepare
 django.contrib.gis.db.backends.postgis.features.DatabaseFeatures.empty_intersection_returns_none
 django.contrib.gis.db.backends.postgis.features.DatabaseFeatures.supports_geography
 django.contrib.gis.db.backends.postgis.models.PostGISGeometryColumns.Meta
-django.contrib.gis.db.backends.postgis.models.PostGISGeometryColumns.objects
 django.contrib.gis.db.backends.postgis.models.PostGISSpatialRefSys.Meta
-django.contrib.gis.db.backends.postgis.models.PostGISSpatialRefSys.objects
 django.contrib.gis.db.backends.postgis.operations.PostGISOperations.convert_extent
 django.contrib.gis.db.backends.postgis.operations.PostGISOperations.convert_extent3d
 django.contrib.gis.db.backends.postgis.operations.PostGISOperator.check_geography
@@ -335,9 +331,7 @@ django.contrib.gis.db.backends.spatialite.features.DatabaseFeatures.can_alter_ge
 django.contrib.gis.db.backends.spatialite.features.DatabaseFeatures.django_test_skips
 django.contrib.gis.db.backends.spatialite.features.DatabaseFeatures.supports_area_geodetic
 django.contrib.gis.db.backends.spatialite.models.SpatialiteGeometryColumns.Meta
-django.contrib.gis.db.backends.spatialite.models.SpatialiteGeometryColumns.objects
 django.contrib.gis.db.backends.spatialite.models.SpatialiteSpatialRefSys.Meta
-django.contrib.gis.db.backends.spatialite.models.SpatialiteSpatialRefSys.objects
 django.contrib.gis.db.backends.spatialite.operations.SpatiaLiteOperations.convert_extent
 django.contrib.gis.db.backends.spatialite.operations.SpatiaLiteOperations.from_text
 django.contrib.gis.db.backends.spatialite.operations.SpatiaLiteOperations.geom_lib_version
@@ -1276,7 +1270,6 @@ django.db.migrations.questioner.NonInteractiveMigrationQuestioner.log_lack_of_mi
 django.db.migrations.recorder.MigrationRecorder.Migration.get_next_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.get_previous_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.id
-django.db.migrations.recorder.MigrationRecorder.Migration.objects
 django.db.migrations.serializer.ChoicesSerializer
 django.db.migrations.utils.FieldReference
 django.db.migrations.utils.field_is_referenced
@@ -1534,7 +1527,6 @@ django.db.models.base.Model.Meta
 django.db.models.base.Model.add_to_class
 django.db.models.base.ModelBase.__new__
 django.db.models.base.ModelBase.add_to_class
-django.db.models.base.ModelBase.objects
 django.db.models.base.ModelStateFieldsCacheDescriptor.__get__
 django.db.models.base.make_foreign_order_accessors
 django.db.models.base.method_get_order

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -51,6 +51,7 @@
     Recursive(parent=Recursive(parent=None))
     Concrete(parent=Concrete(parent=None))
   out: |
+    main:4: error: Access to generic instance variables via class is ambiguous
     main:4: error: Unexpected attribute "parent" for model "Recursive"
     main:5: error: Cannot instantiate abstract class "Recursive" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
     main:5: error: Unexpected attribute "parent" for model "Recursive"
@@ -209,4 +210,4 @@
 
             def create_animal_generic(klass: Type[T], name: str) -> T:
                 reveal_type(klass)  # N: Revealed type is "Type[T`-1]"
-                return klass.objects.create(name=name)
+                return klass.objects.create(name=name)  # E: Incompatible return value type (got "Animal", expected "T")

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -80,7 +80,7 @@
 
         # Errors:
         AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
-        AbstractModel.objects.create()
+        AbstractModel.objects.create()  # E: Access to generic instance variables via class is ambiguous
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
# I have made things!

mypy 1.5.0 was fixed to understand that metaclass attributes take precedence over attributes in the regular class.  So we need to declare `objects` in the regular class to allow it to be overridden in subclasses.

## Related issues

- Fixes #1648.