### PR TITLE
Version 4.2.6 release (django-stubs only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out/
 pip-wheel-metadata/
 stubgen/
 build/
+dist/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
+| 4.2.6          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.5          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.4          | 1.5.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |
 | 4.2.3          | 1.4.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,9 +5,9 @@ if [[ -z $(git status -s) ]]
 then
   if [[ "$VIRTUAL_ENV" != ""  ]]
   then
-    pip install --upgrade setuptools wheel twine
+    pip install --upgrade setuptools wheel twine build
     rm -rf dist/ build/
-    python setup.py sdist bdist_wheel
+    python -m build
     twine upload dist/*
     rm -rf dist/ build/
   else

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="4.2.5",
+    version="4.2.6",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Draft release notes: https://github.com/typeddjango/django-stubs/releases/tag/untagged-057ce17cd60e340b7f30

## Related issues

* Closes #1780
* Fixes #1781
