### PR TITLE
Add a `returncode` attribute to `CommandError`

### DIFF
--- a/django-stubs/core/management/base.pyi
+++ b/django-stubs/core/management/base.pyi
@@ -10,6 +10,7 @@ from django.utils.datastructures import _ListOrTuple
 ALL_CHECKS: Literal["__all__"]
 
 class CommandError(Exception):
+    returncode: int
     def __init__(self, *args: Any, returncode: int = ..., **kwargs: Any) -> None: ...
 
 class SystemCheckError(CommandError): ...


### PR DESCRIPTION
Though I'm curious why `stubtest` didn't notice `returncode` was missing