### PR TITLE
Fix `AsyncClient.defaults` attribute typing

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -4,9 +4,9 @@ from io import BytesIO, IOBase
 from json import JSONEncoder
 from re import Pattern
 from types import TracebackType
-from typing import Any, Generic, NoReturn, TypeVar, type_check_only
+from typing import Any, Generic, Literal, NoReturn, TypedDict, TypeVar, type_check_only
 
-from asgiref.typing import HTTPScope
+from asgiref.typing import ASGIVersions
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.sessions.backends.base import SessionBase
 from django.core.handlers.asgi import ASGIRequest
@@ -154,6 +154,24 @@ class _RequestFactory(Generic[_T]):
     ) -> _T: ...
 
 class RequestFactory(_RequestFactory[WSGIRequest]): ...
+
+# A non total duplication of `asgiref.typing.HTTPScope`
+@type_check_only
+class HTTPScope(TypedDict, total=False):
+    type: Literal["http"]
+    asgi: ASGIVersions
+    http_version: str
+    method: str
+    scheme: str
+    path: str
+    raw_path: bytes
+    query_string: bytes
+    root_path: str
+    headers: Iterable[tuple[bytes, bytes]]
+    client: tuple[str, int] | None
+    server: tuple[str, int | None] | None
+    state: dict[str, Any]
+    extensions: dict[str, dict[object, object]] | None
 
 @type_check_only
 class _AsyncRequestFactory(_RequestFactory[_T]):

--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -6,6 +6,7 @@ from re import Pattern
 from types import TracebackType
 from typing import Any, Generic, NoReturn, TypeVar, type_check_only
 
+from asgiref.typing import HTTPScope
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.sessions.backends.base import SessionBase
 from django.core.handlers.asgi import ASGIRequest
@@ -155,7 +156,8 @@ class _RequestFactory(Generic[_T]):
 class RequestFactory(_RequestFactory[WSGIRequest]): ...
 
 @type_check_only
-class _AsyncRequestFactory(_RequestFactory[_T]): ...
+class _AsyncRequestFactory(_RequestFactory[_T]):
+    defaults: HTTPScope  # type: ignore[assignment]
 
 class AsyncRequestFactory(_AsyncRequestFactory[ASGIRequest]): ...
 

--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -157,7 +157,7 @@ class RequestFactory(_RequestFactory[WSGIRequest]): ...
 
 # A non total duplication of `asgiref.typing.HTTPScope`
 @type_check_only
-class HTTPScope(TypedDict, total=False):
+class _HTTPScope(TypedDict, total=False):
     type: Literal["http"]
     asgi: ASGIVersions
     http_version: str
@@ -175,7 +175,7 @@ class HTTPScope(TypedDict, total=False):
 
 @type_check_only
 class _AsyncRequestFactory(_RequestFactory[_T]):
-    defaults: HTTPScope  # type: ignore[assignment]
+    defaults: _HTTPScope  # type: ignore[assignment]
 
 class AsyncRequestFactory(_AsyncRequestFactory[ASGIRequest]): ...
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open("README.md") as f:
 
 dependencies = [
     "django",
+    "asgiref",
     "django-stubs-ext>=5.0.0.dev1",
     "tomli; python_version < '3.11'",
     # Types:


### PR DESCRIPTION
e.g. overriding client for an ASGI request requires a list

Here's the runtime reference for the available ASGI scope: https://github.com/django/django/blob/617bcf611f3daa796e4054ba041089ece30a32fc/django/test/client.py#L640-L662