### PR TITLE
fix variance for migration operations

### DIFF
--- a/django-stubs/db/migrations/migration.pyi
+++ b/django-stubs/db/migrations/migration.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.operations.base import Operation

--- a/django-stubs/db/migrations/migration.pyi
+++ b/django-stubs/db/migrations/migration.pyi
@@ -1,4 +1,5 @@
 from typing import Sequence
+
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.state import ProjectState

--- a/django-stubs/db/migrations/migration.pyi
+++ b/django-stubs/db/migrations/migration.pyi
@@ -1,10 +1,11 @@
+from typing import Sequence
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.state import ProjectState
 from typing_extensions import Self
 
 class Migration:
-    operations: list[Operation]
+    operations: Sequence[Operation]
     dependencies: list[tuple[str, str]]
     run_before: list[tuple[str, str]]
     replaces: list[tuple[str, str]]


### PR DESCRIPTION
# I have made things!

without this there are some cryptic errors when the operations are all the same type or they are defined as a tuple

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
