### PR TITLE
5.0: Update `django.http`

### DIFF
--- a/django-stubs/http/multipartparser.pyi
+++ b/django-stubs/http/multipartparser.pyi
@@ -10,6 +10,7 @@ class InputStreamExhausted(Exception): ...
 RAW: Literal["raw"]
 FILE: Literal["file"]
 FIELD: Literal["field"]
+FIELD_TYPES: frozenset[Literal["field", "raw"]]
 
 class MultiPartParser:
     def __init__(

--- a/django-stubs/http/multipartparser.pyi
+++ b/django-stubs/http/multipartparser.pyi
@@ -10,7 +10,7 @@ class InputStreamExhausted(Exception): ...
 RAW: Literal["raw"]
 FILE: Literal["file"]
 FIELD: Literal["field"]
-FIELD_TYPES: frozenset[Literal["field", "raw"]]
+FIELD_TYPES: frozenset[str]
 
 class MultiPartParser:
     def __init__(

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from re import Pattern
-from typing import Any, BinaryIO, Literal, NoReturn, TypeVar, overload, type_check_only
+from typing import Any, BinaryIO, Callable, Literal, NoReturn, TypeVar, overload, type_check_only
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
@@ -56,6 +56,8 @@ class HttpRequest(BytesIO):
     current_app: str
     # django.contrib.auth.middleware.AuthenticationMiddleware:
     user: AbstractBaseUser | AnonymousUser
+    # django.contrib.auth.middleware.AuthenticationMiddleware:
+    auser: Callable[[], AbstractBaseUser | AnonymousUser]
     # django.middleware.locale.LocaleMiddleware:
     LANGUAGE_CODE: str
     # django.contrib.sites.middleware.CurrentSiteMiddleware


### PR DESCRIPTION
# I have made things!

Update stubs for `django.http` for Django 5.0.

- [x] `django.http.multipartparser`
  - [x] `django.http.multipartparser.FIELD_TYPES` was added
- [x] `django.http.request`
  - [x] `django.http.request.HttpRequest.auser` was added

## Related issues

Refs #1493