### PR TITLE
fix: missing max_length attribute on forms.FileField

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -261,6 +261,7 @@ class EmailField(CharField):
 
 class FileField(Field):
     allow_empty_file: bool
+    max_length: int | None
     def __init__(
         self,
         *,


### PR DESCRIPTION
# I have made things!

Add `max_length` to `forms.FileField`

Official docs: https://docs.djangoproject.com/en/4.2/ref/forms/fields/#filefield
