### PR TITLE
Support `psycopg2.sql.SQL` in `QuerySet.raw`

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -2,6 +2,7 @@ import datetime
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, MutableMapping, Reversible, Sequence, Sized
 from typing import Any, Generic, NamedTuple, TypeVar, overload
 
+from django.db.backends.utils import _ExecuteQuery
 from django.db.models import Manager
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable
@@ -121,7 +122,7 @@ class _QuerySet(Generic[_T, _Row], Collection[_Row], Reversible[_Row], Sized):
     async def acontains(self, obj: Model) -> bool: ...
     def raw(
         self,
-        raw_query: str,
+        raw_query: _ExecuteQuery,
         params: Any = ...,
         translations: dict[str, str] | None = ...,
         using: str | None = ...,


### PR DESCRIPTION
## Related issues

Refs: #1029 