### PR TITLE
Annotate Migration fields as a ClassVar

### DIFF
--- a/django-stubs/db/migrations/migration.pyi
+++ b/django-stubs/db/migrations/migration.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import ClassVar
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.operations.base import Operation
@@ -6,12 +7,14 @@ from django.db.migrations.state import ProjectState
 from typing_extensions import Self
 
 class Migration:
-    operations: Sequence[Operation]
-    dependencies: list[tuple[str, str]]
-    run_before: list[tuple[str, str]]
-    replaces: list[tuple[str, str]]
-    initial: bool | None
-    atomic: bool
+    # Django copies these 4 attributes from the class to the instance,
+    # but they're practically used as ClassVar
+    operations: ClassVar[Sequence[Operation]]
+    dependencies: ClassVar[list[tuple[str, str]]]
+    run_before: ClassVar[list[tuple[str, str]]]
+    replaces: ClassVar[list[tuple[str, str]]]
+    initial: ClassVar[bool | None]
+    atomic: ClassVar[bool]
     name: str
     app_label: str
     def __init__(self, name: str, app_label: str) -> None: ...

--- a/tests/typecheck/db/migrations/test_classvar.yml
+++ b/tests/typecheck/db/migrations/test_classvar.yml
@@ -1,0 +1,28 @@
+- case: explicit
+  main: |
+    from typing import ClassVar, List
+    from django.db import migrations
+    from django.db.migrations.operations.base import Operation
+
+    class Migration(migrations.Migration):
+        operations: ClassVar[List[Operation]] = []
+        initial: ClassVar[bool] = True
+
+- case: explicit_incorrect
+  expect_fail: true
+  main: |
+    from typing import ClassVar, List
+    from django.db import migrations
+    from django.db.migrations.operations.base import Operation
+
+    class Migration(migrations.Migration):
+        operations: List[Operation] = []
+        initial: bool = True
+
+- case: implicit
+  main: |
+    from django.db import migrations
+
+    class Migration(migrations.Migration):
+        operations = []
+        initial = True


### PR DESCRIPTION
For the fields `initial` and `atomic`, this is strictly correct, as these are set on the class, not the instance.

For `operations`, `dependencies`, `run_before`, and `replaces`, [Django intentionally copies the class attributes to the instance during construction](https://github.com/django/django/blob/e15174983adf0ee5caa1b678c94bb1c6fbd40402/django/db/migrations/migration.py#L59-L62). However, annotating the attributes as either (using `|`) class or instance variables causes MyPy to issue the warning:
> Cannot override instance variable (previously declared on base class "Migration") with class variable

Since Django projects will nearly always override these as class variables, annotate them as such.