### PR TITLE
Allow custom Form class in `SuccessMessageMixin.form_valid()`

### DIFF
--- a/django-stubs/contrib/messages/views.pyi
+++ b/django-stubs/contrib/messages/views.pyi
@@ -1,8 +1,12 @@
+from typing import Generic, TypeVar
+
 from django.forms.forms import BaseForm
 from django.http.response import HttpResponse
 from django.utils.functional import _StrOrPromise
 
-class SuccessMessageMixin:
+_F = TypeVar("_F", bound=BaseForm)
+
+class SuccessMessageMixin(Generic[_F]):
     success_message: _StrOrPromise
-    def form_valid(self, form: BaseForm) -> HttpResponse: ...
+    def form_valid(self, form: _F) -> HttpResponse: ...
     def get_success_message(self, cleaned_data: dict[str, str]) -> _StrOrPromise: ...

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 from django import VERSION
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.options import BaseModelAdmin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
@@ -64,6 +65,7 @@ _need_generic: List[MPGeneric[Any]] = [
     MPGeneric(BaseModelFormSet),
     MPGeneric(Feed),
     MPGeneric(Sitemap),
+    MPGeneric(SuccessMessageMixin),
     MPGeneric(FileProxyMixin),
     MPGeneric(Lookup),
     MPGeneric(BaseConnectionHandler),


### PR DESCRIPTION
# I have made \<first contrib here\> things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

Allow to retype `form_valid` in `SuccessMessageMixin` as suggested in relate issue

```py
from django import forms
from django.contrib.messages.views import SuccessMessageMixin
from django.forms import ModelForm


class MyForm(forms.Form):
    pass


class Test(SuccessMessageMixin[MyForm], ModelForm):
    def form_valid(self, form: MyForm):
        pass
```

## Related issues
Closes #1809 - `SuccessMessageMixin` does not allow `form_valid` to be retyped
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

Feedback: Thanks for awesome library 😻 