### PR TITLE
Add type of `django.VERSION`

### DIFF
--- a/django-stubs/__init__.pyi
+++ b/django-stubs/__init__.pyi
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, Literal
 
 from .utils.version import get_version as get_version
 
-VERSION: Any
+VERSION: tuple[int, int, int, Literal["alpha", "beta", "rc", "final"], int]
 __version__: str
 
 def setup(set_prefix: bool = ...) -> None: ...

--- a/django-stubs/__init__.pyi
+++ b/django-stubs/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Literal
 
 from .utils.version import get_version as get_version
 


### PR DESCRIPTION
See https://docs.djangoproject.com/en/dev/internals/howto-release-django/#notes-on-setting-the-version-tuple,

the attribute has been consistent for a long time now so this is probably safe.