### PR TITLE
CI: Update Django 4.2 version used for test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-shard==0.1.2
 
 # Django deps:
 psycopg2-binary
-Django==4.2.7; python_version < '3.10'
+Django==4.2.11; python_version < '3.10'
 Django==5.0.4; python_version >= '3.10'
 -e ./ext
 -e .[redis,compatible-mypy]


### PR DESCRIPTION
# I have made things!

Django 4.2.7 was used when testing with Python versions 3.9 and 3.8. Updated to 4.2.11.

* Solves security advisory https://github.com/typeddjango/django-stubs/security/dependabot/6
  (though the vulnerability has 0 impact for us)
