### PR TITLE
Add `DeferredAttribute.__get__()`

### DIFF
--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -48,6 +48,7 @@ class Q(tree.Node):
 class DeferredAttribute:
     field: Field
     def __init__(self, field: Field) -> None: ...
+    def __get__(self, instance: Model | None, cls: type[Model] | None = None) -> Any: ...
 
 _R = TypeVar("_R", bound=type)
 

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1315,7 +1315,6 @@ django.db.models.query.RelatedPopulator
 django.db.models.query.get_related_populators
 django.db.models.query.normalize_prefetch_lookups
 django.db.models.query.prefetch_one_level
-django.db.models.query_utils.DeferredAttribute.__get__
 django.db.models.query_utils.InvalidQuery
 django.db.models.query_utils.Q.XOR
 django.db.models.query_utils.Q.resolve_expression


### PR DESCRIPTION
This PR adds the `DeferredAttribute.__get__()` method that was previously missing from the stubs.

I assumed that the `DeferredAttribute` descriptor will always be used on `Model` classes.

I left the returned data type as `Any`. In theory it should match the field's get type, but that doesn't seem worth the hassle: as the descriptor stubs are relevant for custom descriptors that inherit it, not for application code that accesses the fields, the data type is not that important.