### PR TITLE
Update mypy, add a bit more metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
-| (next release) | 1.8.x        | 5.0            | 4.2, 4.1               | 3.8 - 3.12     |
+| (next release) | 1.9.x        | 5.0            | 4.2, 4.1               | 3.8 - 3.12     |
 | 4.2.7          | 1.7.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.6          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |
 | 4.2.5          | 1.6.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |

--- a/django-stubs/core/mail/message.pyi
+++ b/django-stubs/core/mail/message.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from email import charset as Charset
+from email.header import Header
 from email._policybase import Policy
 from email.message import Message
 from email.mime.base import MIMEBase
@@ -27,30 +28,13 @@ class MIMEMixin:
     def as_string(self, unixfrom: bool = ..., linesep: str = ...) -> str: ...
     def as_bytes(self, unixfrom: bool = ..., linesep: str = ...) -> bytes: ...
 
-class SafeMIMEMessage(MIMEMixin, MIMEMessage):  # type: ignore[misc]
-    defects: list[Any]
-    epilogue: Any
-    policy: Policy
-    preamble: Any
-    def __setitem__(self, name: str, val: str) -> None: ...
+class SafeMIMEMessage(MIMEMixin, MIMEMessage): ...  # type: ignore[misc]
 
 class SafeMIMEText(MIMEMixin, MIMEText):  # type: ignore[misc]
-    defects: list[Any]
-    epilogue: None
-    policy: Policy
-    preamble: None
     encoding: str
     def __init__(self, _text: str, _subtype: str = ..., _charset: str = ...) -> None: ...
-    def __setitem__(self, name: str, val: str) -> None: ...
-    def set_payload(
-        self, payload: list[Message] | str | bytes, charset: str | Charset.Charset | None = ...
-    ) -> None: ...
 
 class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):  # type: ignore[misc]
-    defects: list[Any]
-    epilogue: None
-    policy: Policy
-    preamble: None
     encoding: str
     def __init__(
         self,
@@ -60,7 +44,6 @@ class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):  # type: ignore[misc]
         encoding: str = ...,
         **_params: Any,
     ) -> None: ...
-    def __setitem__(self, name: str, val: str) -> None: ...
 
 _AttachmentContent: TypeAlias = bytes | EmailMessage | Message | SafeMIMEText | str
 _AttachmentTuple: TypeAlias = (

--- a/django-stubs/core/mail/message.pyi
+++ b/django-stubs/core/mail/message.pyi
@@ -1,7 +1,4 @@
 from collections.abc import Sequence
-from email import charset as Charset
-from email.header import Header
-from email._policybase import Policy
 from email.message import Message
 from email.mime.base import MIMEBase
 from email.mime.message import MIMEMessage

--- a/ext/setup.py
+++ b/ext/setup.py
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Typing :: Typed",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",

--- a/ext/setup.py
+++ b/ext/setup.py
@@ -23,7 +23,6 @@ setup(
     license_files=["LICENSE.md"],
     url="https://github.com/typeddjango/django-stubs",
     author="Simula Proxy",
-    author_email="3nki.nam.shub@gmail.com",
     maintainer="Marti Raudsepp",
     maintainer_email="marti@juffo.org",
     py_modules=[],
@@ -47,6 +46,7 @@ setup(
         "Framework :: Django :: 5.0",
     ],
     project_urls={
+        "Funding": "https://github.com/sponsors/typeddjango",
         "Release notes": "https://github.com/typeddjango/django-stubs/releases",
     },
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ Django==5.0.3; python_version >= '3.10'
 -e .[compatible-mypy]
 
 # Overrides:
-mypy==1.8.0
+mypy==1.9.0

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -420,7 +420,6 @@ django.contrib.gis.db.models.PositiveIntegerField.integer_field_class
 django.contrib.gis.db.models.PositiveSmallIntegerField.formfield
 django.contrib.gis.db.models.PositiveSmallIntegerField.integer_field_class
 django.contrib.gis.db.models.Q.XOR
-django.contrib.gis.db.models.Q.__init__
 django.contrib.gis.db.models.Q.check
 django.contrib.gis.db.models.Q.flatten
 django.contrib.gis.db.models.Q.resolve_expression
@@ -970,7 +969,6 @@ django.db.models.PositiveIntegerField.integer_field_class
 django.db.models.PositiveSmallIntegerField.formfield
 django.db.models.PositiveSmallIntegerField.integer_field_class
 django.db.models.Q.XOR
-django.db.models.Q.__init__
 django.db.models.Q.check
 django.db.models.Q.flatten
 django.db.models.Q.resolve_expression
@@ -1364,7 +1362,6 @@ django.db.models.query.prefetch_one_level
 django.db.models.query_utils.DeferredAttribute.__get__
 django.db.models.query_utils.InvalidQuery
 django.db.models.query_utils.Q.XOR
-django.db.models.query_utils.Q.__init__
 django.db.models.query_utils.Q.check
 django.db.models.query_utils.Q.flatten
 django.db.models.query_utils.Q.resolve_expression
@@ -1673,3 +1670,8 @@ django.urls.path
 django.urls.re_path
 django.urls.resolvers.LocaleRegexDescriptor.__get__
 django.urls.resolvers.ResolverMatch.__iter__
+
+# mypy 1.9.0 new issues:
+django.db.models.expressions.rhs
+django.db.models.expressions.result
+django.db.models.expressions.lhs

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1675,3 +1675,4 @@ django.urls.resolvers.ResolverMatch.__iter__
 django.db.models.expressions.rhs
 django.db.models.expressions.result
 django.db.models.expressions.lhs
+django.db.backends.postgresql.base.Cursor

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
 
 # Keep compatible-mypy major.minor version pinned to what we use in CI (requirements.txt)
 extras_require = {
-    "compatible-mypy": ["mypy~=1.8.0"],
+    "compatible-mypy": ["mypy~=1.9.0"],
 }
 
 setup(
@@ -66,12 +66,12 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Typing :: Typed",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
     ],
     project_urls={
+        "Funding": "https://github.com/sponsors/typeddjango",
         "Release notes": "https://github.com/typeddjango/django-stubs/releases",
     },
 )


### PR DESCRIPTION
We don't need to duplicate most of the types of the message objects: 
- https://github.com/python/typeshed/blob/3802899a01269df575ea32a21534c5400fb9218a/stdlib/email/message.pyi#L28
- https://github.com/django/django/blob/894fa55da1ff05229391da6a2b3dfc2bb2876eb0/django/core/mail/message.py#L153

Closes https://github.com/typeddjango/django-stubs/pull/1995

I've noticed that Simula's profile was deleted: https://github.com/typeddjango/django-stubs/pull/526

So, I removed `author_email`, because I cannot verify that it is still correct.