### PR TITLE
Update `Model._meta` to `ClassVar[Options[Self]]`

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -41,7 +41,7 @@ class Model(metaclass=ModelBase):
     objects: ClassVar[Manager[Self]]
 
     class Meta: ...
-    _meta: Options[Any]
+    _meta: ClassVar[Options[Self]]
     pk: Any
     _state: ModelState
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -613,13 +613,6 @@ class AddExtraFieldMethods(ModelClassInitializer):
                 )
 
 
-class AddMetaOptionsAttribute(ModelClassInitializer):
-    def run_with_model_cls(self, model_cls: Type[Model]) -> None:
-        if "_meta" not in self.model_classdef.info.names:
-            options_info = self.lookup_typeinfo_or_incomplete_defn_error(fullnames.OPTIONS_CLASS_FULLNAME)
-            self.add_new_node_to_model_class("_meta", Instance(options_info, [Instance(self.model_classdef.info, [])]))
-
-
 class ProcessManyToManyFields(ModelClassInitializer):
     """
     Processes 'ManyToManyField()' fields and generates any implicit through tables that
@@ -918,7 +911,6 @@ def process_model_class(ctx: ClassDefContext, django_context: DjangoContext) -> 
         AddDefaultManagerAttribute,
         AddReverseLookups,
         AddExtraFieldMethods,
-        AddMetaOptionsAttribute,
         ProcessManyToManyFields,
         MetaclassAdjustments,
     ]

--- a/tests/typecheck/models/test_contrib_models.yml
+++ b/tests/typecheck/models/test_contrib_models.yml
@@ -62,3 +62,32 @@
                   ...
               class MyUser(AbstractUser):
                   objects: ClassVar[MyUserManager] = MyUserManager()
+
+-   case: can_combine_permissions_mixin_and_abstract_base_user
+    main: |
+        from django.contrib.auth.base_user import AbstractBaseUser
+        from django.contrib.auth.models import PermissionsMixin
+        from myapp.models import AuthUser
+        reveal_type(AuthUser._meta)
+        reveal_type(AuthUser()._meta)
+        reveal_type(PermissionsMixin._meta)
+        reveal_type(AbstractBaseUser._meta)
+    out: |
+        main:4: note: Revealed type is "django.db.models.options.Options[myapp.models.AuthUser]"
+        main:5: note: Revealed type is "django.db.models.options.Options[myapp.models.AuthUser]"
+        main:6: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.models.PermissionsMixin]"
+        main:7: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.base_user.AbstractBaseUser]"
+    installed_apps:
+        - django.contrib.auth
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.contrib.auth.base_user import AbstractBaseUser
+              from django.contrib.auth.models import PermissionsMixin
+
+              class AuthUser(AbstractBaseUser, PermissionsMixin):
+                  class Meta:
+                      abstract = False
+                      db_table = "auth_user"

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -40,7 +40,7 @@
         from myapp.models import AbstractModel
         class MyModel(AbstractModel):
             pass
-        reveal_type(MyModel._meta.get_field('field'))  # N: Revealed type is "Any"
+        reveal_type(MyModel._meta.get_field('field'))  # N: Revealed type is "Union[django.db.models.fields.Field[Any, Any], django.db.models.fields.reverse_related.ForeignObjectRel, django.contrib.contenttypes.fields.GenericForeignKey]"
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
Runtime `_meta` attribute is available on a model type, abstract or not doesn't matter. Also drop the plugin code populating the `Options` argument as it isn't needed.

## Related issues

Closes: #471 