### PR TITLE
fill out descriptor for ModelStateFieldsCacheDescriptor

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, TypeVar
+from typing import Any, ClassVar, Final, TypeVar, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -11,7 +11,11 @@ from typing_extensions import Self
 
 _Self = TypeVar("_Self", bound=Model)
 
-class ModelStateFieldsCacheDescriptor: ...
+class ModelStateFieldsCacheDescriptor:
+    @overload
+    def __get__(self, inst: None, owner: object) -> Self: ...
+    @overload
+    def __get__(self, inst: object, owner: object) -> dict[Any, Any]: ...
 
 class ModelState:
     db: str | None


### PR DESCRIPTION
some example usage here (and surrounding lines) https://github.com/getsentry/sentry/blob/808f610f97f78a5ad5df2381efecad642c368f63/src/sentry/db/models/base.py#L92