### PR TITLE
Added `search_help_text=` parameter to `ChangeList.__init__()`

### DIFF
--- a/django-stubs/contrib/admin/views/main.pyi
+++ b/django-stubs/contrib/admin/views/main.pyi
@@ -27,6 +27,7 @@ class ChangeList:
     list_filter: Sequence[_ListFilterT]
     date_hierarchy: Any
     search_fields: Sequence[str]
+    search_help_text: str | None
     list_select_related: bool | Sequence[str]
     list_per_page: int
     list_max_show_all: int
@@ -59,6 +60,7 @@ class ChangeList:
         list_editable: Sequence[str],
         model_admin: ModelAdmin,
         sortable_by: Sequence[str] | None,
+        search_help_text: str | None,
     ) -> None: ...
     def get_filters_params(self, params: dict[str, Any] | None = ...) -> dict[str, Any]: ...
     def get_filters(self, request: HttpRequest) -> tuple[list[ListFilter], bool, dict[str, bool | str], bool, bool]: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -90,7 +90,6 @@ django.contrib.admin.utils.prepare_lookup_value
 django.contrib.admin.views.autocomplete.AutocompleteJsonView.admin_site
 django.contrib.admin.views.autocomplete.AutocompleteJsonView.process_request
 django.contrib.admin.views.autocomplete.AutocompleteJsonView.serialize_result
-django.contrib.admin.views.main.ChangeList.__init__
 django.contrib.admin.views.main.ChangeList.search_form_class
 django.contrib.admin.views.main.ChangeListSearchForm
 django.contrib.admin.widgets.AutocompleteMixin.media


### PR DESCRIPTION
# I have made things!

## Related issues

None found

##

The new parameter `search_help_text` was added with Django 4: https://github.com/django/django/commit/1143f3bb5ecaa2be58f2cd9077f147040291659d
