### PR TITLE
feat: Allow setting django_settings_module from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ django_settings_module = "myproject.settings"
 Two things happening here:
 
 1. We need to explicitly list our plugin to be loaded by `mypy`
-2. Our plugin also requires `django` settings module (what you put into `DJANGO_SETTINGS_MODULE` variable) to be specified
+2. You can either specify `django_settings_module` as seen above, or let `django_stubs` use the `DJANGO_SETTINGS_MODULE` variable from your environment.
 
 This fully working [typed boilerplate](https://github.com/wemake-services/wemake-django-template) can serve you as an example.
 
@@ -96,7 +96,7 @@ django-stubs has a few settings, which you can list in:
 
 The supported settings are:
 
-- `django_settings_module`, a string.
+- `django_settings_module`, a string, default to `os.getenv(DJANGO_SETTINGS_MODULE)`.
 
   Specify the import path of your settings module, the same as Django’s [`DJANGO_SETTINGS_MODULE` environment variable](https://docs.djangoproject.com/en/stable/topics/settings/#designating-the-settings).
 

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -83,9 +83,11 @@ class DjangoPluginConfig:
         except KeyError:
             toml_exit(MISSING_SECTION.format(section="tool.django-stubs"))
 
-        self.django_settings_module = config.get("django_settings_module") or os.getenv(DJANGO_SETTINGS_ENV_VAR)
-        if not self.django_settings_module:
+        django_settings_module = config.get("django_settings_module") or os.getenv(DJANGO_SETTINGS_ENV_VAR)
+        if not django_settings_module:
             toml_exit(MISSING_DJANGO_SETTINGS)
+
+        self.django_settings_module = django_settings_module
 
         if not isinstance(self.django_settings_module, str):
             toml_exit("invalid 'django_settings_module': the setting must be a string")
@@ -107,11 +109,14 @@ class DjangoPluginConfig:
             exit_with_error(MISSING_SECTION.format(section=section))
 
         if parser.has_option(section, "django_settings_module"):
-            self.django_settings_module = parser.get(section, "django_settings_module").strip("'\"")
+            django_settings_module = parser.get(section, "django_settings_module").strip("'\"")
         else:
-            self.django_settings_module = os.getenv(DJANGO_SETTINGS_ENV_VAR)
-            if not self.django_settings_module:
-                exit_with_error(MISSING_DJANGO_SETTINGS)
+            django_settings_module = os.getenv(DJANGO_SETTINGS_ENV_VAR, "")
+
+        if not django_settings_module:
+            exit_with_error(MISSING_DJANGO_SETTINGS)
+
+        self.django_settings_module = django_settings_module
 
         try:
             self.strict_settings = parser.getboolean(section, "strict_settings", fallback=True)

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -15,7 +15,7 @@ INI_USAGE = """
 (config)
 ...
 [mypy.plugins.django-stubs]
-django_settings_module = str (required)
+django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
 strict_settings = bool (default: true)
 ...
 """
@@ -23,16 +23,17 @@ TOML_USAGE = """
 (config)
 ...
 [tool.django-stubs]
-django_settings_module = str (required)
+django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
 strict_settings = bool (default: true)
 ...
 """
 INVALID_FILE = "mypy config file is not specified or found"
 COULD_NOT_LOAD_FILE = "could not load configuration file"
 MISSING_SECTION = "no section [{section}] found"
-MISSING_DJANGO_SETTINGS = "missing required 'django_settings_module' config"
-INVALID_BOOL_SETTING = "invalid {key!r}: the setting must be a boolean"
 DJANGO_SETTINGS_ENV_VAR = "DJANGO_SETTINGS_MODULE"
+MISSING_DJANGO_SETTINGS = f"missing required 'django_settings_module' config.\
+ Either specify this config or set your `{DJANGO_SETTINGS_ENV_VAR}` env var"
+INVALID_BOOL_SETTING = "invalid {key!r}: the setting must be a boolean"
 
 
 def exit_with_error(msg: str, is_toml: bool = False) -> NoReturn:

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -15,7 +15,7 @@ INI_USAGE = """
 (config)
 ...
 [mypy.plugins.django-stubs]
-django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
+django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 ...
 """
@@ -23,7 +23,7 @@ TOML_USAGE = """
 (config)
 ...
 [tool.django-stubs]
-django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
+django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 ...
 """

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -13,7 +13,7 @@ TEMPLATE = """
 (config)
 ...
 [mypy.plugins.django-stubs]
-django_settings_module = str (required)
+django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
 strict_settings = bool (default: true)
 ...
 (django-stubs) mypy: error: {}
@@ -23,7 +23,7 @@ TEMPLATE_TOML = """
 (config)
 ...
 [tool.django-stubs]
-django_settings_module = str (required)
+django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
 strict_settings = bool (default: true)
 ...
 (django-stubs) mypy: error: {}
@@ -48,12 +48,14 @@ def write_to_file(file_contents: str, suffix: Optional[str] = None) -> Generator
         ),
         pytest.param(
             ["[mypy.plugins.django-stubs]", "\tnot_django_not_settings_module = badbadmodule"],
-            "missing required 'django_settings_module' config",
+            "missing required 'django_settings_module' config.\
+ Either specify this config or set your `DJANGO_SETTINGS_MODULE` env var",
             id="missing-settings-module",
         ),
         pytest.param(
             ["[mypy.plugins.django-stubs]"],
-            "missing required 'django_settings_module' config",
+            "missing required 'django_settings_module' config.\
+ Either specify this config or set your `DJANGO_SETTINGS_MODULE` env var",
             id="no-settings-given",
         ),
         pytest.param(
@@ -114,7 +116,8 @@ def test_handles_filename(capsys: Any, filename: str) -> None:
             [tool.django-stubs]
             not_django_not_settings_module = "badbadmodule"
             """,
-            "missing required 'django_settings_module' config",
+            "missing required 'django_settings_module' config.\
+ Either specify this config or set your `DJANGO_SETTINGS_MODULE` env var",
             id="missing django_settings_module",
         ),
         pytest.param(
@@ -194,13 +197,12 @@ def test_correct_toml_configuration_with_django_setting_from_env(boolean_value: 
 
 
 @pytest.mark.parametrize("boolean_value", ["true", "True", "false", "False"])
-def test_correct_configuration(boolean_value) -> None:
+def test_correct_configuration_with_django_setting_from_env(boolean_value) -> None:
     """Django settings module gets extracted given valid configuration."""
     config_file_contents = "\n".join(
         [
             "[mypy.plugins.django-stubs]",
             "some_other_setting = setting",
-            "django_settings_module = my.module",
             f"strict_settings = {boolean_value}",
         ]
     )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -13,7 +13,7 @@ TEMPLATE = """
 (config)
 ...
 [mypy.plugins.django-stubs]
-django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
+django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 ...
 (django-stubs) mypy: error: {}
@@ -23,7 +23,7 @@ TEMPLATE_TOML = """
 (config)
 ...
 [tool.django-stubs]
-django_settings_module = str (default: DJANGO_SETTINGS_MODULE env var)
+django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 ...
 (django-stubs) mypy: error: {}


### PR DESCRIPTION
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
## What changed
* `django_settings_module` is now not required as part of the config
* When not given, `django_settings_module` will be populated from `DJANGO_SETTINGS_MODULE` env variable
* Error messages now mention setting either of these values
* Tests added to see correct population of the config

## Why
* Some projects use `DJANGO_SETTINGS_MODULE` to deploy multiple variants of an app, this will allow the config to be dynamic to accommodate
* `DJANGO_SETTINGS_MODULE` acts as the single source of truth when it comes to the project, so allowing population from that variable will reduce duplication.

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
- Closes #2018 
- An updated version of #153 

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
