### PR TITLE
Update `django.middleware.csrf` types

### DIFF
--- a/django-stubs/middleware/csrf.pyi
+++ b/django-stubs/middleware/csrf.pyi
@@ -1,18 +1,30 @@
+from collections import defaultdict
 from collections.abc import Callable
 from logging import Logger
+from re import Pattern
 from typing import Any
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseForbidden
 from django.utils.deprecation import MiddlewareMixin
+from django.utils.functional import cached_property
 
 logger: Logger
+
+invalid_token_chars_re: Pattern[str]
+
+REASON_BAD_ORIGIN: str
 REASON_NO_REFERER: str
 REASON_BAD_REFERER: str
 REASON_NO_CSRF_COOKIE: str
+REASON_CSRF_TOKEN_MISSING: str
 REASON_BAD_TOKEN: str
 REASON_MALFORMED_REFERER: str
 REASON_INSECURE_REFERER: str
+
+REASON_INCORRECT_LENGTH: str
+REASON_INVALID_CHARACTERS: str
+
 CSRF_SECRET_LENGTH: int
 CSRF_TOKEN_LENGTH: Any
 CSRF_ALLOWED_CHARS: Any
@@ -21,7 +33,21 @@ CSRF_SESSION_KEY: str
 def get_token(request: HttpRequest) -> str: ...
 def rotate_token(request: HttpRequest) -> None: ...
 
+class InvalidTokenFormat(Exception):
+    reason: str
+    def __init__(self, reason: str) -> None: ...
+
+class RejectRequest(Exception):
+    reason: str
+    def __init__(self, reason: str) -> None: ...
+
 class CsrfViewMiddleware(MiddlewareMixin):
+    @cached_property
+    def csrf_trusted_origins_hosts(self) -> list[str]: ...
+    @cached_property
+    def allowed_origins_exact(self) -> set[str]: ...
+    @cached_property
+    def allowed_origin_subdomains(self) -> defaultdict[str, list[str]]: ...
     def process_request(self, request: HttpRequest) -> None: ...
     def process_view(
         self, request: HttpRequest, callback: Callable | None, callback_args: tuple, callback_kwargs: dict[str, Any]

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -60,6 +60,7 @@ django.core.validators.slug_re
 django.core.validators.slug_unicode_re
 django.core.management.commands.makemessages.plural_forms_re
 django.http.request.host_validation_re
+django.middleware.csrf.invalid_token_chars_re
 django.template.base.filter_re
 django.template.base.kwarg_re
 django.test.client.CONTENT_TYPE_RE
@@ -103,3 +104,9 @@ django.db.migrations.operations.models.AlterTogetherOptionOperation.option_name
 # Attributes defaulting to None messing with mypy
 django.views.generic.detail.SingleObjectMixin.model
 django.views.generic.edit.BaseDeleteView.form_class
+
+# `error: <...> is not present at runtime`
+# This happens often for variables removed in later django version.
+# We still keep them in stubs to be a bit more backward compatible.
+# RemovedInDjango40:
+django.middleware.csrf.REASON_BAD_TOKEN

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -2158,17 +2158,6 @@ django.middleware.cache.CacheMiddleware.__init__
 django.middleware.cache.CacheMiddleware.cache
 django.middleware.cache.FetchFromCacheMiddleware.cache
 django.middleware.cache.UpdateCacheMiddleware.cache
-django.middleware.csrf.CsrfViewMiddleware.allowed_origin_subdomains
-django.middleware.csrf.CsrfViewMiddleware.allowed_origins_exact
-django.middleware.csrf.CsrfViewMiddleware.csrf_trusted_origins_hosts
-django.middleware.csrf.InvalidTokenFormat
-django.middleware.csrf.REASON_BAD_ORIGIN
-django.middleware.csrf.REASON_BAD_TOKEN
-django.middleware.csrf.REASON_CSRF_TOKEN_MISSING
-django.middleware.csrf.REASON_INCORRECT_LENGTH
-django.middleware.csrf.REASON_INVALID_CHARACTERS
-django.middleware.csrf.RejectRequest
-django.middleware.csrf.invalid_token_chars_re
 django.middleware.gzip.GZipMiddleware.max_random_bytes
 django.shortcuts.SupportsGetAbsoluteUrl
 django.template.Engine.template_context_processors


### PR DESCRIPTION
This MR updates the types in `django.middleware.csrf`.

I also added a section in the `todolist.txt` for the specific errors `<...> is not present at runtime`. I don't think we should remove these because it would cause incompatibility with older Django version we partially support.

But maybe worth keeping a track of for when we want to officially drop support of some django versions ?

This removes 11 entries from the todolist