### PR TITLE
Avoid returning None from get_field_related_model_cls

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -369,6 +369,9 @@ class DjangoContext:
         else:
             related_model_cls = field.field.model
 
+        if related_model_cls is None:
+            raise UnregisteredModelError
+
         if isinstance(related_model_cls, str):
             if related_model_cls == "self":  # type: ignore[unreachable]
                 # same model


### PR DESCRIPTION
https://github.com/typeddjango/django-stubs/pull/1495 updated `get_field_related_model_cls` to raise `UnregisteredModelError` rather than returning `None` for failure paths. However, None can still be returned if the initial retrieval of `related_model_cls` returns None.

This patch adds a check to see if the initial retrieval has got a `None` and then raises the appropriate error rather than letting `None` be returned.

## Related issues

Closes https://github.com/typeddjango/django-stubs/issues/1953
