### PR TITLE
Resolve any `settings.AUTH_USER_MODEL` used as `to` in relation

### DIFF
--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -12,6 +12,7 @@ FOREIGN_KEY_FULLNAME = "django.db.models.fields.related.ForeignKey"
 ONETOONE_FIELD_FULLNAME = "django.db.models.fields.related.OneToOneField"
 MANYTOMANY_FIELD_FULLNAME = "django.db.models.fields.related.ManyToManyField"
 DUMMY_SETTINGS_BASE_CLASS = "django.conf._DjangoConfLazyObject"
+AUTH_USER_MODEL_FULLNAME = "django.conf.settings.AUTH_USER_MODEL"
 
 QUERYSET_CLASS_FULLNAME = "django.db.models.query._QuerySet"
 BASE_MANAGER_CLASS_FULLNAME = "django.db.models.manager.BaseManager"

--- a/tests/typecheck/models/test_contrib_models.yml
+++ b/tests/typecheck/models/test_contrib_models.yml
@@ -91,3 +91,71 @@
                   class Meta:
                       abstract = False
                       db_table = "auth_user"
+
+-   case: test_relation_specified_by_auth_user_model
+    main: |
+        from other.models import Other
+        reveal_type(Other().users.get())
+        reveal_type(Other.users.through)
+        reveal_type(Other.users.through().myuser)
+        reveal_type(Other.users.through.objects.get().myuser)
+
+        reveal_type(Other().user)
+
+        reveal_type(Other().unq_user)
+    out: |
+        main:2: note: Revealed type is "myapp.models.MyUser"
+        main:3: note: Revealed type is "Type[other.models.Other_users]"
+        main:4: note: Revealed type is "myapp.models.MyUser"
+        main:5: note: Revealed type is "myapp.models.MyUser"
+
+        main:7: note: Revealed type is "myapp.models.MyUser"
+
+        main:9: note: Revealed type is "myapp.models.MyUser"
+    custom_settings: |
+        INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth', 'myapp', 'other')
+        AUTH_USER_MODEL='myapp.MyUser'
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+
+              class MyUser(models.Model):
+                  ...
+        - path: other/__init__.py
+        - path: other/models.py
+          content: |
+              from django.conf import settings
+              from django.db import models
+
+              class Other(models.Model):
+                  users = models.ManyToManyField(settings.AUTH_USER_MODEL)
+                  user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+                  unq_user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+
+-   case: test_relate_to_auth_user_model_when_auth_not_installed
+    main: |
+        from other.models import Other
+        reveal_type(Other().user)
+    out: |
+        main:2: note: Revealed type is "myapp.models.MyUser"
+    custom_settings: |
+        INSTALLED_APPS = ('django.contrib.contenttypes', 'myapp', 'other')
+        AUTH_USER_MODEL='myapp.MyUser'
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+
+              class MyUser(models.Model):
+                  ...
+        - path: other/__init__.py
+        - path: other/models.py
+          content: |
+              from django.conf import settings
+              from django.db import models
+
+              class Other(models.Model):
+                  user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)


### PR DESCRIPTION
e.g.

```python
OneToOneField(settings.AUTH_USER_MODEL, ...)
ForeignKey(settings.AUTH_USER_MODEL, ...)
ManyToManyField(settings.AUTH_USER_MODEL, ...)
```

## Related issues

Ref: https://github.com/typeddjango/django-stubs/pull/1719#issuecomment-1734341183
Ref: #1740