### PR TITLE
Accurately infer `capfirst()` `None` return

### DIFF
--- a/django-stubs/utils/text.pyi
+++ b/django-stubs/utils/text.pyi
@@ -7,8 +7,9 @@ from django.db.models.base import Model
 from django.utils.functional import SimpleLazyObject, _StrOrPromise
 
 _StrOrPromiseT = TypeVar("_StrOrPromiseT", bound=_StrOrPromise)
+_StrOrPromiseOrNoneT = TypeVar("_StrOrPromiseOrNoneT", bound=_StrOrPromise | None)
 
-def capfirst(x: _StrOrPromiseT | None) -> _StrOrPromiseT | None: ...
+def capfirst(x: _StrOrPromiseOrNoneT) -> _StrOrPromiseOrNoneT: ...
 
 re_words: Pattern[str]
 re_chars: Pattern[str]


### PR DESCRIPTION
# I have made things!

While looking into #1626, I noticed that `capfirst()` is hinted as returning `... | None` even when input is never `None`. This can be fixed with a new `TypeVar`.

```python
reveal_type(capfirst('constant string'))
# Before: Revealed type is "Union[builtins.str, None]"
# After: Revealed type is "builtins.str"
```
