### PR TITLE
Fix type hint of `EmailBackend.ssl_keyfile` and `EmailBackend.ssl_certfile`

### DIFF
--- a/django-stubs/core/mail/backends/smtp.pyi
+++ b/django-stubs/core/mail/backends/smtp.pyi
@@ -1,6 +1,7 @@
 import smtplib
 import threading
 
+from _typeshed import StrOrBytesPath
 from django.core.mail.backends.base import BaseEmailBackend
 
 class EmailBackend(BaseEmailBackend):
@@ -11,7 +12,7 @@ class EmailBackend(BaseEmailBackend):
     use_tls: bool
     use_ssl: bool
     timeout: int | None
-    ssl_keyfile: str | None
-    ssl_certfile: str | None
+    ssl_keyfile: StrOrBytesPath | None
+    ssl_certfile: StrOrBytesPath | None
     connection: smtplib.SMTP_SSL | smtplib.SMTP | None
     _lock: threading.RLock


### PR DESCRIPTION
Only hit in the Django codebase was [here](https://github.com/django/django/blob/10c7c7320baf1c655fcb91202169d77725c9c4bd/django/core/mail/backends/smtp.py#L59-L63), and according to the [typeshed definition](https://github.com/python/typeshed/blob/c51de8ee6859b3b1b411d48e56cd537716893e81/stdlib/ssl.pyi#L405-L407):

```python
    def load_cert_chain(
        self, certfile: StrOrBytesPath, keyfile: StrOrBytesPath | None = None, password: _PasswordType | None = None
    ) -> None: ...
```