### PR TITLE
Allow `None` in settings `MIGRATION_MODULES` dict values

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -502,7 +502,7 @@ STATICFILES_FINDERS: list[str]
 ##############
 
 # Migration module overrides for apps, by app label.
-MIGRATION_MODULES: dict[str, str]
+MIGRATION_MODULES: dict[str, str | None]
 
 #################
 # SYSTEM CHECKS #


### PR DESCRIPTION
this is used to disable migrations for a particular module (such as during tests) https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-MIGRATION_MODULES
