### PR TITLE
Add stubs for `django.contrib.postgres.expressions`

### DIFF
--- a/django-stubs/contrib/postgres/expressions.pyi
+++ b/django-stubs/contrib/postgres/expressions.pyi
@@ -1,8 +1,9 @@
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import Subquery
+from django.utils.functional import cached_property
 
 class ArraySubquery(Subquery):
     template: str
 
-    @property
+    @cached_property
     def output_field(self) -> ArrayField: ...

--- a/django-stubs/contrib/postgres/expressions.pyi
+++ b/django-stubs/contrib/postgres/expressions.pyi
@@ -1,0 +1,8 @@
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import Subquery
+
+class ArraySubquery(Subquery):
+    template: str
+
+    @property
+    def output_field(self) -> ArrayField: ...

--- a/django-stubs/contrib/postgres/expressions.pyi
+++ b/django-stubs/contrib/postgres/expressions.pyi
@@ -1,9 +1,14 @@
+from typing import Any
+
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import Subquery
+from django.db.models.query import QuerySet
+from django.db.models.sql.query import Query
 from django.utils.functional import cached_property
 
 class ArraySubquery(Subquery):
     template: str
 
+    def __init__(self, queryset: Query | QuerySet[Any], **kwargs: Any) -> None: ...
     @cached_property
     def output_field(self) -> ArrayField: ...

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -163,6 +163,7 @@ django.contrib.gis.forms.BaseForm.changed_data
 django.contrib.gis.forms.BaseFormSet.forms
 django.contrib.gis.forms.BaseFormSet.management_form
 django.contrib.gis.forms.BoundField.subwidgets
+django.contrib.postgres.expressions.ArraySubquery.output_field
 django.core.files.File.size
 django.core.files.base.File.size
 django.core.files.storage.FileSystemStorage.base_location


### PR DESCRIPTION
I'm a little bit surprised that this wasn't part of the `allowlist_todo.txt`. Suppose there might be some discrepancy in stubtest for missing modules?