### PR TITLE
Version 4.2.7 release (django-stubs, django-stubs-ext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
-| (next version) | 1.7.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
+| 4.2.7          | 1.7.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.6          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.5          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.4          | 1.5.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.11     |

--- a/ext/setup.py
+++ b/ext/setup.py
@@ -15,7 +15,7 @@ dependencies = [
 # It's fine to skip django-stubs-ext releases, but when doing a release, update this to newest django-stubs version.
 setup(
     name="django-stubs-ext",
-    version="4.2.5",
+    version="4.2.7",
     description="Monkey-patching and extensions for django-stubs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md") as f:
 
 dependencies = [
     "django",
-    "django-stubs-ext>=4.2.5",
+    "django-stubs-ext>=4.2.7",
     "tomli; python_version < '3.11'",
     # Types:
     "typing-extensions",
@@ -37,7 +37,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="4.2.6",
+    version="4.2.7",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Closes #1828

Draft release notes: https://github.com/typeddjango/django-stubs/releases/edit/untagged-55cb07060f95767603ae