### PR TITLE
fix: UserAdmin accepts AbstractUser

### DIFF
--- a/django-stubs/contrib/auth/admin.pyi
+++ b/django-stubs/contrib/auth/admin.pyi
@@ -1,16 +1,17 @@
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from django.contrib import admin
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import AbstractUser, Group
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 
 csrf_protect_m: Any
 sensitive_post_parameters_m: Any
+_M = TypeVar("_M", bound=AbstractUser, covariant=False)
 
 class GroupAdmin(admin.ModelAdmin[Group]): ...
 
-class UserAdmin(admin.ModelAdmin[User]):
+class UserAdmin(admin.ModelAdmin[_M], Generic[_M]):
     change_user_password_template: Any
     add_fieldsets: Any
     add_form: Any


### PR DESCRIPTION
# I have made things!

Fix an issue I introduced with UserAdmin: if you inherit from it with a custom `User` it would not work, only with Django base `User`.

If needed, can add a test case akin of:
```
@admin.register(CustomUser)
class CustomUserAdmin(UserAdmin[CustomUser]):
   ...
```
and 
```
@admin.register(CustomUser)
class CustomUserAdmin(UserAdmin):
   ...
```

Any feedback is appreciated!

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
