### PR TITLE
Remove incorrect `django.db.models` re-exports

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -3,9 +3,9 @@ from typing import Any, TypeVar, overload
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
-from django.db.models import Combinable, QuerySet
+from django.db.models import QuerySet
 from django.db.models.base import Model
-from django.db.models.expressions import BaseExpression
+from django.db.models.expressions import BaseExpression, Combinable
 from django.http import HttpRequest, HttpResponseBase
 from django.utils.functional import _StrOrPromise
 from typing_extensions import TypeAlias

--- a/django-stubs/db/models/__init__.pyi
+++ b/django-stubs/db/models/__init__.pyi
@@ -26,9 +26,6 @@ from .enums import Choices as Choices
 from .enums import IntegerChoices as IntegerChoices
 from .enums import TextChoices as TextChoices
 from .expressions import Case as Case
-from .expressions import Col as Col
-from .expressions import Combinable as Combinable
-from .expressions import CombinedExpression as CombinedExpression
 from .expressions import Exists as Exists
 from .expressions import Expression as Expression
 from .expressions import ExpressionList as ExpressionList
@@ -37,8 +34,6 @@ from .expressions import F as F
 from .expressions import Func as Func
 from .expressions import OrderBy as OrderBy
 from .expressions import OuterRef as OuterRef
-from .expressions import RawSQL as RawSQL
-from .expressions import Ref as Ref
 from .expressions import RowRange as RowRange
 from .expressions import Subquery as Subquery
 from .expressions import Value as Value
@@ -77,8 +72,6 @@ from .fields import TextField as TextField
 from .fields import TimeField as TimeField
 from .fields import URLField as URLField
 from .fields import UUIDField as UUIDField
-from .fields.files import FieldFile as FieldFile
-from .fields.files import FileDescriptor as FileDescriptor
 from .fields.files import FileField as FileField
 from .fields.files import ImageField as ImageField
 from .fields.json import JSONField as JSONField
@@ -94,11 +87,9 @@ from .fields.related import OneToOneRel as OneToOneRel
 from .indexes import Index as Index
 from .lookups import Lookup as Lookup
 from .lookups import Transform as Transform
-from .manager import BaseManager as BaseManager
 from .manager import Manager as Manager
 from .query import Prefetch as Prefetch
 from .query import QuerySet as QuerySet
-from .query import RawQuerySet as RawQuerySet
 from .query import prefetch_related_objects as prefetch_related_objects
 from .query_utils import FilteredRelation as FilteredRelation
 from .query_utils import Q as Q

--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -2,9 +2,8 @@ import datetime
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, MutableMapping, Sequence
 from typing import Any, Generic, NoReturn, TypeVar, overload
 
-from django.db.models import Combinable
 from django.db.models.base import Model
-from django.db.models.expressions import OrderBy
+from django.db.models.expressions import Combinable, OrderBy
 from django.db.models.query import QuerySet, RawQuerySet
 from typing_extensions import Self
 

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -299,7 +299,6 @@ django.contrib.gis.db.models.BLANK_CHOICE_DASH
 django.contrib.gis.db.models.BaseConstraint.contains_expressions
 django.contrib.gis.db.models.BaseConstraint.get_violation_error_message
 django.contrib.gis.db.models.BaseConstraint.validate
-django.contrib.gis.db.models.BaseManager
 django.contrib.gis.db.models.BigAutoField.rel_db_type
 django.contrib.gis.db.models.BigIntegerField.formfield
 django.contrib.gis.db.models.BinaryField.get_placeholder
@@ -309,9 +308,6 @@ django.contrib.gis.db.models.CharField.cast_db_type
 django.contrib.gis.db.models.CharField.description
 django.contrib.gis.db.models.CharField.formfield
 django.contrib.gis.db.models.CheckConstraint.validate
-django.contrib.gis.db.models.Col
-django.contrib.gis.db.models.Combinable
-django.contrib.gis.db.models.CombinedExpression
 django.contrib.gis.db.models.Count.__init__
 django.contrib.gis.db.models.Count.empty_result_set_value
 django.contrib.gis.db.models.DEFERRED
@@ -356,8 +352,6 @@ django.contrib.gis.db.models.Field.rel_db_type
 django.contrib.gis.db.models.Field.select_format
 django.contrib.gis.db.models.Field.unique
 django.contrib.gis.db.models.FieldDoesNotExist
-django.contrib.gis.db.models.FieldFile
-django.contrib.gis.db.models.FileDescriptor
 django.contrib.gis.db.models.FileField.__get__
 django.contrib.gis.db.models.FileField.attr_class
 django.contrib.gis.db.models.FileField.contribute_to_class
@@ -461,9 +455,6 @@ django.contrib.gis.db.models.QuerySet.__reversed__
 django.contrib.gis.db.models.QuerySet.__xor__
 django.contrib.gis.db.models.QuerySet.datetimes
 django.contrib.gis.db.models.RasterField.contribute_to_class
-django.contrib.gis.db.models.RawQuerySet
-django.contrib.gis.db.models.RawSQL
-django.contrib.gis.db.models.Ref
 django.contrib.gis.db.models.SlugField.formfield
 django.contrib.gis.db.models.SmallAutoField.rel_db_type
 django.contrib.gis.db.models.StdDev.__init__
@@ -957,7 +948,6 @@ django.db.models.BLANK_CHOICE_DASH
 django.db.models.BaseConstraint.contains_expressions
 django.db.models.BaseConstraint.get_violation_error_message
 django.db.models.BaseConstraint.validate
-django.db.models.BaseManager
 django.db.models.BigAutoField.rel_db_type
 django.db.models.BigIntegerField.formfield
 django.db.models.BinaryField.get_placeholder
@@ -967,9 +957,6 @@ django.db.models.CharField.cast_db_type
 django.db.models.CharField.description
 django.db.models.CharField.formfield
 django.db.models.CheckConstraint.validate
-django.db.models.Col
-django.db.models.Combinable
-django.db.models.CombinedExpression
 django.db.models.Count.__init__
 django.db.models.Count.empty_result_set_value
 django.db.models.DEFERRED
@@ -1012,8 +999,6 @@ django.db.models.Field.rel_db_type
 django.db.models.Field.select_format
 django.db.models.Field.unique
 django.db.models.FieldDoesNotExist
-django.db.models.FieldFile
-django.db.models.FileDescriptor
 django.db.models.FileField.__get__
 django.db.models.FileField.attr_class
 django.db.models.FileField.contribute_to_class
@@ -1114,9 +1099,6 @@ django.db.models.QuerySet.__deepcopy__
 django.db.models.QuerySet.__reversed__
 django.db.models.QuerySet.__xor__
 django.db.models.QuerySet.datetimes
-django.db.models.RawQuerySet
-django.db.models.RawSQL
-django.db.models.Ref
 django.db.models.SlugField.formfield
 django.db.models.SmallAutoField.rel_db_type
 django.db.models.StdDev.__init__


### PR DESCRIPTION
# I have made things!

Trying to import these items in Django 4.2.7 fails with `ImportError` at runtime. Not sure if they were removed, or never worked in the first place.

```
>>> from django.db.models import BaseManager
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'BaseManager' from 'django.db.models' (.../site-packages/django/db/models/__init__.py)
```

## Related issues

Discovered when I was testing #1834.
