### PR TITLE
Correct `db_comment` arg position for `django.db.models.Field.__init__`

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -175,11 +175,11 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
         choices: _FieldChoices | None = ...,
         help_text: _StrOrPromise = ...,
         db_column: str | None = ...,
-        db_comment: str | None = ...,
         db_tablespace: str | None = ...,
         auto_created: bool = ...,
         validators: Iterable[validators._ValidatorCallable] = ...,
         error_messages: _ErrorMessagesMapping | None = ...,
+        db_comment: str | None = ...,
     ) -> None: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     # class access

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -359,7 +359,6 @@ django.contrib.gis.db.models.Field.__deepcopy__
 django.contrib.gis.db.models.Field.__ge__
 django.contrib.gis.db.models.Field.__get__
 django.contrib.gis.db.models.Field.__gt__
-django.contrib.gis.db.models.Field.__init__
 django.contrib.gis.db.models.Field.__le__
 django.contrib.gis.db.models.Field.__lt__
 django.contrib.gis.db.models.Field.__set__
@@ -1102,7 +1101,6 @@ django.db.models.Field.__deepcopy__
 django.db.models.Field.__ge__
 django.db.models.Field.__get__
 django.db.models.Field.__gt__
-django.db.models.Field.__init__
 django.db.models.Field.__le__
 django.db.models.Field.__lt__
 django.db.models.Field.__set__
@@ -1393,7 +1391,6 @@ django.db.models.fields.Field.__deepcopy__
 django.db.models.fields.Field.__ge__
 django.db.models.fields.Field.__get__
 django.db.models.fields.Field.__gt__
-django.db.models.fields.Field.__init__
 django.db.models.fields.Field.__le__
 django.db.models.fields.Field.__lt__
 django.db.models.fields.Field.__set__


### PR DESCRIPTION
Gets rid of `django.db.models.fields.Field.__init__` from `allowlist_todo.txt`. Which is a regularly used method and nice to detect other errors for.