### PR TITLE
Import `redis.connection.BaseParser` instead of from untyped module

### DIFF
--- a/django-stubs/core/cache/backends/redis.pyi
+++ b/django-stubs/core/cache/backends/redis.pyi
@@ -4,9 +4,8 @@ from typing import Any, Callable, Iterable, Protocol, SupportsInt, overload, typ
 
 from _typeshed import ReadableBuffer
 from django.core.cache.backends.base import BaseCache
-from redis._parsers import BaseParser
 from redis.client import Redis
-from redis.connection import ConnectionPool
+from redis.connection import BaseParser, ConnectionPool
 from typing_extensions import TypeAlias
 
 @type_check_only


### PR DESCRIPTION
I was getting errors when running `stubtest` locally:

```
➤ bash ./scripts/stubtest.sh
error: not checking stubs due to mypy build errors:
django-stubs/core/cache/backends/redis.pyi:7: error: Library stubs not installed for "redis._parsers"  [import-untyped]
django-stubs/core/cache/backends/redis.pyi:7: note: Hint: "python3 -m pip install types-redis"
django-stubs/core/cache/backends/redis.pyi:7: note: (or run "mypy --install-types" to install all missing stub packages)
django-stubs/core/cache/backends/redis.pyi:7: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

Not sure if it could be related to the new release of `types-redis` from ~12h ago: https://pypi.org/project/types-redis/4.6.0.20240417/

Though I'm finding the `DefaultParser` / `BaseParser` from `redis` declared at:
- https://github.com/python/typeshed/blob/6e16a4ce23235d5ba8ebd2adcd32f7d62f509dbe/stubs/redis/redis/connection.pyi#L73
- https://github.com/python/typeshed/blob/6e16a4ce23235d5ba8ebd2adcd32f7d62f509dbe/stubs/redis/redis/connection.pyi#L32-L35

And I think that aligns with Django's runtime usage, found here:

- https://github.com/django/django/blob/476d7c581ac97dae2bc14ee79a1294db4f802e74/django/core/cache/backends/redis.py#L59