### PR TITLE
5.0: Update `django.test.testcases`

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -35,7 +35,6 @@ class _AssertTemplateUsedContext:
     test_case: SimpleTestCase
     template_name: str
     rendered_templates: list[Template]
-    rendered_template_names: list[str]
     context: ContextList
     def __init__(self, test_case: Any, template_name: Any) -> None: ...
     def on_template_render(self, sender: Any, signal: Any, template: Any, context: Any, **kwargs: Any) -> None: ...
@@ -100,7 +99,6 @@ class SimpleTestCase(unittest.TestCase):
         msg_prefix: str = ...,
         html: bool = ...,
     ) -> None: ...
-    @overload
     def assertFormError(
         self,
         form: Form,
@@ -108,17 +106,7 @@ class SimpleTestCase(unittest.TestCase):
         errors: list[str] | str,
         msg_prefix: str = ...,
     ) -> None: ...
-    @overload
-    def assertFormError(  # old signature, deprecated in Django 4.1
-        self,
-        response: HttpResponseBase,
-        form: str,
-        field: str | None,
-        errors: list[str] | str,
-        msg_prefix: str = ...,
-    ) -> None: ...
     # assertFormsetError (lowercase "set") deprecated in Django 4.2
-    @overload
     def assertFormsetError(
         self,
         formset: BaseFormSet,
@@ -127,30 +115,9 @@ class SimpleTestCase(unittest.TestCase):
         errors: list[str] | str,
         msg_prefix: str = ...,
     ) -> None: ...
-    @overload
-    def assertFormsetError(  # old signature, deprecated in Django 4.1
-        self,
-        response: HttpResponseBase,
-        formset: str,
-        form_index: int | None,
-        field: str | None,
-        errors: list[str] | str,
-        msg_prefix: str = ...,
-    ) -> None: ...
-    @overload
     def assertFormSetError(
         self,
         formset: BaseFormSet,
-        form_index: int | None,
-        field: str | None,
-        errors: list[str] | str,
-        msg_prefix: str = ...,
-    ) -> None: ...
-    @overload
-    def assertFormSetError(
-        self,
-        response: HttpResponseBase,
-        formset: str,
         form_index: int | None,
         field: str | None,
         errors: list[str] | str,

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1566,8 +1566,6 @@ django.template.utils.EngineHandler.__init__
 django.templatetags.i18n.BlockTranslateNode.__init__
 django.templatetags.static.PrefixNode.__init__
 django.templatetags.static.StaticNode.__init__
-django.test.SimpleTestCase.assertFormError
-django.test.SimpleTestCase.assertFormSetError
 django.test.SimpleTestCase.assertTemplateNotUsed
 django.test.runner.DiscoverRunner.log
 django.test.runner.DiscoverRunner.reorder_by
@@ -1607,8 +1605,6 @@ django.test.selenium.SeleniumTestCaseBase.selenium_hub
 django.test.testcases.LiveServerThread.__init__
 django.test.testcases.LiveServerThread.server_class
 django.test.testcases.SerializeMixin.tearDownClass
-django.test.testcases.SimpleTestCase.assertFormError
-django.test.testcases.SimpleTestCase.assertFormSetError
 django.test.testcases.SimpleTestCase.assertTemplateNotUsed
 django.test.testcases._AssertTemplateUsedContext.__init__
 django.test.testcases._AssertTemplateUsedContext.message


### PR DESCRIPTION
# I have made things!

Update stubs for `django.test.testcases` for Django 5.0.

- [x] `django.test.testcases.SimpleTestCase.assertFormError`'s signature was changed (response and form/formset name)
- [x] `django.test.testcases.SimpleTestCase.assertFormSetError`'s signature was changed (response and form/formset name)
- [x] `django.test.testcases._AssertTemplateUsedContext.rendered_template_names` was removed

## Related issues

Refs #1493
