### PR TITLE
Don't crash on bad arguments for model relationship fields

### DIFF
--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1225,7 +1225,7 @@
             instance = arg(field=1, unknown=2)
             reveal_type(instance.field)  # N: Revealed type is "Any"
             reveal_type(instance.unknown)  # N: Revealed type is "Any"
-            reveal_type(instance.bad)  # N: Revealed type is "Any"
+            reveal_type(instance.bad)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[Any]"
             return instance
     installed_apps:
         -   myapp
@@ -1238,4 +1238,4 @@
                 class MyModel(models.Model):
                     field = models.ForeignKey("slef", on_delete=models.CASCADE)  # E: Cannot find model 'slef' referenced in field 'field'
                     unknown = models.OneToOneField("unknown", on_delete=models.CASCADE)  # E: Cannot find model 'unknown' referenced in field 'unknown'
-                    bad = models.ManyToManyField("bad")
+                    bad = models.ManyToManyField("bad")  # E: Need type annotation for "bad"

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1216,3 +1216,26 @@
                     # Reference without explicit app label
                     parents = models.ManyToManyField("Parent")
                     other_parents = models.ManyToManyField(to="Parent")
+
+-   case: test_relations_with_bad_arguments
+    main: |
+        from myapp.models import MyModel
+        from typing import Type
+        def f(arg: Type[MyModel]) -> MyModel:
+            instance = arg(field=1, unknown=2)
+            reveal_type(instance.field)  # N: Revealed type is "Any"
+            reveal_type(instance.unknown)  # N: Revealed type is "Any"
+            reveal_type(instance.bad)  # N: Revealed type is "Any"
+            return instance
+    installed_apps:
+        -   myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class MyModel(models.Model):
+                    field = models.ForeignKey("slef", on_delete=models.CASCADE)  # E: Cannot find model 'slef' referenced in field 'field'
+                    unknown = models.OneToOneField("unknown", on_delete=models.CASCADE)  # E: Cannot find model 'unknown' referenced in field 'unknown'
+                    bad = models.ManyToManyField("bad")


### PR DESCRIPTION
Found 2 places where we needed to catch exceptions in the plugin;

- When massaging descriptor get/set types
- Trying to check the `__init__` call of a model (in regards to fields)

## Related issues

Closes: #403 