### PR TITLE
AbstractBaseUser.REQUIRED_FIELDS is a ClassVar

### DIFF
--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, ClassVar, Literal, TypeVar, overload
 
 from django.db import models
 from django.db.models.base import Model
@@ -14,7 +14,7 @@ class BaseUserManager(models.Manager[_T]):
     def get_by_natural_key(self, username: str | None) -> _T: ...
 
 class AbstractBaseUser(models.Model):
-    REQUIRED_FIELDS: list[str]
+    REQUIRED_FIELDS: ClassVar[list[str]]
 
     password = models.CharField(max_length=128)
     last_login = models.DateTimeField(blank=True, null=True)


### PR DESCRIPTION
On a subclass, there's not correct way to annotate `REQUIRED_FIELDS`.

- Annotating as `list[str]` warns that this should be annotated as `ClassVar`.
- Annotating as `ClassVar` warns that the this doesn't match the parent class.

This field is a class variable anyway, so this is the correct annotation.