### PR TITLE
Include ModelBase subclasses in plugin base class hook condition

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -474,4 +474,9 @@ def resolve_lazy_reference(
 
 
 def is_model_type(info: TypeInfo) -> bool:
-    return info.metaclass_type is not None and info.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
+    return info.metaclass_type is not None and (
+        # Using the model metaclass shipped by Django
+        info.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
+        # Using a custom model metaclass that inherits above
+        or info.metaclass_type.type.has_base(fullnames.MODEL_METACLASS_FULLNAME)
+    )

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -474,9 +474,4 @@ def resolve_lazy_reference(
 
 
 def is_model_type(info: TypeInfo) -> bool:
-    return info.metaclass_type is not None and (
-        # Using the model metaclass shipped by Django
-        info.metaclass_type.type.fullname == fullnames.MODEL_METACLASS_FULLNAME
-        # Using a custom model metaclass that inherits above
-        or info.metaclass_type.type.has_base(fullnames.MODEL_METACLASS_FULLNAME)
-    )
+    return info.metaclass_type is not None and info.metaclass_type.type.has_base(fullnames.MODEL_METACLASS_FULLNAME)

--- a/tests/typecheck/models/test_metaclass.yml
+++ b/tests/typecheck/models/test_metaclass.yml
@@ -73,3 +73,25 @@
 
               class Concrete3(Concrete2):
                   ...
+
+-   case: test_custom_model_base_metaclass
+    main: |
+        from myapp.models import This, Other
+
+        this = This(field=Other())
+        reveal_type(this.field)  # N: Revealed type is "myapp.models.Other"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.base import ModelBase
+
+              class MyBase(ModelBase): ...
+              class MyModel(models.Model, metaclass=MyBase): ...
+
+              class Other(MyModel): ...
+              class This(MyModel):
+                  field = models.ForeignKey(Other, on_delete=models.CASCADE)


### PR DESCRIPTION
# I have made things!

We now also trigger the base class hook for subclasses of `ModelBase`.

## Related issues

Refs: https://github.com/typeddjango/django-stubs/pull/1668#issuecomment-1700897353
Supersedes: #1670 
Closes: #1799 