### PR TITLE
Do not annotate PRs with pyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
         uses: jakebailey/pyright-action@v2
         with:
           pylance-version: latest-release
+          annotate: false
         continue-on-error: true  # TODO: remove this part
 
   matrix-test:


### PR DESCRIPTION
Looking at https://github.com/typeddjango/django-stubs/pull/2022/files I've noticed that pyright annotates our code, which is not good. Disabled.
