### PR TITLE
5.0: Update `django.core.servers.basehttp`

### DIFF
--- a/django-stubs/core/servers/basehttp.pyi
+++ b/django-stubs/core/servers/basehttp.pyi
@@ -37,7 +37,7 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
 
 def run(
     addr: str,
-    port: str,
+    port: int,
     wsgi_handler: WSGIHandler,
     ipv6: bool = ...,
     threading: bool = ...,

--- a/django-stubs/core/servers/basehttp.pyi
+++ b/django-stubs/core/servers/basehttp.pyi
@@ -1,9 +1,12 @@
 import socketserver
 from io import BytesIO
-from typing import Any
+from typing import Any, Callable
 from wsgiref import simple_server
 
 from django.core.handlers.wsgi import WSGIHandler, WSGIRequest
+
+def get_internal_wsgi_application() -> WSGIHandler: ...
+def is_broken_pipe_error() -> bool: ...
 
 class WSGIServer(simple_server.WSGIServer):
     request_queue_size: int
@@ -32,4 +35,12 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
     request_version: str
     def handle(self) -> None: ...
 
-def get_internal_wsgi_application() -> WSGIHandler: ...
+def run(
+    addr: str,
+    port: str,
+    wsgi_handler: WSGIHandler,
+    ipv6: bool = ...,
+    threading: bool = ...,
+    on_bind: Callable[[str], None] | None = ...,
+    server_cls: type[WSGIServer] = ...,
+) -> None: ...

--- a/django-stubs/core/servers/basehttp.pyi
+++ b/django-stubs/core/servers/basehttp.pyi
@@ -36,7 +36,7 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
     def handle(self) -> None: ...
 
 def run(
-    addr: str,
+    addr: str | bytes | bytearray,
     port: int,
     wsgi_handler: WSGIHandler,
     ipv6: bool = ...,


### PR DESCRIPTION
# I have made things!

Update stubs for `django.core.servers.basehttp` for Django 5.0.

- [x] `django.core.servers.basehttp`
  - [x] `django.core.servers.basehttp.run`'s `on_bind` argument was added
  - [x] `django.core.servers.basehttp.is_broken_pipe_error` was missed

## Related issues

Refs #1493