### PR TITLE
Use `PRI_MYPY` in `get_additional_deps` hook

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -3,6 +3,7 @@ import sys
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
+from mypy.build import PRI_MYPY
 from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
 from mypy.options import Options
@@ -99,7 +100,8 @@ class NewSemanalDjangoPlugin(Plugin):
         return None
 
     def _new_dependency(self, module: str) -> Tuple[int, str, int]:
-        return 10, module, -1
+        fake_lineno = -1
+        return (PRI_MYPY, module, fake_lineno)
 
     def get_additional_deps(self, file: MypyFile) -> List[Tuple[int, str, int]]:
         # for settings


### PR DESCRIPTION
This value comes from here: https://github.com/python/mypy/blob/394d17b758bae6c95cbe91b84c5cccf0f4d73c28/mypy/build.py#L382

It is more correct than `PRI_MED` that we used, because it is a typing-only import.
