### PR TITLE
Drop hard dependency on mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=1.0.0",
     "django",
     "django-stubs-ext>=4.2.5",
     "tomli; python_version < '3.11'",


### PR DESCRIPTION
As [announced in 4.2.5 release notes](https://github.com/typeddjango/django-stubs/releases/tag/4.2.5), we will drop the hard dependency on mypy. Users of django-stubs with mypy will need to add their own dependency on mypy, or use `django-stubs[compatible-mypy]` extra.

Currently mypy remains the only supported type checker. Improvements for other type checkers may be considered in the future, pull requests welcome.

## Related issues

* Closes #1628
