### PR TITLE
Fix type hint of `URLPattern.default_args`

### DIFF
--- a/django-stubs/urls/resolvers.pyi
+++ b/django-stubs/urls/resolvers.pyi
@@ -86,7 +86,7 @@ class LocalePrefixPattern:
 class URLPattern:
     pattern: _Pattern
     callback: Callable
-    default_args: dict[str, str] | None
+    default_args: dict[str, str]
     name: str | None
     def __init__(
         self,

--- a/django-stubs/urls/resolvers.pyi
+++ b/django-stubs/urls/resolvers.pyi
@@ -86,13 +86,13 @@ class LocalePrefixPattern:
 class URLPattern:
     pattern: _Pattern
     callback: Callable
-    default_args: dict[str, str]
+    default_args: dict[str, Any]
     name: str | None
     def __init__(
         self,
         pattern: _Pattern,
         callback: Callable,
-        default_args: dict[str, str] | None = ...,
+        default_args: dict[str, Any] | None = ...,
         name: str | None = ...,
     ) -> None: ...
     def check(self) -> list[CheckMessage]: ...


### PR DESCRIPTION
From the implementation:

```python
class URLPattern:
    def __init__(self, pattern, callback, default_args=None, name=None):
        self.pattern = pattern
        self.callback = callback  # the view
        self.default_args = default_args or {}
        self.name = name
```

I'm wondering if it can be `dict[str, Any]`, as defined in `URLResolver` for `default_kwargs`?