### PR TITLE
Set the calculated metaclass when creating type info in the plugin

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -265,7 +265,7 @@ def create_type_info(name: str, module: str, bases: List[Instance]) -> TypeInfo:
     new_typeinfo = TypeInfo(SymbolTable(), classdef, module)
     new_typeinfo.bases = bases
     calculate_mro(new_typeinfo)
-    new_typeinfo.calculate_metaclass_type()
+    new_typeinfo.metaclass_type = new_typeinfo.calculate_metaclass_type()
 
     classdef.info = new_typeinfo
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -760,12 +760,14 @@ class ProcessManyToManyFields(ModelClassInitializer):
                     through_model,
                     name="objects",
                     sym_type=Instance(manager_info, [Instance(through_model, [])]),
+                    is_classvar=True,
                 )
                 # Also add manager as '_default_manager' attribute
                 helpers.add_new_sym_for_info(
                     through_model,
                     name="_default_manager",
                     sym_type=Instance(manager_info, [Instance(through_model, [])]),
+                    is_classvar=True,
                 )
 
     @cached_property

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1111,6 +1111,9 @@
         reveal_type(Other().autos.custom_qs_method())
         reveal_type(Other().customs.custom_qs_method())
         reveal_type(Other().autos.add)
+
+        reveal_type(Other.autos.through.objects)
+        reveal_type(Other.autos.through._default_manager)
     out: |
         main:2: note: Revealed type is "myapp.models.MyModel_auto_through"
         main:3: note: Revealed type is "myapp.models.Other"
@@ -1135,6 +1138,8 @@
         main:28: note: Revealed type is "builtins.str"
         main:29: note: Revealed type is "builtins.str"
         main:30: note: Revealed type is "def (*objs: Union[myapp.models.MyModel, builtins.int], bulk: builtins.bool =, through_defaults: Union[builtins.dict[builtins.str, Any], None] =)"
+        main:32: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
+        main:33: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
     installed_apps:
         -   myapp
     files:


### PR DESCRIPTION
Simply calling `<TypeInfo>.calculate_metaclass_type()` doesn't modify any instance but rather returns the metaclass type.

Setting the metaclass revealed `objects` and `_default_manager` attributes not being `ClassVar` on plugin generated through models. Which is also fixed in this PR.