### PR TITLE
Include model base subclasses in plugin base class hook condition

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -238,7 +238,10 @@ class NewSemanalDjangoPlugin(Plugin):
             sym is not None
             and isinstance(sym.node, TypeInfo)
             and sym.node.metaclass_type is not None
-            and sym.node.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
+            and (
+                sym.node.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
+                or sym.node.metaclass_type.type.has_base(fullnames.MODEL_METACLASS_FULLNAME)
+            )
         ):
             return partial(process_model_class, django_context=self.django_context)
 


### PR DESCRIPTION
# I have made things!

We now also trigger the base class hook for subclasses of `ModelBase`.

Not at all sure how or if we should incorporate this into our test suite.

## Related issues

Refs: https://github.com/typeddjango/django-stubs/pull/1668#issuecomment-1700897353
