### PR TITLE
Require 1 callable argument for `@cached_property`

### DIFF
--- a/django-stubs/utils/functional.pyi
+++ b/django-stubs/utils/functional.pyi
@@ -7,9 +7,9 @@ from typing_extensions import Self, TypeAlias
 _T = TypeVar("_T")
 
 class cached_property(Generic[_T]):
-    func: Callable[..., _T]
+    func: Callable[[Any], _T]
     name: str | None
-    def __init__(self, func: Callable[..., _T], name: str | None = ...) -> None: ...
+    def __init__(self, func: Callable[[Any], _T], name: str | None = ...) -> None: ...
     @overload
     def __get__(self, instance: None, cls: type[Any] | None = ...) -> Self: ...
     @overload

--- a/tests/typecheck/utils/test_functional.yml
+++ b/tests/typecheck/utils/test_functional.yml
@@ -6,12 +6,14 @@
       class Foo:
           @cached_property
           def attr(self) -> List[str]: ...
+          @cached_property  # E: Argument 1 to "cached_property" has incompatible type "Callable[[Foo, str], List[str]]"; expected "Callable[[Any], List[str]]"
+          def attr2(self, arg2: str) -> List[str]: ...
 
           reveal_type(attr)      # N: Revealed type is "django.utils.functional.cached_property[builtins.list[builtins.str]]"
           reveal_type(attr.name) # N: Revealed type is "Union[builtins.str, None]"
 
       reveal_type(Foo.attr)      # N: Revealed type is "django.utils.functional.cached_property[builtins.list[builtins.str]]"
-      reveal_type(Foo.attr.func) # N: Revealed type is "def (*Any, **Any) -> builtins.list[builtins.str]"
+      reveal_type(Foo.attr.func) # N: Revealed type is "def (Any) -> builtins.list[builtins.str]"
 
       f = Foo()
       reveal_type(f.attr)        # N: Revealed type is "builtins.list[builtins.str]"


### PR DESCRIPTION
`django.utils.functional.cached_property` requires a single argument, not arbitrary `*args` and `**kwargs`.

Having more than 1 argument results in a runtime error when any decorated attribute is accessed (i.e. `cached_property` being evaluated)