### PR TITLE
Refactor: Unify plugin check for model type info

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -416,7 +416,7 @@ def add_new_manager_base(api: SemanticAnalyzerPluginInterface, fullname: str) ->
 
 
 def is_abstract_model(model: TypeInfo) -> bool:
-    if model.metaclass_type is None or model.metaclass_type.type.fullname != fullnames.MODEL_METACLASS_FULLNAME:
+    if not is_model_type(model):
         return False
 
     metadata = get_django_metadata(model)
@@ -473,8 +473,5 @@ def resolve_lazy_reference(
     return None
 
 
-def is_model_instance(instance: Instance) -> bool:
-    return (
-        instance.type.metaclass_type is not None
-        and instance.type.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
-    )
+def is_model_type(info: TypeInfo) -> bool:
+    return info.metaclass_type is not None and info.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -245,12 +245,7 @@ class NewSemanalDjangoPlugin(Plugin):
     def get_base_class_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
         # Base class is a Model class definition
         sym = self.lookup_fully_qualified(fullname)
-        if (
-            sym is not None
-            and isinstance(sym.node, TypeInfo)
-            and sym.node.metaclass_type is not None
-            and sym.node.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
-        ):
+        if sym is not None and isinstance(sym.node, TypeInfo) and helpers.is_model_type(sym.node):
             return partial(process_model_class, django_context=self.django_context)
 
         # Base class is a Manager class definition

--- a/mypy_django_plugin/transformers/manytomany.py
+++ b/mypy_django_plugin/transformers/manytomany.py
@@ -130,10 +130,7 @@ def get_model_from_expression(
     argument(e.g. "<app_label>.<object_name>") to a Django model is also attempted.
     """
     if isinstance(expr, NameExpr) and isinstance(expr.node, TypeInfo):
-        if (
-            expr.node.metaclass_type is not None
-            and expr.node.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
-        ):
+        if helpers.is_model_type(expr.node):
             return Instance(expr.node, [])
 
     lazy_reference = None
@@ -166,7 +163,7 @@ def get_related_manager_and_model(ctx: MethodContext) -> Optional[Tuple[Instance
         if (
             many_related_manager.args
             and isinstance(many_related_manager.args[0], Instance)
-            and helpers.is_model_instance(many_related_manager.args[0])
+            and helpers.is_model_type(many_related_manager.args[0].type)
         ):
             return many_related_manager, many_related_manager.args[0]
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -850,8 +850,7 @@ class MetaclassAdjustments(ModelClassInitializer):
             exception_base_sym = model_base.names.get(name)
             if (
                 # Base class is a Model
-                model_base.metaclass_type is not None
-                and model_base.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
+                helpers.is_model_type(model_base)
                 # But base class is not 'models.Model'
                 and model_base.fullname != fullnames.MODEL_CLASS_FULLNAME
                 # Base class also has a generated exception base e.g. 'DoesNotExist'


### PR DESCRIPTION
Replace a couple of repetitions with an auxiliary call

__Side note:__ Not sure if there's any additional gain, but might be fun to introduce some narrowing with a

```python
ModelTypeInfo = NewType("ModelTypeInfo", TypeInfo)
```

Which could be type guarded from the `def is_model_type(info: TypeInfo) -> TypeGuard[ModelTypeInfo]`

Probably possible to do for an `ModelInstance` as well.

But we should probably find a place where it could be utilised first.

## Related issues

Refs: #1805