### PR TITLE
Fix type of `AppConfig.models_module`

### DIFF
--- a/django-stubs/apps/config.pyi
+++ b/django-stubs/apps/config.pyi
@@ -15,7 +15,7 @@ class AppConfig:
     label: str
     verbose_name: _StrOrPromise
     path: str
-    models_module: str | None
+    models_module: types.ModuleType | None
     # Default auto_field is a cached_property on the base, but is usually subclassed as a str
     # If not subclassing with a str, a type ignore[override] is needed
     models: dict[str, type[Model]]


### PR DESCRIPTION
See https://github.com/django/django/blob/b287af5dc954628d4b336aefc5027b2edceee64b/django/apps/config.py#L262-L269:

```python
    def import_models(self):
        # Dictionary of models for this app, primarily maintained in the
        # 'all_models' attribute of the Apps this AppConfig is attached to.
        self.models = self.apps.all_models[self.label]

        if module_has_submodule(self.module, MODELS_MODULE_NAME):
            models_module_name = "%s.%s" % (self.name, MODELS_MODULE_NAME)
            self.models_module = import_module(models_module_name)
```