### PR TITLE
Update mypy to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
-| (next release) | 1.7.x        | 5.0            | 4.2, 4.1, 3.2          | 3.8 - 3.12     |
+| (next release) | 1.8.x        | 5.0            | 4.2, 4.1, 3.2          | 3.8 - 3.12     |
 | 4.2.7          | 1.7.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.6          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.5          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ Django==5.0.0; python_version >= '3.10'
 -e .[compatible-mypy]
 
 # Overrides:
-mypy==1.7.1
+mypy==1.8.0

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -707,8 +707,6 @@ django.contrib.staticfiles.management.commands.findstatic.Command.handle_label
 django.contrib.staticfiles.storage
 django.core.cache.cache
 django.core.checks.registry.CheckRegistry.register
-django.core.files.File.__next__
-django.core.files.base.File.__next__
 django.core.files.locks.OVERLAPPED
 django.core.files.locks.PVOID
 django.core.files.locks.ULONG_PTR
@@ -1639,8 +1637,6 @@ django.http.HttpRequest.__init__
 django.http.HttpRequest.get_raw_uri
 django.http.HttpRequest.is_ajax
 django.http.HttpRequest.readlines
-django.http.HttpResponseBase.__iter__
-django.http.HttpResponseBase.getvalue
 django.http.StreamingHttpResponse.content
 django.http.multipartparser.MultiPartParser.IE_sanitize
 django.http.multipartparser.MultiPartParser.boundary_re
@@ -1650,8 +1646,6 @@ django.http.request.HttpRequest.is_ajax
 django.http.request.HttpRequest.readlines
 django.http.request.UploadHandlerList
 django.http.request.parse_accept_header
-django.http.response.HttpResponseBase.__iter__
-django.http.response.HttpResponseBase.getvalue
 django.http.response.StreamingHttpResponse.content
 django.middleware.cache.CacheMiddleware.__init__
 django.middleware.cache.CacheMiddleware.cache

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
 
 # Keep compatible-mypy major.minor version pinned to what we use in CI (requirements.txt)
 extras_require = {
-    "compatible-mypy": ["mypy~=1.7.0"],
+    "compatible-mypy": ["mypy~=1.8.0"],
 }
 
 setup(


### PR DESCRIPTION
Closes https://github.com/typeddjango/django-stubs/pull/1884

All changes in `stubtest`'s allowlist is related to new `@type_check_only` feature:
- https://github.com/typeddjango/django-stubs/blob/125f31a81116f5f149c3e868d950608571e9a5e8/django-stubs/core/files/base.pyi#L31-L32
- https://github.com/typeddjango/django-stubs/blob/125f31a81116f5f149c3e868d950608571e9a5e8/django-stubs/http/response.pyi#L87-L91
