### PR TITLE
Handle mismatching types in queryset method resolving gracefully

### DIFF
--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -20,7 +20,7 @@ from mypy.nodes import (
 from mypy.plugin import AnalyzeTypeContext, AttributeContext, CheckerPluginInterface, ClassDefContext
 from mypy.plugins import common
 from mypy.semanal import SemanticAnalyzer
-from mypy.types import AnyType, Instance, LiteralType, TypedDictType, TypeOfAny, TypeType, get_proper_type
+from mypy.types import AnyType, Instance, LiteralType, ProperType, TypedDictType, TypeOfAny, TypeType, get_proper_type
 from mypy.types import Type as MypyType
 from mypy.typevars import fill_typevars
 
@@ -769,7 +769,7 @@ def handle_annotated_type(ctx: AnalyzeTypeContext, django_context: DjangoContext
 
 def get_or_create_annotated_type(
     api: Union[SemanticAnalyzer, CheckerPluginInterface], model_type: Instance, fields_dict: Optional[TypedDictType]
-) -> Instance:
+) -> ProperType:
     """
 
     Get or create the type for a model for which you getting/setting any attr is allowed.
@@ -794,7 +794,9 @@ def get_or_create_annotated_type(
         cast(TypeChecker, api), model_module_name + "." + type_name
     )
     if annotated_typeinfo is None:
-        model_module_file = api.modules[model_module_name]  # type: ignore
+        model_module_file = api.modules.get(model_module_name)  # type: ignore
+        if model_module_file is None:
+            return AnyType(TypeOfAny.from_error)
 
         if isinstance(api, SemanticAnalyzer):
             annotated_model_type = api.named_type_or_none(ANY_ATTR_ALLOWED_CLASS_FULLNAME, [])

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -147,9 +147,11 @@ def get_values_list_row_type(
 
 def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     # called on the Instance, returns QuerySet of something
-    assert isinstance(ctx.type, Instance)
+    if not isinstance(ctx.type, Instance):
+        return ctx.default_return_type
     default_return_type = get_proper_type(ctx.default_return_type)
-    assert isinstance(default_return_type, Instance)
+    if not isinstance(default_return_type, Instance):
+        return ctx.default_return_type
 
     model_type = _extract_model_type_from_queryset(ctx.type)
     if model_type is None:
@@ -205,9 +207,11 @@ def gather_kwargs(ctx: MethodContext) -> Optional[Dict[str, MypyType]]:
 
 def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     # called on the Instance, returns QuerySet of something
-    assert isinstance(ctx.type, Instance)
+    if not isinstance(ctx.type, Instance):
+        return ctx.default_return_type
     default_return_type = get_proper_type(ctx.default_return_type)
-    assert isinstance(default_return_type, Instance)
+    if not isinstance(default_return_type, Instance):
+        return ctx.default_return_type
 
     model_type = _extract_model_type_from_queryset(ctx.type)
     if model_type is None:
@@ -270,9 +274,11 @@ def resolve_field_lookups(lookup_exprs: Sequence[Expression], django_context: Dj
 
 def extract_proper_type_queryset_values(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     # called on QuerySet, return QuerySet of something
-    assert isinstance(ctx.type, Instance)
+    if not isinstance(ctx.type, Instance):
+        return ctx.default_return_type
     default_return_type = get_proper_type(ctx.default_return_type)
-    assert isinstance(default_return_type, Instance)
+    if not isinstance(default_return_type, Instance):
+        return ctx.default_return_type
 
     model_type = _extract_model_type_from_queryset(ctx.type)
     if model_type is None:


### PR DESCRIPTION
Replace a couple of asserts with if statements to avoid unnecessary crashes.

## Related issues

Closes: #1155 
Closes: #843 
Closes: #701 
Refs: #1412 