### PR TITLE
Move plugin generated `<Model>_RelatedManager` entries to allowlist

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -20,6 +20,14 @@ django.core.files.storage.default_storage
 # 'ManyRelatedManager' does exist and is declared locally, inside a function body
 django.db.models.fields.related_descriptors.ManyRelatedManager
 
+# '<Model>_RelatedManager' entries are plugin generated and these subclasses only exist
+# _locally/dynamically_ runtime -- Created via
+# 'django.db.models.fields.related_descriptors.create_reverse_many_to_one_manager'
+django.contrib.admin.models.LogEntry_RelatedManager
+django.contrib.auth.models.Group_RelatedManager
+django.contrib.auth.models.Permission_RelatedManager
+django.contrib.auth.models.User_RelatedManager
+
 # BaseArchive abstract methods that take no argument, but typed with arguments to match the Archive and TarArchive Implementations
 django.utils.archive.BaseArchive.list
 django.utils.archive.BaseArchive.extract

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -63,7 +63,6 @@ django.contrib.admin.models.LogEntry.object_repr
 django.contrib.admin.models.LogEntry.user
 django.contrib.admin.models.LogEntry.user_id
 django.contrib.admin.models.LogEntryManager.__slotnames__
-django.contrib.admin.models.LogEntry_RelatedManager
 django.contrib.admin.options.BaseModelAdmin
 django.contrib.admin.options.BaseModelAdmin.form
 django.contrib.admin.options.BaseModelAdmin.media
@@ -168,7 +167,6 @@ django.contrib.auth.models.Group.name
 django.contrib.auth.models.Group.permissions
 django.contrib.auth.models.Group.user_set
 django.contrib.auth.models.GroupManager.__slotnames__
-django.contrib.auth.models.Group_RelatedManager
 django.contrib.auth.models.Permission.codename
 django.contrib.auth.models.Permission.content_type
 django.contrib.auth.models.Permission.content_type_id
@@ -177,7 +175,6 @@ django.contrib.auth.models.Permission.id
 django.contrib.auth.models.Permission.name
 django.contrib.auth.models.Permission.user_set
 django.contrib.auth.models.PermissionManager.__slotnames__
-django.contrib.auth.models.Permission_RelatedManager
 django.contrib.auth.models.PermissionsMixin.Meta.abstract
 django.contrib.auth.models.PermissionsMixin.groups
 django.contrib.auth.models.PermissionsMixin.is_superuser
@@ -199,7 +196,6 @@ django.contrib.auth.models.User.password
 django.contrib.auth.models.User.user_permissions
 django.contrib.auth.models.User.username
 django.contrib.auth.models.UserManager.__slotnames__
-django.contrib.auth.models.User_RelatedManager
 django.contrib.auth.password_validation.CommonPasswordValidator.DEFAULT_PASSWORD_LIST_PATH
 django.contrib.auth.password_validation.CommonPasswordValidator.__init__
 django.contrib.auth.password_validation.PasswordValidator


### PR DESCRIPTION
Cleaned up some allowlist entries that are plugin generated.

Ref:

https://github.com/typeddjango/django-stubs/blob/53d0c22575dd6493ffde39e91833e0a2edc8a213/mypy_django_plugin/transformers/models.py#L557-L563