### PR TITLE
Specify d.c.serializers.base.DeserializedObject.object type

### DIFF
--- a/django-stubs/core/serializers/base.pyi
+++ b/django-stubs/core/serializers/base.pyi
@@ -75,7 +75,7 @@ class Deserializer:
     def __next__(self) -> Any: ...
 
 class DeserializedObject:
-    object: Any
+    object: Model
     m2m_data: dict[str, Sequence[Any]] | None
     deferred_fields: dict[Field, Any]
     def __init__(


### PR DESCRIPTION
# I have made things!

A DeserializedObject has a [required positional argument](https://github.com/django/django/blob/stable/5.0.x/django/core/serializers/base.py#L250) for a Model object which immediately goes to initialize the `object` attribute. As the argument has a type of `Model`, so too should the instance attribute (instead of `Any`).

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
