### PR TITLE
Make "default_storage" produce a "Storage" object

### DIFF
--- a/django-stubs/core/files/storage/__init__.pyi
+++ b/django-stubs/core/files/storage/__init__.pyi
@@ -24,4 +24,5 @@ def get_storage_class(import_path: str | None = ...) -> type[Storage]: ...
 class DefaultStorage(LazyObject): ...
 
 storages: StorageHandler
-default_storage: DefaultStorage
+# default_storage is actually an instance of DefaultStorage, but it proxies through to a Storage
+default_storage: Storage

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -14,6 +14,9 @@ django.contrib.auth.migrations.*
 django.contrib.flatpages.migrations.*
 django.contrib.contenttypes.migrations.*
 
+# default_storage is actually an instance of DefaultStorage, but it proxies through to a Storage
+django.core.files.storage.default_storage
+
 # BaseArchive abstract methods that take no argument, but typed with arguments to match the Archive and TarArchive Implementations
 django.utils.archive.BaseArchive.list
 django.utils.archive.BaseArchive.extract


### PR DESCRIPTION
The actual `DefaultStorage` storage class is a `LazyObject` proxy, which ought to be a generic `LazyObject[Storage]`, but doesn't support functionality as a proxy. Currently, `default_storage` doesn't have a useful annotation.

## Related issues
- Closes #1610