### PR TITLE
Added `Model._do_update()` method signature

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -52,9 +52,9 @@ class Model(metaclass=ModelBase):
     def _do_update(
         self,
         base_qs: QuerySet[Self],
-        using: Any,
+        using: str | None,
         pk_val: Any,
-        values: Collection[Any] | None,
+        values: Collection[tuple[Field, type[Model] | None, Any]],
         update_fields: Iterable[str] | None,
         forced_update: bool,
     ) -> bool: ...

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, Final, TypeVar, overload
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import BaseConstraint, Field
+from django.db.models import BaseConstraint, Field, QuerySet
 from django.db.models.manager import BaseManager, Manager
 from django.db.models.options import Options
 from typing_extensions import Self
@@ -49,6 +49,15 @@ class Model(metaclass=ModelBase):
     def add_to_class(cls, name: str, value: Any) -> Any: ...
     @classmethod
     def from_db(cls, db: str | None, field_names: Collection[str], values: Collection[Any]) -> Self: ...
+    def _do_update(
+        self,
+        base_qs: QuerySet[Self],
+        using: Any,
+        pk_val: Any,
+        values: Collection[Any] | None,
+        update_fields: Iterable[str] | None,
+        forced_update: bool,
+    ) -> bool: ...
     def delete(self, using: Any = ..., keep_parents: bool = ...) -> tuple[int, dict[str, int]]: ...
     async def adelete(self, using: Any = ..., keep_parents: bool = ...) -> tuple[int, dict[str, int]]: ...
     def full_clean(


### PR DESCRIPTION
# I have made things!

Add typing for a private method (used in django-fsm), which signature has not changed [since 2013](https://github.com/django/django/blame/main/django/db/models/base.py#L1067)

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
