### PR TITLE
Tests: Add mypy error codes to typecheck

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,7 +13,6 @@ warn_unused_configs = true
 warn_unreachable = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-show_error_codes = false
 disable_error_code = empty-body
 # TODO: update our output assertions to match a new syntax
 force_uppercase_builtins = true

--- a/tests/typecheck/contrib/admin/test_decorators.yml
+++ b/tests/typecheck/contrib/admin/test_decorators.yml
@@ -17,7 +17,7 @@
         @admin.display
         def display_property(self) -> str: ...
 
-        @admin.display  # E: Decorators on top of @property are not supported
+        @admin.display  # E: Decorators on top of @property are not supported  [misc]
         @property
         def incorrect_property(self) -> str: ...
 
@@ -79,10 +79,10 @@
     @admin.action
     def freestanding_action_file_response(modeladmin: "MyModelAdmin", request: HttpRequest, queryset: QuerySet[MyModel]) -> FileResponse: ...
 
-    @admin.action # E: Value of type variable "_ModelAdmin" of "action" cannot be "int"
+    @admin.action # E: Value of type variable "_ModelAdmin" of "action" cannot be "int"  [type-var]
     def freestanding_action_invalid_bare(modeladmin: int, request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
 
-    @admin.action(description="Some text here", permissions=["test"]) # E: Value of type variable "_ModelAdmin" of function cannot be "int"
+    @admin.action(description="Some text here", permissions=["test"]) # E: Value of type variable "_ModelAdmin" of function cannot be "int"  [type-var]
     def freestanding_action_invalid_fancy(modeladmin: int, request: HttpRequest, queryset: QuerySet[MyModel]) -> None: ...
 
     @admin.register(MyModel)
@@ -101,10 +101,10 @@
         @admin.action(description="Some text here", permissions=["test"])
         def method_action_file_response(self, request: HttpRequest, queryset: QuerySet[MyModel]) -> FileResponse: ...
 
-        @admin.action  # E: Value of type variable "_QuerySet" of "action" cannot be "int"
+        @admin.action  # E: Value of type variable "_QuerySet" of "action" cannot be "int"  [type-var]
         def method_action_invalid_bare(self, request: HttpRequest, queryset: int) -> None: ...
 
-        @admin.action(description="Some text here", permissions=["test"])  # E: Value of type variable "_QuerySet" of function cannot be "int"
+        @admin.action(description="Some text here", permissions=["test"])  # E: Value of type variable "_QuerySet" of function cannot be "int"  [type-var]
         def method_action_invalid_fancy(self, request: HttpRequest, queryset: int) -> None: ...
 
         def method(self) -> None:

--- a/tests/typecheck/contrib/admin/test_options.yml
+++ b/tests/typecheck/contrib/admin/test_options.yml
@@ -108,17 +108,17 @@
 
       class A(admin.ModelAdmin):
           fieldsets = [
-              (None, {}),  # E: Missing key "fields" for TypedDict "_FieldOpts"
+              (None, {}),  # E: Missing key "fields" for TypedDict "_FieldOpts"  [typeddict-item]
           ]
 -   case: errors_on_invalid_radio_fields
     main: |
       from django.contrib import admin
 
       class A(admin.ModelAdmin):
-          radio_fields = {"some_field": 0}  # E: Dict entry 0 has incompatible type "str": "Literal[0]"; expected "str": "Literal[1, 2]"
+          radio_fields = {"some_field": 0}  # E: Dict entry 0 has incompatible type "str": "Literal[0]"; expected "str": "Literal[1, 2]"  [dict-item]
 
       class B(admin.ModelAdmin):
-          radio_fields = {1: admin.VERTICAL}  # E: Dict entry 0 has incompatible type "int": "Literal[2]"; expected "str": "Literal[1, 2]"
+          radio_fields = {1: admin.VERTICAL}  # E: Dict entry 0 has incompatible type "int": "Literal[2]"; expected "str": "Literal[1, 2]"  [dict-item]
 -   case: errors_for_invalid_formfield_overrides
     main: |
       from django.contrib import admin
@@ -126,7 +126,7 @@
 
       class A(admin.ModelAdmin):
           formfield_overrides = {
-              "not a field": {  # E: Dict entry 0 has incompatible type "str": "Dict[str, Any]"; expected "Type[Field[Any, Any]]": "Mapping[str, Any]"
+              "not a field": {  # E: Dict entry 0 has incompatible type "str": "Dict[str, Any]"; expected "Type[Field[Any, Any]]": "Mapping[str, Any]"  [dict-item]
                   "widget": Textarea
               }
           }
@@ -140,7 +140,7 @@
           pass
 
       class A(admin.ModelAdmin):
-          actions = [an_action]  # E: List item 0 has incompatible type "Callable[[None], None]"; expected "Union[Callable[[Any, HttpRequest, _QuerySet[Any, Any]], Optional[HttpResponseBase]], str]"
+          actions = [an_action]  # E: List item 0 has incompatible type "Callable[[None], None]"; expected "Union[Callable[[Any, HttpRequest, _QuerySet[Any, Any]], Optional[HttpResponseBase]], str]"  [list-item]
 -   case: errors_for_invalid_model_admin_generic
     main: |
       from django.contrib.admin import ModelAdmin
@@ -150,4 +150,4 @@
           pass
 
       class A(ModelAdmin[TestModel]):
-          model = int  # E: Incompatible types in assignment (expression has type "Type[int]", base class "ModelAdmin" defined the type as "Type[TestModel]")
+          model = int  # E: Incompatible types in assignment (expression has type "Type[int]", base class "ModelAdmin" defined the type as "Type[TestModel]")  [assignment]

--- a/tests/typecheck/contrib/auth/test_decorators.yml
+++ b/tests/typecheck/contrib/auth/test_decorators.yml
@@ -26,7 +26,7 @@
     main: |
         from typing import Any
         from django.contrib.auth.decorators import login_required
-        @login_required()  # E: Value of type variable "_VIEW" of function cannot be "Callable[[Any], str]"
+        @login_required()  # E: Value of type variable "_VIEW" of function cannot be "Callable[[Any], str]"  [type-var]
         def view_func2(request: Any) -> str: ...
 -   case: user_passes_test
     main: |
@@ -39,7 +39,7 @@
     main: |
         from django.http import HttpRequest, HttpResponse
         from django.contrib.auth.decorators import user_passes_test
-        @user_passes_test  # E: Argument 1 to "user_passes_test" has incompatible type "Callable[[HttpRequest], HttpResponse]"; expected "Callable[[Union[AbstractBaseUser, AnonymousUser]], bool]"
+        @user_passes_test  # E: Argument 1 to "user_passes_test" has incompatible type "Callable[[HttpRequest], HttpResponse]"; expected "Callable[[Union[AbstractBaseUser, AnonymousUser]], bool]"  [arg-type]
         def view_func(request: HttpRequest) -> HttpResponse: ...
 -   case: permission_required
     main: |

--- a/tests/typecheck/contrib/postgres/test_fields.yml
+++ b/tests/typecheck/contrib/postgres/test_fields.yml
@@ -3,9 +3,9 @@
         from typing import List
         from myapp.models import MyModel
         array_val: List[int] = [1]
-        MyModel(array=array_val)  # E: Incompatible type for "array" of "MyModel" (got "List[int]", expected "Union[Sequence[str], Combinable]")
+        MyModel(array=array_val)  # E: Incompatible type for "array" of "MyModel" (got "List[int]", expected "Union[Sequence[str], Combinable]")  [misc]
         non_init = MyModel()
-        non_init.array = array_val  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[Sequence[str], Combinable]")
+        non_init.array = array_val  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[Sequence[str], Combinable]")  [assignment]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/contrib/sitemaps/test_generic_sitemap.yml
+++ b/tests/typecheck/contrib/sitemaps/test_generic_sitemap.yml
@@ -18,7 +18,7 @@
                     "myapp:detail-offer",
                     kwargs={
                         "provider_name": item.provider,
-                        "offer_name": item.trc, # E: "Offer" has no attribute "trc"
+                        "offer_name": item.trc, # E: "Offer" has no attribute "trc"  [attr-defined]
                     },
                 )
 
@@ -44,12 +44,12 @@
             ),
         ]
     out: |
-        main:24: error: Return type "str" of "items" incompatible with return type "Iterable[Offer]" in supertype "Sitemap"
-        main:26: error: Return type "int" of "location" incompatible with return type "str" in supertype "Sitemap"
-        main:26: error: Argument 1 of "location" is incompatible with supertype "Sitemap"; supertype defines the argument type as "Offer"
+        main:24: error: Return type "str" of "items" incompatible with return type "Iterable[Offer]" in supertype "Sitemap"  [override]
+        main:26: error: Return type "int" of "location" incompatible with return type "str" in supertype "Sitemap"  [override]
+        main:26: error: Argument 1 of "location" is incompatible with supertype "Sitemap"; supertype defines the argument type as "Offer"  [override]
         main:26: note: This violates the Liskov substitution principle
         main:26: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-        main:40: error: Argument 1 to "GenericSitemap" has incompatible type "Dict[str, List[int]]"; expected "Mapping[str, Union[datetime, _QuerySet[Offer, Offer], str]]"
+        main:40: error: Argument 1 to "GenericSitemap" has incompatible type "Dict[str, List[int]]"; expected "Mapping[str, Union[datetime, _QuerySet[Offer, Offer], str]]"  [arg-type]
 
     installed_apps:
         - myapp

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -25,5 +25,5 @@
 
     reveal_type(check_baz)  # N: Revealed type is "django.core.checks.registry._ProcessedCheckCallable[def (**kwargs: Any) -> typing.Sequence[django.core.checks.messages.CheckMessage]]"
 
-    @register()  # E: Value of type variable "_C" of function cannot be "Callable[[int], Sequence[CheckMessage]]"
+    @register()  # E: Value of type variable "_C" of function cannot be "Callable[[int], Sequence[CheckMessage]]"  [type-var]
     def wrong_args(bla: int) -> Sequence[CheckMessage]: ...

--- a/tests/typecheck/db/migrations/test_operations.yml
+++ b/tests/typecheck/db/migrations/test_operations.yml
@@ -16,5 +16,5 @@
 
      RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])], reverse_sql=["SOME SQLS", ("SOME SQLS %s, %s", ["PARAM", "ANOTHER PARAM"])])
 
-     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "Tuple[str, Dict[<nothing>, <nothing>]]"; expected "Union[str, Union[List[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[()]], None]]]], Tuple[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[()]], None]]], ...], Tuple[()]]]"
-     RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", [object(), "ANOTHER PARAM"])]) # E: List item 0 has incompatible type "object"; expected "str"
+     RunSQL(sql=("SOME SQL", {}))                                                 # E: Argument "sql" to "RunSQL" has incompatible type "Tuple[str, Dict[<nothing>, <nothing>]]"; expected "Union[str, Union[List[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[()]], None]]]], Tuple[Union[str, Tuple[str, Union[Dict[str, Any], Union[List[str], Tuple[str, ...], Tuple[()]], None]]], ...], Tuple[()]]]"  [arg-type]
+     RunSQL(sql=["SOME SQLS", ("SOME SQLS %s, %s", [object(), "ANOTHER PARAM"])]) # E: List item 0 has incompatible type "object"; expected "str"  [list-item]

--- a/tests/typecheck/db/models/test_init.yml
+++ b/tests/typecheck/db/models/test_init.yml
@@ -20,7 +20,7 @@
         assert field.many_to_one is not None
         my_bool = field.many_to_one
     out: |
-        main:6: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")
-        main:7: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")
-        main:8: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")
-        main:9: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")
+        main:6: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")  [assignment]
+        main:7: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")  [assignment]
+        main:8: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")  [assignment]
+        main:9: error: Incompatible types in assignment (expression has type "Optional[bool]", variable has type "bool")  [assignment]

--- a/tests/typecheck/db/models/test_query.yml
+++ b/tests/typecheck/db/models/test_query.yml
@@ -18,7 +18,7 @@
         class MyModelModelIterable(ModelIterable[MyModel]):
             pass
     out: |
-        main:4: error: Type argument "int" of "ModelIterable" must be a subtype of "Model"
+        main:4: error: Type argument "int" of "ModelIterable" must be a subtype of "Model"  [type-var]
 
 
 -   case: django_db_models_query_module_has_ValuesListIterable
@@ -36,7 +36,7 @@
         class NonTupleValuesListIterable(ValuesListIterable[int]):
             pass
     out: |
-        main:11: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"
+        main:11: error: Type argument "int" of "ValuesListIterable" must be a subtype of "Tuple[Any, ...]"  [type-var]
 
 
 -   case: django_db_models_query_module_has_NamedValuesListIterable
@@ -53,4 +53,4 @@
         QuerySet._iterable_class = ModelIterable
         QuerySet._iterable_class = int
     out: |
-        main:5: error: Incompatible types in assignment (expression has type "Type[int]", variable has type "Type[BaseIterable[Any]]")
+        main:5: error: Incompatible types in assignment (expression has type "Type[int]", variable has type "Type[BaseIterable[Any]]")  [assignment]

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -63,7 +63,7 @@
     main: |
         from myapp.models import User
         reveal_type(User().my_pk)  # N: Revealed type is "builtins.int"
-        User().id  # E: "User" has no attribute "id"
+        User().id  # E: "User" has no attribute "id"  [attr-defined]
     installed_apps:
         - myapp
     files:
@@ -94,9 +94,9 @@
 -   case: blank_and_not_null_charfield_does_not_allow_none
     main: |
         from myapp.models import MyModel
-        MyModel(notnulltext=None)  # E: Incompatible type for "notnulltext" of "MyModel" (got "None", expected "Union[str, int, Combinable]")
+        MyModel(notnulltext=None)  # E: Incompatible type for "notnulltext" of "MyModel" (got "None", expected "Union[str, int, Combinable]")  [misc]
         MyModel(notnulltext="")
-        MyModel().notnulltext = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[str, int, Combinable]")
+        MyModel().notnulltext = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[str, int, Combinable]")  [assignment]
         reveal_type(MyModel().notnulltext)  # N: Revealed type is "builtins.str"
     installed_apps:
         - myapp
@@ -158,7 +158,7 @@
             published = cast(models.Field[Year, Year], models.IntegerField())
         book = Book()
         reveal_type(book.published)  # N: Revealed type is "main.Year"
-        book.published = 2006  # E: Incompatible types in assignment (expression has type "int", variable has type "Year")
+        book.published = 2006  # E: Incompatible types in assignment (expression has type "int", variable has type "Year")  [assignment]
         book.published = Year(2006)
         reveal_type(book.published)  # N: Revealed type is "main.Year"
         def accepts_int(arg: int) -> None: ...
@@ -190,9 +190,9 @@
         from myapp.models import RenamedField
         instance = RenamedField()
         reveal_type(instance.modelname) # N: Revealed type is "builtins.int"
-        instance.fieldname # E: "RenamedField" has no attribute "fieldname"
+        instance.fieldname # E: "RenamedField" has no attribute "fieldname"  [attr-defined]
         instance.modelname = 1
-        instance.fieldname = 1 # E: "RenamedField" has no attribute "fieldname"
+        instance.fieldname = 1 # E: "RenamedField" has no attribute "fieldname"  [attr-defined]
   installed_apps:
     - myapp
   files:

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -36,7 +36,7 @@
         from myapp.models import MyModel
         reveal_type(MyModel().text)  # N: Revealed type is "builtins.str"
         reveal_type(MyModel().text_nullable)  # N: Revealed type is "Union[builtins.str, None]"
-        MyModel().text = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[str, int, Combinable]")
+        MyModel().text = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[str, int, Combinable]")  [assignment]
         MyModel().text_nullable = None
     installed_apps:
         - myapp
@@ -69,7 +69,7 @@
     main: |
         from myapp.models import Publisher, Book
         reveal_type(Book().publisher)  # N: Revealed type is "Union[myapp.models.Publisher, None]"
-        Book().publisher = 11  # E: Incompatible types in assignment (expression has type "int", variable has type "Union[Publisher, Combinable, None]")
+        Book().publisher = 11  # E: Incompatible types in assignment (expression has type "int", variable has type "Union[Publisher, Combinable, None]")  [assignment]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -47,8 +47,8 @@
         reveal_type(book.publisher_id)  # N: Revealed type is "uuid.UUID"
         book.publisher_id = '821850bb-c105-426f-b340-3974419d00ca'
         book.publisher_id = UUID('821850bb-c105-426f-b340-3974419d00ca')
-        book.publisher_id = [1]  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[str, UUID]")
-        book.publisher_id = Publisher()  # E: Incompatible types in assignment (expression has type "Publisher", variable has type "Union[str, UUID]")
+        book.publisher_id = [1]  # E: Incompatible types in assignment (expression has type "List[int]", variable has type "Union[str, UUID]")  [assignment]
+        book.publisher_id = Publisher()  # E: Incompatible types in assignment (expression has type "Publisher", variable has type "Union[str, UUID]")  [assignment]
     installed_apps:
         - myapp
     files:
@@ -154,7 +154,7 @@
     main: |
         from myapp.models import View
         reveal_type(View().app.views)  # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.View]"
-        View().app.unknown  # E: "App" has no attribute "unknown"
+        View().app.unknown  # E: "App" has no attribute "unknown"  [attr-defined]
     installed_apps:
         - myapp
         - myapp2
@@ -393,15 +393,15 @@
         reveal_type(Book().publisher_id)  # N: Revealed type is "builtins.str"
         Book(publisher_id=1)
         Book(publisher_id='hello')
-        Book(publisher_id=datetime.datetime.now())  # E: Incompatible type for "publisher_id" of "Book" (got "datetime", expected "Union[str, int, Combinable]")
+        Book(publisher_id=datetime.datetime.now())  # E: Incompatible type for "publisher_id" of "Book" (got "datetime", expected "Union[str, int, Combinable]")  [misc]
         Book.objects.create(publisher_id=1)
         Book.objects.create(publisher_id='hello')
 
         reveal_type(Book2().publisher_id)  # N: Revealed type is "builtins.int"
         Book2(publisher_id=1)
-        Book2(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        Book2(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
         Book2.objects.create(publisher_id=1)
-        Book2.objects.create(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        Book2.objects.create(publisher_id=[])  # E: Incompatible type for "publisher_id" of "Book2" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -463,7 +463,7 @@
             content: |
                 from django.db import models
                 class Book(models.Model):
-                    publisher = models.ForeignKey(to='Publisher', on_delete=models.CASCADE)  # E: Cannot find model 'Publisher' referenced in field 'publisher'
+                    publisher = models.ForeignKey(to='Publisher', on_delete=models.CASCADE)  # E: Cannot find model 'Publisher' referenced in field 'publisher'  [misc]
 
 
 -   case: test_foreign_key_field_without_backwards_relation
@@ -476,7 +476,7 @@
         reveal_type(publisher.books)
         reveal_type(publisher.books2)  # N: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Book]"
     out: |
-        main:6: error: "Publisher" has no attribute "books"; maybe "books2"?
+        main:6: error: "Publisher" has no attribute "books"; maybe "books2"?  [attr-defined]
         main:6: note: Revealed type is "Any"
     installed_apps:
         - myapp
@@ -735,7 +735,7 @@
                 class TransactionLog(models.Model):
                     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
     out: |
-        myapp/models:11: error: Could not resolve manager type for "myapp.models.Transaction.objects"
+        myapp/models:11: error: Could not resolve manager type for "myapp.models.Transaction.objects"  [django-manager-missing]
         myapp/models:13: note: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.TransactionLog]"
         myapp/models:15: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Transaction]"
         myapp/models:16: note: Revealed type is "Any"
@@ -867,7 +867,7 @@
     main: |
         from myapp.models import User
         reveal_type(User().purchases)  # N: Revealed type is "builtins.int"
-        User().purchases.filter()  # E: "int" has no attribute "filter"
+        User().purchases.filter()  # E: "int" has no attribute "filter"  [attr-defined]
     installed_apps:
         - myapp
     files:
@@ -961,7 +961,7 @@
             content: |
                 from django.db import models
                 class InstalledModel(models.Model):
-                    non_installed = models.ForeignKey(  # E: Cannot find model 'not_installed.NonInstalledModel' referenced in field 'non_installed'
+                    non_installed = models.ForeignKey(  # E: Cannot find model 'not_installed.NonInstalledModel' referenced in field 'non_installed'  [misc]
                         "not_installed.NonInstalledModel", on_delete=models.CASCADE
                     )
 -   case: test_foreign_key_to_as_string
@@ -1049,8 +1049,8 @@
         main:5: note: Revealed type is "Type[django.core.exceptions.ObjectDoesNotExist]"
         main:6: note: Revealed type is "Type[django.core.exceptions.ObjectDoesNotExist]"
         main:9: note: Revealed type is "myapp.models.MyModel"
-        main:14: error: Incompatible types in assignment (expression has type "Other", variable has type "Optional[MyModel]")
-        main:17: error: Incompatible types in assignment (expression has type "Other", variable has type "Optional[MyModel]")
+        main:14: error: Incompatible types in assignment (expression has type "Other", variable has type "Optional[MyModel]")  [assignment]
+        main:17: error: Incompatible types in assignment (expression has type "Other", variable has type "Optional[MyModel]")  [assignment]
     installed_apps:
         -   myapp
     files:
@@ -1195,8 +1195,8 @@
     out: |
         main:2: note: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[Any]"
         main:3: note: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[Any]"
-        myapp/models/child:5: error: Need type annotation for "parents"
-        myapp/models/child:6: error: Need type annotation for "other_parents"
+        myapp/models/child:5: error: Need type annotation for "parents"  [var-annotated]
+        myapp/models/child:6: error: Need type annotation for "other_parents"  [var-annotated]
     installed_apps:
         -   myapp
     files:
@@ -1239,6 +1239,6 @@
                 from django.db import models
 
                 class MyModel(models.Model):
-                    field = models.ForeignKey("slef", on_delete=models.CASCADE)  # E: Cannot find model 'slef' referenced in field 'field'
-                    unknown = models.OneToOneField("unknown", on_delete=models.CASCADE)  # E: Cannot find model 'unknown' referenced in field 'unknown'
-                    bad = models.ManyToManyField("bad")  # E: Need type annotation for "bad"
+                    field = models.ForeignKey("slef", on_delete=models.CASCADE)  # E: Cannot find model 'slef' referenced in field 'field'  [misc]
+                    unknown = models.OneToOneField("unknown", on_delete=models.CASCADE)  # E: Cannot find model 'unknown' referenced in field 'unknown'  [misc]
+                    bad = models.ManyToManyField("bad")  # E: Need type annotation for "bad"  [var-annotated]

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -8,20 +8,20 @@
 
         unannotated_user = User.objects.get(id=1)
 
-        print(annotated_user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "asdf"
-        print(unannotated_user.asdf) # E: "User" has no attribute "asdf"
+        print(annotated_user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "asdf"  [attr-defined]
+        print(unannotated_user.asdf) # E: "User" has no attribute "asdf"  [attr-defined]
 
         def func(user: Annotated[User, Annotations]) -> str:
             return user.asdf
 
-        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"
-        func(annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"
+        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
+        func(annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
 
         def func2(user: WithAnnotations[User]) -> str:
             return user.asdf
 
-        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"
-        func2(annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"
+        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
+        func2(annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
     installed_apps:
         - myapp
     files:
@@ -44,26 +44,26 @@
             foo: str
 
         def func(user: Annotated[User, Annotations[MyDict]]) -> str:
-            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"
+            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
         unannotated_user = User.objects.get(id=1)
         annotated_user = User.objects.annotate(foo=Value("")).get()
         other_annotated_user = User.objects.annotate(other=Value("")).get()
 
-        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"
+        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
         x: WithAnnotations[User]
         func(x)
         func(annotated_user)
-        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"
+        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
 
         def func2(user: WithAnnotations[User, MyDict]) -> str:
-            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"
+            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
-        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"
+        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
         func2(annotated_user)
-        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"
+        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
     installed_apps:
         - myapp
     files:
@@ -100,7 +100,7 @@
         func(y)
 
         z: WithAnnotations[User, OtherDict]
-        func(z) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict('main.OtherDict', {'other': builtins.str})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.NarrowDict', {'foo': builtins.str})]"
+        func(z) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict('main.OtherDict', {'other': builtins.str})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.NarrowDict', {'foo': builtins.str})]"  [arg-type]
 
     installed_apps:
         - myapp
@@ -124,7 +124,7 @@
         annotated = qs.get()
         reveal_type(annotated) # N: Revealed type is "django_stubs_ext.WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"
         reveal_type(annotated.foo) # N: Revealed type is "Any"
-        print(annotated.bar) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "bar"
+        print(annotated.bar) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "bar"  [attr-defined]
         reveal_type(annotated.username) # N: Revealed type is "builtins.str"
 
     installed_apps:
@@ -167,11 +167,11 @@
         def animals_only(param: Animal) -> None:
             pass
         # Make sure that even though attr access falls back to Any, the type is still checked
-        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "WithAnnotations[myapp__models__User]"; expected "Animal"
+        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "WithAnnotations[myapp__models__User]"; expected "Animal"  [arg-type]
 
         def users_allowed(param: User) -> None:
             # But this function accepts only the original User type, so any attr access is not allowed within this function
-            param.foo  # E: "User" has no attribute "foo"
+            param.foo  # E: "User" has no attribute "foo"  [attr-defined]
         # Passing in the annotated User to a function taking a (unannotated) User is OK
         users_allowed(annotated_user)
 
@@ -227,11 +227,11 @@
           return qs.annotate(foo=F('id'))
 
         def add_wrong_annotation(qs: QuerySet[User]) -> QuerySet[WithAnnotations[User, FooDict]]:
-          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "_QuerySet[WithAnnotations[myapp__models__User, TypedDict({'bar': Any})], WithAnnotations[myapp__models__User, TypedDict({'bar': Any})]]", expected "_QuerySet[WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})], WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]]")
+          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "_QuerySet[WithAnnotations[myapp__models__User, TypedDict({'bar': Any})], WithAnnotations[myapp__models__User, TypedDict({'bar': Any})]]", expected "_QuerySet[WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})], WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]]")  [return-value]
 
         qs = add_annotation(qs)
         qs.get().foo
-        qs.get().bar # E: "WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]" has no attribute "bar"
+        qs.get().bar # E: "WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]" has no attribute "bar"  [attr-defined]
 
     installed_apps:
         - myapp
@@ -274,7 +274,7 @@
         values_list_named = Blog.objects.annotate(foo=F('id'), bar=F('isad')).values_list('foo', 'text', named=True).get()
         # We have to assume we don't know any of the tuple member types.
         reveal_type(values_list_named)  # N: Revealed type is "Tuple[Any, builtins.str, fallback=main.Row]"
-        values_list_named.unknown # E: "Row" has no attribute "unknown"
+        values_list_named.unknown # E: "Row" has no attribute "unknown"  [attr-defined]
         reveal_type(values_list_named.foo) # N: Revealed type is "Any"
         reveal_type(values_list_named.text) # N: Revealed type is "builtins.str"
 

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -218,9 +218,9 @@
         reveal_type(MyModel.objects.example_set())  # N: Revealed type is "builtins.set[myapp.models.MyModel]"
         reveal_type(MyModel.objects.example_dict())  # N: Revealed type is "builtins.dict[builtins.str, myapp.models.MyModel]"
         reveal_type(MyModel.objects.example_list_dict())  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, myapp.models.MyModel]]"
-        class TestQuerySet(BaseQuerySet[str]): ... # E: Type argument "str" of "BaseQuerySet" must be a subtype of "Model"
+        class TestQuerySet(BaseQuerySet[str]): ... # E: Type argument "str" of "BaseQuerySet" must be a subtype of "Model"  [type-var]
         reveal_type(MyModel.objects.example_t(5))  # N: Revealed type is "builtins.int"
-        MyModel.objects.example_arg(5, "5")  # E: Argument 1 to "example_arg" of "BaseQuerySet" has incompatible type "int"; expected "MyModel"
+        MyModel.objects.example_arg(5, "5")  # E: Argument 1 to "example_arg" of "BaseQuerySet" has incompatible type "int"; expected "MyModel"  [arg-type]
         reveal_type(MyModel.objects.example_arg(MyModel(), "5"))  # N: Revealed type is "myapp.models.MyModel"
     installed_apps:
         - myapp

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -48,7 +48,7 @@
     main: |
         from myapp.models import User
         reveal_type(User.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
-        User.objects.not_existing_method()  # E: "Manager[User]" has no attribute "not_existing_method"
+        User.objects.not_existing_method()  # E: "Manager[User]" has no attribute "not_existing_method"  [attr-defined]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -18,7 +18,7 @@
 -   case: no_such_field_for_filter
     main: |
         from myapp.models import User
-        User.objects.filter(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id
+        User.objects.filter(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id  [misc]
     installed_apps:
         - myapp
     files:
@@ -33,7 +33,7 @@
 -   case: filter_with_invalid_type
     main: |
         from myapp.models import User
-        User.objects.filter(age=User())  # E: Incompatible type for lookup 'age': (got "User", expected "Union[str, int]")
+        User.objects.filter(age=User())  # E: Incompatible type for lookup 'age': (got "User", expected "Union[str, int]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -53,8 +53,8 @@
     installed_apps:
         - myapp
     out: |
-        main:2: error: Incompatible type for lookup 'age': (got "User", expected "Union[str, int]")
-        main:2: error: Incompatible type for lookup 'gender': (got "User", expected "Union[str, int]")
+        main:2: error: Incompatible type for lookup 'age': (got "User", expected "Union[str, int]")  [misc]
+        main:2: error: Incompatible type for lookup 'gender': (got "User", expected "Union[str, int]")  [misc]
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
@@ -85,11 +85,11 @@
 -   case: invalid_filter_with_lookup
     main: |
         from myapp.models import User
-        User.objects.filter(username__contains=1)  # E: Incompatible type for lookup 'username__contains': (got "int", expected "str")
-        User.objects.filter(username__icontains=1)  # E: Incompatible type for lookup 'username__icontains': (got "int", expected "str")
-        User.objects.filter(username__isnull=1)  # E: Incompatible type for lookup 'username__isnull': (got "int", expected "bool")
+        User.objects.filter(username__contains=1)  # E: Incompatible type for lookup 'username__contains': (got "int", expected "str")  [misc]
+        User.objects.filter(username__icontains=1)  # E: Incompatible type for lookup 'username__icontains': (got "int", expected "str")  [misc]
+        User.objects.filter(username__isnull=1)  # E: Incompatible type for lookup 'username__isnull': (got "int", expected "bool")  [misc]
 
-        User.objects.filter(created_at=User())  # E: Incompatible type for lookup 'created_at': (got "User", expected "Union[str, datetime]")
+        User.objects.filter(created_at=User())  # E: Incompatible type for lookup 'created_at': (got "User", expected "Union[str, datetime]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -127,8 +127,8 @@
         Blog.objects.filter(publisher_id=1)
         Blog.objects.filter(publisher__id=1)
 
-        Blog.objects.filter(publisher=blog)  # E: Incompatible type for lookup 'publisher': (got "Blog", expected "Union[Publisher, int, None]")
-        Blog.objects.filter(publisher_id=blog)  # E: Incompatible type for lookup 'publisher_id': (got "Blog", expected "Union[str, int]")
+        Blog.objects.filter(publisher=blog)  # E: Incompatible type for lookup 'publisher': (got "Blog", expected "Union[Publisher, int, None]")  [misc]
+        Blog.objects.filter(publisher_id=blog)  # E: Incompatible type for lookup 'publisher_id': (got "Blog", expected "Union[str, int]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -150,8 +150,8 @@
         Publisher.objects.filter(blogs=Blog())
         Publisher.objects.filter(blogs__id=1)
 
-        Publisher.objects.filter(blogs=publisher)  # E: Incompatible type for lookup 'blogs': (got "Publisher", expected "Union[Blog, int, None]")
-        Publisher.objects.filter(blogs__id=publisher)  # E: Incompatible type for lookup 'blogs__id': (got "Publisher", expected "Union[str, int]")
+        Publisher.objects.filter(blogs=publisher)  # E: Incompatible type for lookup 'blogs': (got "Publisher", expected "Union[Blog, int, None]")  [misc]
+        Publisher.objects.filter(blogs__id=publisher)  # E: Incompatible type for lookup 'blogs__id': (got "Publisher", expected "Union[str, int]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -172,12 +172,12 @@
         author = Author()
 
         Book.objects.filter(authors=author)
-        Book.objects.filter(authors=book)  # E: Incompatible type for lookup 'authors': (got "Book", expected "Union[Author, int, None]")
-        Book.objects.filter(authors='hello')  # E: Incompatible type for lookup 'authors': (got "str", expected "Union[Author, int, None]")
+        Book.objects.filter(authors=book)  # E: Incompatible type for lookup 'authors': (got "Book", expected "Union[Author, int, None]")  [misc]
+        Book.objects.filter(authors='hello')  # E: Incompatible type for lookup 'authors': (got "str", expected "Union[Author, int, None]")  [misc]
 
         Author.objects.filter(books=book)
-        Author.objects.filter(books=author)  # E: Incompatible type for lookup 'books': (got "Author", expected "Union[Book, int, None]")
-        Author.objects.filter(books='hello')  # E: Incompatible type for lookup 'books': (got "str", expected "Union[Book, int, None]")
+        Author.objects.filter(books=author)  # E: Incompatible type for lookup 'books': (got "Author", expected "Union[Book, int, None]")  [misc]
+        Author.objects.filter(books='hello')  # E: Incompatible type for lookup 'books': (got "str", expected "Union[Book, int, None]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -197,11 +197,11 @@
         user = User()
         profile = Profile()
         User.objects.filter(profile=profile)
-        User.objects.filter(profile=user)  # E: Incompatible type for lookup 'profile': (got "User", expected "Union[Profile, int, None]")
-        User.objects.filter(profile='hello')  # E: Incompatible type for lookup 'profile': (got "str", expected "Union[Profile, int, None]")
+        User.objects.filter(profile=user)  # E: Incompatible type for lookup 'profile': (got "User", expected "Union[Profile, int, None]")  [misc]
+        User.objects.filter(profile='hello')  # E: Incompatible type for lookup 'profile': (got "str", expected "Union[Profile, int, None]")  [misc]
         Profile.objects.filter(user=user)
-        Profile.objects.filter(user=profile)  # E: Incompatible type for lookup 'user': (got "Profile", expected "Union[User, int, None]")
-        Profile.objects.filter(user='hello')  # E: Incompatible type for lookup 'user': (got "str", expected "Union[User, int, None]")
+        Profile.objects.filter(user=profile)  # E: Incompatible type for lookup 'user': (got "Profile", expected "Union[User, int, None]")  [misc]
+        Profile.objects.filter(user='hello')  # E: Incompatible type for lookup 'user': (got "str", expected "Union[User, int, None]")  [misc]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_querysetany.yml
+++ b/tests/typecheck/managers/querysets/test_querysetany.yml
@@ -16,7 +16,7 @@
         foo(obj)
         bar(obj)
 
-      if isinstance(obj, QuerySet):  # E: Parameterized generics cannot be used with class or instance checks
+      if isinstance(obj, QuerySet):  # E: Parameterized generics cannot be used with class or instance checks  [misc]
         reveal_type(obj)             # N: Revealed type is "django.db.models.query._QuerySet[Any, Any]"
         foo(obj)
         bar(obj)
@@ -31,7 +31,7 @@
       user_querysets: List[QuerySet[User]] = []
       user_querysets.append(queryset_instance)
       user_querysets.append(queryset)
-      user_querysets.append(queryset_book)  # E: Argument 1 to "append" of "list" has incompatible type "_QuerySet[Book, Book]"; expected "_QuerySet[User, User]"
+      user_querysets.append(queryset_book)  # E: Argument 1 to "append" of "list" has incompatible type "_QuerySet[Book, Book]"; expected "_QuerySet[User, User]"  [arg-type]
   installed_apps:
     - myapp
   files:

--- a/tests/typecheck/managers/querysets/test_union_type.yml
+++ b/tests/typecheck/managers/querysets/test_union_type.yml
@@ -10,7 +10,7 @@
 
         reveal_type(model_cls) # N: Revealed type is "Union[Type[myapp.models.Order], Type[myapp.models.User]]"
         reveal_type(model_cls.objects)  # N: Revealed type is "Union[myapp.models.ManagerFromMyQuerySet[myapp.models.Order], myapp.models.ManagerFromMyQuerySet[myapp.models.User]]"
-        model_cls.objects.my_method()  # E: Unable to resolve return type of queryset/manager method "my_method"
+        model_cls.objects.my_method()  # E: Unable to resolve return type of queryset/manager method "my_method"  [misc]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -107,7 +107,7 @@
         reveal_type(MyUser.objects.values_list(flat=True)[0])  # N: Revealed type is "builtins.int"
         reveal_type(MyUser2.objects.values_list(flat=True)[0])  # N: Revealed type is "builtins.str"
     out: |
-        main:3: error: 'flat' is not valid when 'values_list' is called with more than one field
+        main:3: error: 'flat' is not valid when 'values_list' is called with more than one field  [misc]
         main:3: note: Revealed type is "Any"
     installed_apps:
         - myapp
@@ -163,7 +163,7 @@
         from myapp.models import MyUser
         reveal_type(MyUser.objects.values_list('name', flat=True, named=True).get())
     out: |
-        main:2: error: 'flat' and 'named' can't be used together
+        main:2: error: 'flat' and 'named' can't be used together  [misc]
         main:2: note: Revealed type is "Any"
     installed_apps:
         - myapp
@@ -183,11 +183,11 @@
         reveal_type(Blog.objects.values_list('unknown', named=True).get())
         reveal_type(Blog.objects.values_list('publisher__unknown').get())
     out: |
-        main:2: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id
+        main:2: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
         main:2: note: Revealed type is "Any"
-        main:3: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id
+        main:3: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
         main:3: note: Revealed type is "Any"
-        main:4: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id
+        main:4: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
         main:4: note: Revealed type is "Any"
         main:5: note: Revealed type is "Tuple[Any]"
     installed_apps:

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -402,8 +402,8 @@
     installed_apps:
         - myapp
     out: |
-        myapp/models:5: error: Return type "MyModel" of "create" incompatible with return type "_T" in supertype "BaseManager"
-        myapp/models:6: error: Incompatible return value type (got "_T", expected "MyModel")
+        myapp/models:5: error: Return type "MyModel" of "create" incompatible with return type "_T" in supertype "BaseManager"  [override]
+        myapp/models:6: error: Incompatible return value type (got "_T", expected "MyModel")  [return-value]
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
@@ -537,13 +537,13 @@
                     reveal_type(user.booking_set.all().custom)
                     reveal_type(user.booking_set.all().first())
     out: |
-        myapp/models:13: error: Couldn't resolve related manager for relation 'booking' (from myapp.models.Booking.myapp.Booking.renter).
-        myapp/models:13: error: Couldn't resolve related manager for relation 'bookingowner_set' (from myapp.models.Booking.myapp.Booking.owner).
-        myapp/models:20: error: Could not resolve manager type for "myapp.models.Booking.objects"
-        myapp/models:23: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.objects"
-        myapp/models:24: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.second_objects"
-        myapp/models:27: error: Could not resolve manager type for "myapp.models.AbstractUnresolvable.objects"
-        myapp/models:32: error: Could not resolve manager type for "myapp.models.InvisibleUnresolvable.objects"
+        myapp/models:13: error: Couldn't resolve related manager for relation 'booking' (from myapp.models.Booking.myapp.Booking.renter).  [django-manager-missing]
+        myapp/models:13: error: Couldn't resolve related manager for relation 'bookingowner_set' (from myapp.models.Booking.myapp.Booking.owner).  [django-manager-missing]
+        myapp/models:20: error: Could not resolve manager type for "myapp.models.Booking.objects"  [django-manager-missing]
+        myapp/models:23: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.objects"  [django-manager-missing]
+        myapp/models:24: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.second_objects"  [django-manager-missing]
+        myapp/models:27: error: Could not resolve manager type for "myapp.models.AbstractUnresolvable.objects"  [django-manager-missing]
+        myapp/models:32: error: Could not resolve manager type for "myapp.models.InvisibleUnresolvable.objects"  [django-manager-missing]
         myapp/models:36: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
         myapp/models:37: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
         myapp/models:39: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Booking]"
@@ -610,7 +610,7 @@
     out: |
         main:2: note: Revealed type is "myapp.models.MySubManager"
         main:3: note: Revealed type is "Any"
-        myapp/models:9: error: Missing type parameters for generic type "MyManager"
+        myapp/models:9: error: Missing type parameters for generic type "MyManager"  [type-arg]
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -51,9 +51,9 @@
     Recursive(parent=Recursive(parent=None))
     Concrete(parent=Concrete(parent=None))
   out: |
-    main:4: error: "Type[Recursive]" has no attribute "objects"
-    main:5: error: Cannot instantiate abstract class "Recursive" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
-    main:5: error: Unexpected attribute "parent" for model "Recursive"
+    main:4: error: "Type[Recursive]" has no attribute "objects"  [attr-defined]
+    main:5: error: Cannot instantiate abstract class "Recursive" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+    main:5: error: Unexpected attribute "parent" for model "Recursive"  [misc]
   installed_apps:
     - myapp
   files:
@@ -77,27 +77,27 @@
       from myapp.models import Abstract, Concrete, LiteralAbstract
       from typing import Generic, Type, TypeVar, overload, Union
 
-      Abstract()  # E: Cannot instantiate abstract class "Abstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
-      LiteralAbstract()  # E: Cannot instantiate abstract class "LiteralAbstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
+      Abstract()  # E: Cannot instantiate abstract class "Abstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+      LiteralAbstract()  # E: Cannot instantiate abstract class "LiteralAbstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
 
       def f(klass: Type[Abstract]) -> None:
           return None
 
-      f(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
+      f(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
       f(Concrete)
 
       def second_arg(arg: str, klass: Type[Abstract]) -> None:
           return None
 
-      second_arg("abc", Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
-      second_arg(Abstract, Concrete)  # E: Argument 1 to "second_arg" has incompatible type "Type[Abstract]"; expected "str"
+      second_arg("abc", Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
+      second_arg(Abstract, Concrete)  # E: Argument 1 to "second_arg" has incompatible type "Type[Abstract]"; expected "str"  [arg-type]
 
       T = TypeVar("T", bound=Abstract)
 
       def g(klass: Type[T]) -> None:
           return None
 
-      g(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
+      g(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
       g(Concrete)
 
       @overload
@@ -107,8 +107,8 @@
       def o(klass: Type[T], arg: Union[str, int]) -> None:
           return None
 
-      o(Abstract, "a")  # E: Only concrete class can be given where "Type[Abstract]" is expected
-      o(Abstract, 1)  # E: Only concrete class can be given where "Type[Abstract]" is expected
+      o(Abstract, "a")  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
+      o(Abstract, 1)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
       o(Concrete, 1)
 
       class M:
@@ -126,18 +126,18 @@
           def overloaded(self, arg: Union[str, int], klass: Type[Abstract]) -> None:
               return None
 
-      M().method(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
-      M().overloaded(1, Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
-      M().overloaded("1", Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
+      M().method(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
+      M().overloaded(1, Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
+      M().overloaded("1", Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
 
       class G(Generic[T]):
           def method(self, klass: Type[T]) -> None:
               return None
 
-      G[Abstract]().method(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected
+      G[Abstract]().method(Abstract)  # E: Only concrete class can be given where "Type[Abstract]" is expected  [type-abstract]
       # Additional plugin coverage
-      unknown(Abstract)  # E: Name "unknown" is not defined
-      M().unknown(Abstract)  # E: "M" has no attribute "unknown"
+      unknown(Abstract)  # E: Name "unknown" is not defined  [name-defined]
+      M().unknown(Abstract)  # E: "M" has no attribute "unknown"  [attr-defined]
   installed_apps:
     - myapp
   files:
@@ -165,11 +165,11 @@
   main: |
     from myapp.models import create_animal, create_animal_generic, Cat, Animal, ExplicitConcrete
     create_animal(Cat, "Garfield")
-    create_animal(Animal, "Animal")  # E: Only concrete class can be given where "Type[Animal]" is expected
+    create_animal(Animal, "Animal")  # E: Only concrete class can be given where "Type[Animal]" is expected  [type-abstract]
     create_animal_generic(Cat, "Grumpy")
-    create_animal_generic(Animal, "Animal")  # E: Only concrete class can be given where "Type[Animal]" is expected
+    create_animal_generic(Animal, "Animal")  # E: Only concrete class can be given where "Type[Animal]" is expected  [type-abstract]
 
-    Animal()  # E: Cannot instantiate abstract class "Animal" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
+    Animal()  # E: Cannot instantiate abstract class "Animal" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
     ExplicitConcrete()
   installed_apps:
     - myapp

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -2,7 +2,7 @@
     main: |
         from myapp.models import User
         User.objects.create(pk=1, name='Max', age=10)
-        User.objects.create(age=[])  # E: Incompatible type for "age" of "User" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        User.objects.create(age=[])  # E: Incompatible type for "age" of "User" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -40,7 +40,7 @@
         from myapp.models import Child4
         Child4.objects.create(name1='n1', name2='n2', value=1, value4=4)
     out: |
-        myapp/models:9: error: Definition of "child1" in base class "Parent1" is incompatible with definition in base class "Parent2"
+        myapp/models:9: error: Definition of "child1" in base class "Parent1" is incompatible with definition in base class "Parent2"  [misc]
     installed_apps:
         - myapp
     files:
@@ -64,9 +64,9 @@
     main: |
         from myapp.models import Publisher, Book
 
-        Book.objects.create(id=None)  # E: Incompatible type for "id" of "Book" (got "None", expected "Union[float, int, str, Combinable]")
-        Book.objects.create(publisher=None)  # E: Incompatible type for "publisher" of "Book" (got "None", expected "Union[Publisher, Combinable]")
-        Book.objects.create(publisher_id=None)  # E: Incompatible type for "publisher_id" of "Book" (got "None", expected "Union[Combinable, int, str]")
+        Book.objects.create(id=None)  # E: Incompatible type for "id" of "Book" (got "None", expected "Union[float, int, str, Combinable]")  [misc]
+        Book.objects.create(publisher=None)  # E: Incompatible type for "publisher" of "Book" (got "None", expected "Union[Publisher, Combinable]")  [misc]
+        Book.objects.create(publisher_id=None)  # E: Incompatible type for "publisher_id" of "Book" (got "None", expected "Union[Combinable, int, str]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -106,18 +106,18 @@
         reveal_type(first.id)  # N: Revealed type is "builtins.int"
 
         from myapp.models import MyModel2
-        MyModel2(id=None)  # E: Incompatible type for "id" of "MyModel2" (got "None", expected "Union[float, int, str, Combinable]")
-        MyModel2.objects.create(id=None)  # E: Incompatible type for "id" of "MyModel2" (got "None", expected "Union[float, int, str, Combinable]")
+        MyModel2(id=None)  # E: Incompatible type for "id" of "MyModel2" (got "None", expected "Union[float, int, str, Combinable]")  [misc]
+        MyModel2.objects.create(id=None)  # E: Incompatible type for "id" of "MyModel2" (got "None", expected "Union[float, int, str, Combinable]")  [misc]
         second = MyModel2()
-        second.id = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[float, int, str, Combinable]")
+        second.id = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[float, int, str, Combinable]")  [assignment]
         reveal_type(second.id)  # N: Revealed type is "builtins.int"
 
         # default set but no primary key doesn't allow None
         from myapp.models import MyModel3
-        MyModel3(default=None)  # E: Incompatible type for "default" of "MyModel3" (got "None", expected "Union[float, int, str, Combinable]")
-        MyModel3.objects.create(default=None)  # E: Incompatible type for "default" of "MyModel3" (got "None", expected "Union[float, int, str, Combinable]")
+        MyModel3(default=None)  # E: Incompatible type for "default" of "MyModel3" (got "None", expected "Union[float, int, str, Combinable]")  [misc]
+        MyModel3.objects.create(default=None)  # E: Incompatible type for "default" of "MyModel3" (got "None", expected "Union[float, int, str, Combinable]")  [misc]
         third = MyModel3()
-        third.default = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[float, int, str, Combinable]")
+        third.default = None  # E: Incompatible types in assignment (expression has type "None", variable has type "Union[float, int, str, Combinable]")  [assignment]
         reveal_type(third.default)  # N: Revealed type is "builtins.int"
     installed_apps:
         - myapp

--- a/tests/typecheck/models/test_extra_methods.yml
+++ b/tests/typecheck/models/test_extra_methods.yml
@@ -2,7 +2,7 @@
     main: |
         from myapp.models import MyUser
         user = MyUser(name='user', gender='M')
-        user.get_name_display()  # E: "MyUser" has no attribute "get_name_display"; maybe "get_gender_display"?
+        user.get_name_display()  # E: "MyUser" has no attribute "get_name_display"; maybe "get_gender_display"?  [attr-defined]
         reveal_type(user.get_gender_display())  # N: Revealed type is "builtins.str"
     installed_apps:
         - myapp
@@ -51,8 +51,8 @@
 -   case: get_next_by_get_previous_by_absent_if_null_true
     main: |
         from myapp.models import MyUser
-        MyUser().get_next_by_date()  # E: "MyUser" has no attribute "get_next_by_date"
-        MyUser().get_previous_by_date()  # E: "MyUser" has no attribute "get_previous_by_date"
+        MyUser().get_next_by_date()  # E: "MyUser" has no attribute "get_next_by_date"  [attr-defined]
+        MyUser().get_previous_by_date()  # E: "MyUser" has no attribute "get_previous_by_date"  [attr-defined]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_inheritance.yml
+++ b/tests/typecheck/models/test_inheritance.yml
@@ -26,7 +26,7 @@
         def service(a: A) -> int:
             pass
         b_instance = B()
-        service(b_instance)  # E: Argument 1 to "service" has incompatible type "B"; expected "A"
+        service(b_instance)  # E: Argument 1 to "service" has incompatible type "B"; expected "A"  [arg-type]
         a_instance = A()
         c_instance = C()
         service(a_instance)
@@ -52,8 +52,8 @@
         b_instance = B()
         reveal_type(b_instance.b_attr) # N: Revealed type is "builtins.int"
 
-        b_instance.non_existent_attribute  # E: "B" has no attribute "non_existent_attribute"
-        b_instance.non_existent_attribute = 2  # E: "B" has no attribute "non_existent_attribute"
+        b_instance.non_existent_attribute  # E: "B" has no attribute "non_existent_attribute"  [attr-defined]
+        b_instance.non_existent_attribute = 2  # E: "B" has no attribute "non_existent_attribute"  [attr-defined]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -3,8 +3,8 @@
         from myapp.models import MyUser
         user = MyUser(name=1, age=12)
     out: |
-        main:2: error: Unexpected attribute "name" for model "MyUser"
-        main:2: error: Unexpected attribute "age" for model "MyUser"
+        main:2: error: Unexpected attribute "name" for model "MyUser"  [misc]
+        main:2: error: Unexpected attribute "age" for model "MyUser"  [misc]
     installed_apps:
         - myapp
     files:
@@ -21,7 +21,7 @@
         from myapp.models import MyUser
         def func(i: int) -> MyUser:
             pass
-        func("hello")  # E: Argument 1 to "func" has incompatible type "str"; expected "int"
+        func("hello")  # E: Argument 1 to "func" has incompatible type "str"; expected "int"  [arg-type]
     installed_apps:
         - myapp
     files:
@@ -37,7 +37,7 @@
         from myapp.models import MyUser
         user = MyUser(name='hello', age=[])
     out: |
-        main:2: error: Incompatible type for "age" of "MyUser" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        main:2: error: Incompatible type for "age" of "MyUser" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -107,7 +107,7 @@
 -   case: typechecking_of_pk
     main: |
         from myapp.models import MyUser1
-        user = MyUser1(pk=[])  # E: Incompatible type for "pk" of "MyUser1" (got "List[Any]", expected "Union[float, int, str, Combinable, None]")
+        user = MyUser1(pk=[])  # E: Incompatible type for "pk" of "MyUser1" (got "List[Any]", expected "Union[float, int, str, Combinable, None]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -126,8 +126,8 @@
 
         from myapp.models import Publisher, PublisherDatetime, Book
         Book(publisher_id=1, publisher_dt_id=now)
-        Book(publisher_id=[], publisher_dt_id=now)  # E: Incompatible type for "publisher_id" of "Book" (got "List[Any]", expected "Union[Combinable, int, str]")
-        Book(publisher_id=1, publisher_dt_id=1)  # E: Incompatible type for "publisher_dt_id" of "Book" (got "int", expected "Union[str, datetime, date, Combinable]")
+        Book(publisher_id=[], publisher_dt_id=now)  # E: Incompatible type for "publisher_id" of "Book" (got "List[Any]", expected "Union[Combinable, int, str]")  [misc]
+        Book(publisher_id=1, publisher_dt_id=1)  # E: Incompatible type for "publisher_dt_id" of "Book" (got "int", expected "Union[str, datetime, date, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -155,11 +155,11 @@
         class NotAValid:
             pass
         array_val3: List[NotAValid] = [NotAValid()]
-        MyModel(array=array_val3)  # E: Incompatible type for "array" of "MyModel" (got "List[NotAValid]", expected "Union[Sequence[Union[float, int, str]], Combinable]")
+        MyModel(array=array_val3)  # E: Incompatible type for "array" of "MyModel" (got "List[NotAValid]", expected "Union[Sequence[Union[float, int, str]], Combinable]")  [misc]
         non_init = MyModel()
         non_init.array = array_val
         non_init.array = array_val2
-        non_init.array = array_val3  # E: Incompatible types in assignment (expression has type "List[NotAValid]", variable has type "Union[Sequence[Union[float, int, str]], Combinable]")
+        non_init.array = array_val3  # E: Incompatible types in assignment (expression has type "List[NotAValid]", variable has type "Union[Sequence[Union[float, int, str]], Combinable]")  [assignment]
     installed_apps:
         - myapp
     files:
@@ -191,7 +191,7 @@
         from myapp.models import MyModel, MyModel2
         MyModel(1)
         MyModel2(1, 12)
-        MyModel2(1, [])  # E: Incompatible type for "name" of "MyModel2" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        MyModel2(1, [])  # E: Incompatible type for "name" of "MyModel2" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -289,14 +289,14 @@
         main:6: note: Revealed type is "builtins.list[builtins.int]"
         main:7: note: Revealed type is "builtins.int"
         main:8: note: Revealed type is "Any"
-        main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")
-        main:10: error: Incompatible types in assignment (expression has type "str", variable has type "Union[int, float]")
-        main:12: error: Incompatible types in assignment (expression has type "List[str]", variable has type "Sequence[Union[int, float]]")
-        main:13: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "Union[float, int, str, Combinable]")
-        main:15: error: Incompatible type for "redefined_set_type" of "MyModel" (got "str", expected "int")
-        main:15: error: Incompatible type for "redefined_union_set_type" of "MyModel" (got "str", expected "Union[int, float]")
-        main:15: error: Incompatible type for "redefined_array_set_type" of "MyModel" (got "int", expected "Sequence[Union[int, float]]")
-        main:15: error: Incompatible type for "default_set_type" of "MyModel" (got "List[Any]", expected "Union[float, int, str, Combinable]")
+        main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
+        main:10: error: Incompatible types in assignment (expression has type "str", variable has type "Union[int, float]")  [assignment]
+        main:12: error: Incompatible types in assignment (expression has type "List[str]", variable has type "Sequence[Union[int, float]]")  [assignment]
+        main:13: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "Union[float, int, str, Combinable]")  [assignment]
+        main:15: error: Incompatible type for "redefined_set_type" of "MyModel" (got "str", expected "int")  [misc]
+        main:15: error: Incompatible type for "redefined_union_set_type" of "MyModel" (got "str", expected "Union[int, float]")  [misc]
+        main:15: error: Incompatible type for "redefined_array_set_type" of "MyModel" (got "int", expected "Sequence[Union[int, float]]")  [misc]
+        main:15: error: Incompatible type for "default_set_type" of "MyModel" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -20,7 +20,7 @@
         reveal_type(MyUser._meta.get_field('age'))  # N: Revealed type is "django.db.models.fields.IntegerField[Any, Any]"
         reveal_type(MyUser._meta.get_field('to_user'))  # N: Revealed type is "django.db.models.fields.related.ForeignKey[Any, Any]"
 
-        MyUser._meta.get_field('unknown')  # E: MyUser has no field named 'unknown'
+        MyUser._meta.get_field('unknown')  # E: MyUser has no field named 'unknown'  [misc]
     installed_apps:
         - myapp
     files:
@@ -64,9 +64,9 @@
         class MyModel(models.Model):
             example = models.CharField(max_length=100)
             class Meta(TypedModelMeta):
-                abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")
-                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")
-                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")
+                abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+                verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "List[str]", base class "TypedModelMeta" defined the type as "Union[str, _StrPromise]")  [assignment]
+                unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "Dict[int, int]", base class "TypedModelMeta" defined the type as "Union[Sequence[Sequence[str]], Sequence[str]]")  [assignment]
                 unknown_attr = True  # can't check this
 
 
@@ -80,8 +80,8 @@
         AbstractModel._default_manager.create()
 
         # Errors:
-        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"
-        AbstractModel.objects.create()  # E: "Type[AbstractModel]" has no attribute "objects"
+        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+        AbstractModel.objects.create()  # E: "Type[AbstractModel]" has no attribute "objects"  [attr-defined]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_metaclass.yml
+++ b/tests/typecheck/models/test_metaclass.yml
@@ -4,8 +4,8 @@
         from myapp.models import Abstract1, Abstract2, Concrete1, Concrete2, Concrete3
         from django.db import models
 
-        models.Model.DoesNotExist  # E: "Type[Model]" has no attribute "DoesNotExist"
-        models.Model.MultipleObjectsReturned  # E: "Type[Model]" has no attribute "MultipleObjectsReturned"
+        models.Model.DoesNotExist  # E: "Type[Model]" has no attribute "DoesNotExist"  [attr-defined]
+        models.Model.MultipleObjectsReturned  # E: "Type[Model]" has no attribute "MultipleObjectsReturned"  [attr-defined]
 
         reveal_type(Abstract1.DoesNotExist)  # N: Revealed type is "Type[django.core.exceptions.ObjectDoesNotExist]"
         reveal_type(Abstract2.DoesNotExist)  # N: Revealed type is "Type[django.core.exceptions.ObjectDoesNotExist]"
@@ -26,13 +26,13 @@
         a = Concrete3.DoesNotExist
 
         b: Type[Concrete2.DoesNotExist]
-        b = Concrete1.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.DoesNotExist]", variable has type "Type[myapp.models.Concrete2.DoesNotExist]")
+        b = Concrete1.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.DoesNotExist]", variable has type "Type[myapp.models.Concrete2.DoesNotExist]")  [assignment]
         b = Concrete2.DoesNotExist
         b = Concrete3.DoesNotExist
 
         c: Type[Concrete3.DoesNotExist]
-        c = Concrete1.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.DoesNotExist]", variable has type "Type[myapp.models.Concrete3.DoesNotExist]")
-        c = Concrete2.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete2.DoesNotExist]", variable has type "Type[myapp.models.Concrete3.DoesNotExist]")
+        c = Concrete1.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.DoesNotExist]", variable has type "Type[myapp.models.Concrete3.DoesNotExist]")  [assignment]
+        c = Concrete2.DoesNotExist  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete2.DoesNotExist]", variable has type "Type[myapp.models.Concrete3.DoesNotExist]")  [assignment]
         c = Concrete3.DoesNotExist
 
         d: Type[Concrete1.MultipleObjectsReturned]
@@ -41,13 +41,13 @@
         d = Concrete3.MultipleObjectsReturned
 
         e: Type[Concrete2.MultipleObjectsReturned]
-        e = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete2.MultipleObjectsReturned]")
+        e = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete2.MultipleObjectsReturned]")  [assignment]
         e = Concrete2.MultipleObjectsReturned
         e = Concrete3.MultipleObjectsReturned
 
         f: Type[Concrete3.MultipleObjectsReturned]
-        f = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete3.MultipleObjectsReturned]")
-        f = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete3.MultipleObjectsReturned]")
+        f = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
+        f = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "Type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "Type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
         f = Concrete3.MultipleObjectsReturned
     installed_apps:
         - myapp

--- a/tests/typecheck/models/test_primary_key.yml
+++ b/tests/typecheck/models/test_primary_key.yml
@@ -49,10 +49,10 @@
     x = MyModel.objects.get(primary='a')
     reveal_type(x.primary)  # N: Revealed type is "builtins.str"
     reveal_type(x.pk)  # N: Revealed type is "builtins.str"
-    x.id  # E: "MyModel" has no attribute "id"
+    x.id  # E: "MyModel" has no attribute "id"  [attr-defined]
 
     MyModel.objects.get(pk='a')
-    MyModel.objects.get(id='a')  # E: Cannot resolve keyword 'id' into field. Choices are: primary
+    MyModel.objects.get(id='a')  # E: Cannot resolve keyword 'id' into field. Choices are: primary  [misc]
   installed_apps:
     - myapp
   files:
@@ -65,5 +65,5 @@
             def __str__(self) -> str:
                 reveal_type(self.primary)  # N: Revealed type is "builtins.str"
                 reveal_type(self.pk)  # N: Revealed type is "builtins.str"
-                self.id  # E: "MyModel" has no attribute "id"
+                self.id  # E: "MyModel" has no attribute "id"  [attr-defined]
                 return self.primary

--- a/tests/typecheck/test_formsets.yml
+++ b/tests/typecheck/test_formsets.yml
@@ -4,7 +4,7 @@
     from django import forms
     from myapp.models import Article, Category
     ArticleFS: Type[forms.BaseInlineFormSet[Article, Category, Any]] = forms.inlineformset_factory(Category, Article)
-    ArticleFS(instance=Article())  # E: Argument "instance" to "BaseInlineFormSet" has incompatible type "Article"; expected "Optional[Category]"
+    ArticleFS(instance=Article())  # E: Argument "instance" to "BaseInlineFormSet" has incompatible type "Article"; expected "Optional[Category]"  [arg-type]
     fs = ArticleFS(instance=Category())
     reveal_type(fs.instance)  # N: Revealed type is "myapp.models.Category"
   installed_apps:

--- a/tests/typecheck/test_helpers.yml
+++ b/tests/typecheck/test_helpers.yml
@@ -37,7 +37,7 @@
             @transaction.atomic(using="db", savepoint=True)
             def atomic_method3(self, myparam: str) -> int:
                 pass
-        ClassWithAtomicMethod().atomic_method1("abc") # E: Argument 1 to "atomic_method1" of "ClassWithAtomicMethod" has incompatible type "str"; expected "int"
+        ClassWithAtomicMethod().atomic_method1("abc") # E: Argument 1 to "atomic_method1" of "ClassWithAtomicMethod" has incompatible type "str"; expected "int"  [arg-type]
         # Ensure that the method's type is preserved
         reveal_type(ClassWithAtomicMethod().atomic_method1) # N: Revealed type is "def (abc: builtins.int) -> builtins.str"
         # Ensure that the method's type is preserved

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -86,8 +86,8 @@
         req = mk_request()
         reveal_type(req)  # N: Revealed type is "django.http.request.HttpRequest"
         reveal_type(req.GET)  # N: Revealed type is "django.http.request._ImmutableQueryDict"
-        req.GET.setdefault('foo', 'bar')  # E: This QueryDict is immutable.
-        x = 1  # E: Statement is unreachable
+        req.GET.setdefault('foo', 'bar')  # E: This QueryDict is immutable.  [misc]
+        x = 1  # E: Statement is unreachable  [unreachable]
 
 -   case: request_get_post_unreachable
     main: |
@@ -104,5 +104,5 @@
         req = mk_request()
         reveal_type(req)  # N: Revealed type is "django.http.request.HttpRequest"
         reveal_type(req.GET)  # N: Revealed type is "django.http.request._ImmutableQueryDict"
-        req.GET['foo'] = 'bar'  # E: This QueryDict is immutable.
-        x = 1  # E: Statement is unreachable
+        req.GET['foo'] = 'bar'  # E: This QueryDict is immutable.  [misc]
+        x = 1  # E: Statement is unreachable  [unreachable]

--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -30,7 +30,7 @@
 -   case: fail_if_there_is_no_setting
     main: |
         from django.conf import settings
-        settings.NOT_EXISTING  # E: 'Settings' object has no attribute 'NOT_EXISTING'
+        settings.NOT_EXISTING  # E: 'Settings' object has no attribute 'NOT_EXISTING'  [misc]
 
 -   case: override_default_setting_with_different_type_in_the_different_module
     custom_settings: |
@@ -55,8 +55,8 @@
           reveal_type(settings.NON_EXISTANT_SETTING)
     out: |
       main:3: note: Revealed type is "builtins.str"
-      main:4: error: 'Settings' object has no attribute 'NON_EXISTANT_SETTING'
-      main:5: error: 'Settings' object has no attribute 'NON_EXISTANT_SETTING'
+      main:4: error: 'Settings' object has no attribute 'NON_EXISTANT_SETTING'  [misc]
+      main:5: error: 'Settings' object has no attribute 'NON_EXISTANT_SETTING'  [misc]
       main:5: note: Revealed type is "Any"
 
 
@@ -70,7 +70,7 @@
 
         # Custom:
         reveal_type(settings.A)  # N: Revealed type is "Any"
-        reveal_type(settings.B)  # E: 'Settings' object has no attribute 'B' # N: Revealed type is "Any"
+        reveal_type(settings.B)  # E: 'Settings' object has no attribute 'B'  [misc] # N: Revealed type is "Any"
     custom_settings: |
         # Some code that mypy cannot analyze, but values exist in runtime:
         exec('A = 1')
@@ -89,8 +89,8 @@
         reveal_type(settings.SECRET_KEY)  # N: Revealed type is "builtins.str"
 
         # Custom:
-        reveal_type(settings.A)  # E: 'Settings' object has no attribute 'A' # N: Revealed type is "Any"
-        reveal_type(settings.B)  # E: 'Settings' object has no attribute 'B' # N: Revealed type is "Any"
+        reveal_type(settings.A)  # E: 'Settings' object has no attribute 'A'  [misc] # N: Revealed type is "Any"
+        reveal_type(settings.B)  # E: 'Settings' object has no attribute 'B'  [misc] # N: Revealed type is "Any"
     custom_settings: |
         # Some code that mypy cannot analyze, but values exist in runtime:
         exec('A = 1')

--- a/tests/typecheck/utils/test_datastructures.yml
+++ b/tests/typecheck/utils/test_datastructures.yml
@@ -4,7 +4,7 @@
       from typing import Dict, List, Tuple, Union
 
       # check constructors
-      var1 = MultiValueDict()  # E: Need type annotation for "var1"
+      var1 = MultiValueDict()  # E: Need type annotation for "var1"  [var-annotated]
       d2: Dict[str, List[Union[str, int]]] = {'foo': ['Foo'], 'bar': [2, 3]}
       var2 = MultiValueDict(d2)
       d3: Tuple[Tuple[str, List[Union[str, int]]], ...] = (('foo', ['Foo']), ('bar', [2, 3]))
@@ -33,10 +33,10 @@
 
       # setters
       reveal_type(d.setlistdefault('baz'))  # N: Revealed type is "builtins.list[builtins.str]"
-      d.setlistdefault('baz', [1])  # E: List item 0 has incompatible type "int"; expected "str"
+      d.setlistdefault('baz', [1])  # E: List item 0 has incompatible type "int"; expected "str"  [list-item]
       reveal_type(d.setlistdefault('baz', []))  # N: Revealed type is "builtins.list[builtins.str]"
       d.appendlist('baz', 'Baz')
-      d.appendlist('baz', 1)  # E: Argument 2 to "appendlist" of "MultiValueDict" has incompatible type "int"; expected "str"
+      d.appendlist('baz', 1)  # E: Argument 2 to "appendlist" of "MultiValueDict" has incompatible type "int"; expected "str"  [arg-type]
 
       # iterators
       # actually [('foo', 'Foo'), ('bar', [])]

--- a/tests/typecheck/utils/test_functional.yml
+++ b/tests/typecheck/utils/test_functional.yml
@@ -6,7 +6,7 @@
       class Foo:
           @cached_property
           def attr(self) -> List[str]: ...
-          @cached_property  # E: Argument 1 to "cached_property" has incompatible type "Callable[[Foo, str], List[str]]"; expected "Callable[[Any], List[str]]"
+          @cached_property  # E: Argument 1 to "cached_property" has incompatible type "Callable[[Foo, str], List[str]]"; expected "Callable[[Any], List[str]]"  [arg-type]
           def attr2(self, arg2: str) -> List[str]: ...
 
           reveal_type(attr)      # N: Revealed type is "django.utils.functional.cached_property[builtins.list[builtins.str]]"
@@ -17,7 +17,7 @@
 
       f = Foo()
       reveal_type(f.attr)        # N: Revealed type is "builtins.list[builtins.str]"
-      f.attr.name                # E: "List[str]" has no attribute "name"
+      f.attr.name                # E: "List[str]" has no attribute "name"  [attr-defined]
 
 -   case: str_promise_proxy
     main:  |
@@ -33,7 +33,7 @@
       reveal_type(s.capitalize())    # N: Revealed type is "builtins.str"
       reveal_type(s.swapcase)        # N: Revealed type is "def () -> builtins.str"
       reveal_type(s.__getnewargs__)  # N: Revealed type is "def () -> Tuple[builtins.str]"
-      s.nonsense                     # E: "_StrPromise" has no attribute "nonsense"
+      s.nonsense                     # E: "_StrPromise" has no attribute "nonsense"  [attr-defined]
       f: Union[_StrPromise, str]
       reveal_type(f.format("asd"))   # N: Revealed type is "builtins.str"
       reveal_type(f + "asd")         # N: Revealed type is "builtins.str"
@@ -49,7 +49,7 @@
       def bar(content: Promise) -> None:
         ...
 
-      foo(s)                         # E: Argument 1 to "foo" has incompatible type "_StrPromise"; expected "str"
+      foo(s)                         # E: Argument 1 to "foo" has incompatible type "_StrPromise"; expected "str"  [arg-type]
       bar(s)
 
 -   case: classproperty_usage

--- a/tests/typecheck/utils/test_timezone.yml
+++ b/tests/typecheck/utils/test_timezone.yml
@@ -6,7 +6,7 @@
       reveal_type(is_naive(datetime(2020, 1, 1)))
       reveal_type(is_naive(time()))
     out: |
-      main:3: error: No overload variant of "is_naive" matches argument type "date"
+      main:3: error: No overload variant of "is_naive" matches argument type "date"  [call-overload]
       main:3: note: Possible overload variants:
       main:3: note:     def is_naive(value: time) -> Literal[True]
       main:3: note:     def is_naive(value: datetime) -> bool
@@ -21,7 +21,7 @@
       reveal_type(is_aware(datetime(2020, 1, 1)))
       reveal_type(is_aware(time()))
     out: |
-      main:3: error: No overload variant of "is_aware" matches argument type "date"
+      main:3: error: No overload variant of "is_aware" matches argument type "date"  [call-overload]
       main:3: note: Possible overload variants:
       main:3: note:     def is_aware(value: time) -> Literal[False]
       main:3: note:     def is_aware(value: datetime) -> bool

--- a/tests/typecheck/views/generic/test_detail.yml
+++ b/tests/typecheck/views/generic/test_detail.yml
@@ -49,7 +49,7 @@
                 class Other(models.Model):
                     ...
     out: |
-      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "SingleObjectMixin" defined the type as "Type[Other]")
-      main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "SingleObjectMixin" defined the type as "Optional[_QuerySet[Other, Other]]")
-      main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_QuerySet[Other, Other]" in supertype "SingleObjectMixin"
-      main:12: error: Incompatible return value type (got "_QuerySet[Other, Other]", expected "_QuerySet[MyModel, MyModel]")
+      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "SingleObjectMixin" defined the type as "Type[Other]")  [assignment]
+      main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "SingleObjectMixin" defined the type as "Optional[_QuerySet[Other, Other]]")  [assignment]
+      main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_QuerySet[Other, Other]" in supertype "SingleObjectMixin"  [override]
+      main:12: error: Incompatible return value type (got "_QuerySet[Other, Other]", expected "_QuerySet[MyModel, MyModel]")  [return-value]

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -83,7 +83,7 @@
             def some(self) -> None:
                 reveal_type(self.get_form())  # N: Revealed type is "main.ArticleModelForm"
                 reveal_type(self.get_form(SubArticleModelForm))  # N: Revealed type is "main.SubArticleModelForm"
-                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.AnotherArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "Type[AnotherArticleModelForm]"; expected "Optional[Type[ArticleModelForm]]"
+                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.AnotherArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "Type[AnotherArticleModelForm]"; expected "Optional[Type[ArticleModelForm]]"  [arg-type]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/views/generic/test_list.yml
+++ b/tests/typecheck/views/generic/test_list.yml
@@ -47,6 +47,6 @@
                 class Other(models.Model):
                     ...
     out: |
-      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[Type[Other]]")
-      main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[_SupportsPagination[Other]]")
-      main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_SupportsPagination[Other]" in supertype "MultipleObjectMixin"
+      main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[Type[Other]]")  [assignment]
+      main:8: error: Incompatible types in assignment (expression has type "_QuerySet[MyModel, MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[_SupportsPagination[Other]]")  [assignment]
+      main:10: error: Return type "_QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_SupportsPagination[Other]" in supertype "MultipleObjectMixin"  [override]


### PR DESCRIPTION
# I have made things!

I've been doing some work with the stubs lately and was relying on mypy error code to add accurate `type: ignore` comments when necessary. However, I had to change the `show_error_codes` settings quite often for that.

I've seen [here](https://github.com/typeddjango/django-stubs/pull/1577/files#r1243393029) that this setting was legacy so this PR removes it and update the tests accordingly. 

I've used a small python script to do the update automatically.

## Related issues
I could probably reuse the script to do what was started in #1577 and update `force_union_syntax` setting too.
This just require a decision on the value to set for `python_version`. See https://github.com/typeddjango/django-stubs/pull/1572#issuecomment-1605606030
However, because we want to run tests on multiple python versions, maybe it's fine to keep those settings.
