### PR TITLE
Add `ModuleType` as a possible type to `URLResolver.urlconf_name`

### DIFF
--- a/django-stubs/urls/resolvers.pyi
+++ b/django-stubs/urls/resolvers.pyi
@@ -103,7 +103,7 @@ class URLPattern:
 
 class URLResolver:
     pattern: _Pattern
-    urlconf_name: str | None | Sequence[_AnyURL] | ModuleType
+    urlconf_name: str | Sequence[_AnyURL] | ModuleType
     callback: None
     default_kwargs: dict[str, Any]
     namespace: str | None
@@ -113,7 +113,7 @@ class URLResolver:
     def __init__(
         self,
         pattern: _Pattern,
-        urlconf_name: str | None | Sequence[_AnyURL] | ModuleType,
+        urlconf_name: str | Sequence[_AnyURL] | ModuleType,
         default_kwargs: dict[str, Any] | None = ...,
         app_name: str | None = ...,
         namespace: str | None = ...,

--- a/django-stubs/urls/resolvers.pyi
+++ b/django-stubs/urls/resolvers.pyi
@@ -113,7 +113,7 @@ class URLResolver:
     def __init__(
         self,
         pattern: _Pattern,
-        urlconf_name: str | None | Sequence[_AnyURL],
+        urlconf_name: str | None | Sequence[_AnyURL] | ModuleType,
         default_kwargs: dict[str, Any] | None = ...,
         app_name: str | None = ...,
         namespace: str | None = ...,

--- a/django-stubs/urls/resolvers.pyi
+++ b/django-stubs/urls/resolvers.pyi
@@ -103,7 +103,7 @@ class URLPattern:
 
 class URLResolver:
     pattern: _Pattern
-    urlconf_name: str | None | Sequence[_AnyURL]
+    urlconf_name: str | None | Sequence[_AnyURL] | ModuleType
     callback: None
     default_kwargs: dict[str, Any]
     namespace: str | None


### PR DESCRIPTION
According to code comment:
It may also be an object with an urlpatterns attribute (i.e. a module object)

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
