### PR TITLE
Restore `RelatedManager`, `ManyRelatedManager` to inherit from `Manager` not `BaseManager`

### DIFF
--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -126,7 +126,7 @@ class ManyToManyDescriptor(ReverseManyToOneDescriptor, Generic[_M]):
     def related_manager_cls(self) -> type[ManyRelatedManager[Any]]: ...  # type: ignore[override]
 
 # Fake class, Django defines 'ManyRelatedManager' inside a function body
-class ManyRelatedManager(BaseManager[_M], Generic[_M]):
+class ManyRelatedManager(Manager[_M], Generic[_M]):
     related_val: tuple[int, ...]
     def add(self, *objs: _M | int, bulk: bool = ...) -> None: ...
     async def aadd(self, *objs: _M | int, bulk: bool = ...) -> None: ...

--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -6,7 +6,7 @@ from django.db.models.base import Model
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey, ManyToManyField, RelatedField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel, OneToOneRel
-from django.db.models.manager import BaseManager
+from django.db.models.manager import BaseManager, Manager
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import DeferredAttribute
 from django.utils.functional import cached_property
@@ -88,7 +88,7 @@ class ReverseManyToOneDescriptor:
     def __set__(self, instance: Any, value: Any) -> NoReturn: ...
 
 # Fake class, Django defines 'RelatedManager' inside a function body
-class RelatedManager(BaseManager[_M], Generic[_M]):
+class RelatedManager(Manager[_M], Generic[_M]):
     related_val: tuple[int, ...]
     def add(self, *objs: _M | int, bulk: bool = ...) -> None: ...
     async def aadd(self, *objs: _M | int, bulk: bool = ...) -> None: ...


### PR DESCRIPTION
Ping @flaeppe.

The base class of `RelatedManager` was changed from `Manager` to `BaseManager` in #1814. I did not notice the change when reviewing, but only discovered it later when testing `django-stubs` git version out on my projects.

It looks like this will cascade to many users, forcing users to replace `Manager` type hints with `BaseManager`, including `djangorestframework-stubs` and my own projects. So I'd expect some justification for the change, otherwise we should revert it (as this PR does).

I don't want to make a `django-stubs` release with this change, without having discussed and agreed that it's what we really want. Maybe we should just revert (merge this) for the time being and can continue this discussion later?

----

`BaseManager` seems to be intended as an impementation detail in Django -- it's not even mentioned anywhere in their documentation. Inspecting relation objects at Django runtime, they by default inherit from `Manager` also.

What are the use cases for creating custom manager classes from `BaseManager` instead of `Manager`, and are those use cases important enough that we want to move to `BaseManager`?

## Related issues

* #1814
* https://github.com/typeddjango/djangorestframework-stubs/pull/508
