### PR TITLE
Fix type annotation for RegisterLookupMixin.class_lookups

### DIFF
--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Literal, TypeVar
+from typing import Any, ClassVar, Literal, TypeVar
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.base import Model
@@ -49,7 +49,7 @@ class DeferredAttribute:
 _R = TypeVar("_R", bound=type)
 
 class RegisterLookupMixin:
-    class_lookups: list[dict[Any, Any]]
+    class_lookups: ClassVar[dict[str, Any]]
     lookup_name: str
     @classmethod
     def get_lookups(cls) -> dict[str, Any]: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -300,12 +300,9 @@ django.contrib.gis.db.models.CheckConstraint.validate
 django.contrib.gis.db.models.Count.__init__
 django.contrib.gis.db.models.Count.empty_result_set_value
 django.contrib.gis.db.models.DEFERRED
-django.contrib.gis.db.models.DateField.class_lookups
 django.contrib.gis.db.models.DateField.contribute_to_class
 django.contrib.gis.db.models.DateField.formfield
-django.contrib.gis.db.models.DateTimeField.class_lookups
 django.contrib.gis.db.models.DateTimeField.formfield
-django.contrib.gis.db.models.DecimalField.class_lookups
 django.contrib.gis.db.models.DecimalField.context
 django.contrib.gis.db.models.DecimalField.formfield
 django.contrib.gis.db.models.DurationField.formfield
@@ -326,7 +323,6 @@ django.contrib.gis.db.models.Field.__le__
 django.contrib.gis.db.models.Field.__lt__
 django.contrib.gis.db.models.Field.__set__
 django.contrib.gis.db.models.Field.cast_db_type
-django.contrib.gis.db.models.Field.class_lookups
 django.contrib.gis.db.models.Field.clone
 django.contrib.gis.db.models.Field.db_returning
 django.contrib.gis.db.models.Field.db_tablespace
@@ -347,7 +343,6 @@ django.contrib.gis.db.models.FileField.contribute_to_class
 django.contrib.gis.db.models.FileField.descriptor_class
 django.contrib.gis.db.models.FileField.formfield
 django.contrib.gis.db.models.FilePathField.formfield
-django.contrib.gis.db.models.FloatField.class_lookups
 django.contrib.gis.db.models.FloatField.formfield
 django.contrib.gis.db.models.ForeignKey.__class_getitem__
 django.contrib.gis.db.models.ForeignKey.contribute_to_related_class
@@ -357,7 +352,6 @@ django.contrib.gis.db.models.ForeignKey.formfield
 django.contrib.gis.db.models.ForeignKey.get_db_converters
 django.contrib.gis.db.models.ForeignObject.__copy__
 django.contrib.gis.db.models.ForeignObject.__get__
-django.contrib.gis.db.models.ForeignObject.class_lookups
 django.contrib.gis.db.models.ForeignObject.contribute_to_related_class
 django.contrib.gis.db.models.ForeignObject.forward_related_accessor_class
 django.contrib.gis.db.models.ForeignObject.get_class_lookups
@@ -390,9 +384,7 @@ django.contrib.gis.db.models.ImageField.attr_class
 django.contrib.gis.db.models.ImageField.contribute_to_class
 django.contrib.gis.db.models.ImageField.descriptor_class
 django.contrib.gis.db.models.ImageField.formfield
-django.contrib.gis.db.models.IntegerField.class_lookups
 django.contrib.gis.db.models.IntegerField.formfield
-django.contrib.gis.db.models.JSONField.class_lookups
 django.contrib.gis.db.models.JSONField.formfield
 django.contrib.gis.db.models.JSONField.get_transform
 django.contrib.gis.db.models.Lookup.get_prep_lhs
@@ -450,10 +442,8 @@ django.contrib.gis.db.models.Subquery.external_aliases
 django.contrib.gis.db.models.Subquery.get_external_cols
 django.contrib.gis.db.models.Subquery.subquery
 django.contrib.gis.db.models.TextField.formfield
-django.contrib.gis.db.models.TimeField.class_lookups
 django.contrib.gis.db.models.TimeField.formfield
 django.contrib.gis.db.models.URLField.formfield
-django.contrib.gis.db.models.UUIDField.class_lookups
 django.contrib.gis.db.models.UUIDField.formfield
 django.contrib.gis.db.models.UniqueConstraint.contains_expressions
 django.contrib.gis.db.models.UniqueConstraint.validate
@@ -467,7 +457,6 @@ django.contrib.gis.db.models.aggregates.Extent.is_extent
 django.contrib.gis.db.models.aggregates.Extent3D.is_extent
 django.contrib.gis.db.models.aggregates.GeoAggregate.as_sql
 django.contrib.gis.db.models.aggregates.GeoAggregate.function
-django.contrib.gis.db.models.fields.BaseSpatialField.class_lookups
 django.contrib.gis.db.models.fields.GeometryField.contribute_to_class
 django.contrib.gis.db.models.fields.RasterField.contribute_to_class
 django.contrib.gis.db.models.functions.Area.as_sql
@@ -588,7 +577,6 @@ django.contrib.postgres.constraints.ExclusionConstraint.check_supported
 django.contrib.postgres.constraints.ExclusionConstraint.template
 django.contrib.postgres.constraints.ExclusionConstraint.validate
 django.contrib.postgres.fields.ArrayField.cast_db_type
-django.contrib.postgres.fields.ArrayField.class_lookups
 django.contrib.postgres.fields.ArrayField.formfield
 django.contrib.postgres.fields.ArrayField.get_placeholder
 django.contrib.postgres.fields.BigIntegerRangeField.__get__
@@ -599,31 +587,25 @@ django.contrib.postgres.fields.CIText.db_type
 django.contrib.postgres.fields.CIText.get_internal_type
 django.contrib.postgres.fields.DateRangeField.__get__
 django.contrib.postgres.fields.DateRangeField.base_field
-django.contrib.postgres.fields.DateRangeField.class_lookups
 django.contrib.postgres.fields.DateRangeField.form_field
 django.contrib.postgres.fields.DateTimeRangeField.__get__
 django.contrib.postgres.fields.DateTimeRangeField.base_field
-django.contrib.postgres.fields.DateTimeRangeField.class_lookups
 django.contrib.postgres.fields.DateTimeRangeField.form_field
 django.contrib.postgres.fields.DecimalRangeField.__get__
 django.contrib.postgres.fields.DecimalRangeField.base_field
 django.contrib.postgres.fields.DecimalRangeField.form_field
-django.contrib.postgres.fields.HStoreField.class_lookups
 django.contrib.postgres.fields.HStoreField.formfield
 django.contrib.postgres.fields.IntegerRangeField.__get__
 django.contrib.postgres.fields.IntegerRangeField.base_field
 django.contrib.postgres.fields.IntegerRangeField.form_field
-django.contrib.postgres.fields.RangeField.class_lookups
 django.contrib.postgres.fields.RangeField.formfield
 django.contrib.postgres.fields.RangeField.get_placeholder
 django.contrib.postgres.fields.array.ArrayField.cast_db_type
-django.contrib.postgres.fields.array.ArrayField.class_lookups
 django.contrib.postgres.fields.array.ArrayField.formfield
 django.contrib.postgres.fields.array.ArrayField.get_placeholder
 django.contrib.postgres.fields.citext.CIText.__init__
 django.contrib.postgres.fields.citext.CIText.db_type
 django.contrib.postgres.fields.citext.CIText.get_internal_type
-django.contrib.postgres.fields.hstore.HStoreField.class_lookups
 django.contrib.postgres.fields.hstore.HStoreField.formfield
 django.contrib.postgres.fields.hstore.KeyTransform.as_sql
 django.contrib.postgres.fields.jsonb.KeyTextTransform
@@ -633,11 +615,9 @@ django.contrib.postgres.fields.ranges.BigIntegerRangeField.base_field
 django.contrib.postgres.fields.ranges.BigIntegerRangeField.form_field
 django.contrib.postgres.fields.ranges.DateRangeField.__get__
 django.contrib.postgres.fields.ranges.DateRangeField.base_field
-django.contrib.postgres.fields.ranges.DateRangeField.class_lookups
 django.contrib.postgres.fields.ranges.DateRangeField.form_field
 django.contrib.postgres.fields.ranges.DateTimeRangeField.__get__
 django.contrib.postgres.fields.ranges.DateTimeRangeField.base_field
-django.contrib.postgres.fields.ranges.DateTimeRangeField.class_lookups
 django.contrib.postgres.fields.ranges.DateTimeRangeField.form_field
 django.contrib.postgres.fields.ranges.DecimalRangeField.__get__
 django.contrib.postgres.fields.ranges.DecimalRangeField.base_field
@@ -646,7 +626,6 @@ django.contrib.postgres.fields.ranges.IntegerRangeField.__get__
 django.contrib.postgres.fields.ranges.IntegerRangeField.base_field
 django.contrib.postgres.fields.ranges.IntegerRangeField.form_field
 django.contrib.postgres.fields.ranges.RangeContainedBy.process_lhs
-django.contrib.postgres.fields.ranges.RangeField.class_lookups
 django.contrib.postgres.fields.ranges.RangeField.formfield
 django.contrib.postgres.fields.ranges.RangeField.get_placeholder
 django.contrib.postgres.forms.BaseRangeField.hidden_widget
@@ -661,7 +640,6 @@ django.contrib.postgres.search.SearchQuery.as_sql
 django.contrib.postgres.search.SearchVector.as_sql
 django.contrib.postgres.search.SearchVectorExact.as_sql
 django.contrib.postgres.search.SearchVectorExact.process_rhs
-django.contrib.postgres.search.SearchVectorField.class_lookups
 django.contrib.postgres.signals.get_type_oids
 django.contrib.redirects.admin.RedirectAdmin
 django.contrib.redirects.models.Redirect.id
@@ -876,12 +854,9 @@ django.db.models.CheckConstraint.validate
 django.db.models.Count.__init__
 django.db.models.Count.empty_result_set_value
 django.db.models.DEFERRED
-django.db.models.DateField.class_lookups
 django.db.models.DateField.contribute_to_class
 django.db.models.DateField.formfield
-django.db.models.DateTimeField.class_lookups
 django.db.models.DateTimeField.formfield
-django.db.models.DecimalField.class_lookups
 django.db.models.DecimalField.context
 django.db.models.DecimalField.formfield
 django.db.models.DurationField.formfield
@@ -900,7 +875,6 @@ django.db.models.Field.__le__
 django.db.models.Field.__lt__
 django.db.models.Field.__set__
 django.db.models.Field.cast_db_type
-django.db.models.Field.class_lookups
 django.db.models.Field.clone
 django.db.models.Field.db_returning
 django.db.models.Field.db_tablespace
@@ -921,7 +895,6 @@ django.db.models.FileField.contribute_to_class
 django.db.models.FileField.descriptor_class
 django.db.models.FileField.formfield
 django.db.models.FilePathField.formfield
-django.db.models.FloatField.class_lookups
 django.db.models.FloatField.formfield
 django.db.models.ForeignKey.__class_getitem__
 django.db.models.ForeignKey.contribute_to_related_class
@@ -931,7 +904,6 @@ django.db.models.ForeignKey.formfield
 django.db.models.ForeignKey.get_db_converters
 django.db.models.ForeignObject.__copy__
 django.db.models.ForeignObject.__get__
-django.db.models.ForeignObject.class_lookups
 django.db.models.ForeignObject.contribute_to_related_class
 django.db.models.ForeignObject.forward_related_accessor_class
 django.db.models.ForeignObject.get_class_lookups
@@ -962,9 +934,7 @@ django.db.models.ImageField.attr_class
 django.db.models.ImageField.contribute_to_class
 django.db.models.ImageField.descriptor_class
 django.db.models.ImageField.formfield
-django.db.models.IntegerField.class_lookups
 django.db.models.IntegerField.formfield
-django.db.models.JSONField.class_lookups
 django.db.models.JSONField.formfield
 django.db.models.JSONField.get_transform
 django.db.models.Lookup.get_prep_lhs
@@ -1021,10 +991,8 @@ django.db.models.Subquery.external_aliases
 django.db.models.Subquery.get_external_cols
 django.db.models.Subquery.subquery
 django.db.models.TextField.formfield
-django.db.models.TimeField.class_lookups
 django.db.models.TimeField.formfield
 django.db.models.URLField.formfield
-django.db.models.UUIDField.class_lookups
 django.db.models.UUIDField.formfield
 django.db.models.UniqueConstraint.contains_expressions
 django.db.models.UniqueConstraint.validate
@@ -1107,13 +1075,10 @@ django.db.models.fields.BooleanField.formfield
 django.db.models.fields.CharField.cast_db_type
 django.db.models.fields.CharField.description
 django.db.models.fields.CharField.formfield
-django.db.models.fields.DateField.class_lookups
 django.db.models.fields.DateField.contribute_to_class
 django.db.models.fields.DateField.formfield
 django.db.models.fields.DateTimeCheckMixin.check
-django.db.models.fields.DateTimeField.class_lookups
 django.db.models.fields.DateTimeField.formfield
-django.db.models.fields.DecimalField.class_lookups
 django.db.models.fields.DecimalField.context
 django.db.models.fields.DecimalField.formfield
 django.db.models.fields.DurationField.formfield
@@ -1128,7 +1093,6 @@ django.db.models.fields.Field.__le__
 django.db.models.fields.Field.__lt__
 django.db.models.fields.Field.__set__
 django.db.models.fields.Field.cast_db_type
-django.db.models.fields.Field.class_lookups
 django.db.models.fields.Field.clone
 django.db.models.fields.Field.db_returning
 django.db.models.fields.Field.db_tablespace
@@ -1144,10 +1108,8 @@ django.db.models.fields.Field.select_format
 django.db.models.fields.Field.unique
 django.db.models.fields.FieldDoesNotExist
 django.db.models.fields.FilePathField.formfield
-django.db.models.fields.FloatField.class_lookups
 django.db.models.fields.FloatField.formfield
 django.db.models.fields.GenericIPAddressField.formfield
-django.db.models.fields.IntegerField.class_lookups
 django.db.models.fields.IntegerField.formfield
 django.db.models.fields.PositiveBigIntegerField.formfield
 django.db.models.fields.PositiveBigIntegerField.integer_field_class
@@ -1158,10 +1120,8 @@ django.db.models.fields.PositiveSmallIntegerField.integer_field_class
 django.db.models.fields.SlugField.formfield
 django.db.models.fields.SmallAutoField.rel_db_type
 django.db.models.fields.TextField.formfield
-django.db.models.fields.TimeField.class_lookups
 django.db.models.fields.TimeField.formfield
 django.db.models.fields.URLField.formfield
-django.db.models.fields.UUIDField.class_lookups
 django.db.models.fields.UUIDField.formfield
 django.db.models.fields.files.FileField.__get__
 django.db.models.fields.files.FileField.attr_class
@@ -1178,7 +1138,6 @@ django.db.models.fields.json.CaseInsensitiveMixin.process_rhs
 django.db.models.fields.json.HasKeyLookup.as_mysql
 django.db.models.fields.json.HasKeyLookup.as_sql
 django.db.models.fields.json.HasKeyLookup.as_sqlite
-django.db.models.fields.json.JSONField.class_lookups
 django.db.models.fields.json.JSONField.formfield
 django.db.models.fields.json.JSONField.get_transform
 django.db.models.fields.json.KeyTextTransform.as_mysql
@@ -1186,7 +1145,6 @@ django.db.models.fields.json.KeyTransform.as_mysql
 django.db.models.fields.json.KeyTransform.as_oracle
 django.db.models.fields.json.KeyTransform.as_postgresql
 django.db.models.fields.json.KeyTransform.as_sqlite
-django.db.models.fields.json.KeyTransform.class_lookups
 django.db.models.fields.json.KeyTransformIsNull.as_sqlite
 django.db.models.fields.json.KeyTransformNumericLookupMixin.process_rhs
 django.db.models.fields.related.ForeignKey.__class_getitem__
@@ -1197,7 +1155,6 @@ django.db.models.fields.related.ForeignKey.formfield
 django.db.models.fields.related.ForeignKey.get_db_converters
 django.db.models.fields.related.ForeignObject.__copy__
 django.db.models.fields.related.ForeignObject.__get__
-django.db.models.fields.related.ForeignObject.class_lookups
 django.db.models.fields.related.ForeignObject.contribute_to_related_class
 django.db.models.fields.related.ForeignObject.forward_related_accessor_class
 django.db.models.fields.related.ForeignObject.get_class_lookups
@@ -1272,8 +1229,6 @@ django.db.models.functions.Cot.as_oracle
 django.db.models.functions.Degrees.as_oracle
 django.db.models.functions.Extract.as_sql
 django.db.models.functions.Extract.lookup_name
-django.db.models.functions.ExtractIsoYear.class_lookups
-django.db.models.functions.ExtractYear.class_lookups
 django.db.models.functions.JSONObject.as_oracle
 django.db.models.functions.JSONObject.as_postgresql
 django.db.models.functions.JSONObject.as_sql
@@ -1301,8 +1256,6 @@ django.db.models.functions.comparison.JSONObject.as_sql
 django.db.models.functions.comparison.NullIf.as_oracle
 django.db.models.functions.datetime.Extract.as_sql
 django.db.models.functions.datetime.Extract.lookup_name
-django.db.models.functions.datetime.ExtractIsoYear.class_lookups
-django.db.models.functions.datetime.ExtractYear.class_lookups
 django.db.models.functions.datetime.Now.as_mysql
 django.db.models.functions.datetime.Now.as_postgresql
 django.db.models.functions.datetime.Trunc.__init__


### PR DESCRIPTION
The existing annotation (`list[dict[Any, Any]]`) is incorrect, leading to errors in any code that actually uses this attribute.

The proper type is evident from the code in Django that registers class lookups[^1]:

    def register_class_lookup(cls, lookup, lookup_name=None):
        if lookup_name is None:
            lookup_name = lookup.lookup_name
        if "class_lookups" not in cls.__dict__:
            cls.class_lookups = {}
        cls.class_lookups[lookup_name] = lookup
        cls._clear_cached_class_lookups()
        return lookup

Now that this is a proper type, the appropriate entries are also removed
from allowlist_todo.txt.

[^1]: https://github.com/django/django/blob/50e95ad5367a4a93f94a66a645f9c126f0609f0a/django/db/models/query_utils.py#L296
