### PR TITLE
Remove `null` and `validators` arguments from `ManyToManyField.__init__`

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -238,7 +238,6 @@ class ManyToManyField(RelatedField[_ST, _GT]):
         max_length: int | None = ...,
         unique: bool = ...,
         blank: bool = ...,
-        null: bool = ...,
         db_index: bool = ...,
         default: Any = ...,
         editable: bool = ...,
@@ -252,7 +251,6 @@ class ManyToManyField(RelatedField[_ST, _GT]):
         db_column: str | None = ...,
         db_comment: str | None = ...,
         db_tablespace: str | None = ...,
-        validators: Iterable[validators._ValidatorCallable] = ...,
         error_messages: _ErrorMessagesMapping | None = ...,
     ) -> None: ...
     # class access


### PR DESCRIPTION
Closes: #1638 

Docs: https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.ManyToManyField.swappable

System check warnings

> __fields.W340__: __null__ has no effect on __ManyToManyField__.
> __fields.W341__: __ManyToManyField__ does not support __validators__.

Ref: https://docs.djangoproject.com/en/4.2/ref/checks/#related-fields