### PR TITLE
Update pyright report options (`reportMissingTypeArgument`, `reportPrivateUsage`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ exclude = [
     ".mypy_cache",
     "build",
 ]
+reportMissingTypeArgument = "warning"
+reportPrivateUsage = "none"
 stubPath = "."
 typeCheckingMode = "strict"
 


### PR DESCRIPTION
# I have made things!

I'm using pyright and pylance in VSCode, and I've found that the below error occurs most often.

If we do not plan to make any special improvements on this, I suggest changing the options as shown below.

- Changed `reportMissingTypeArgument` from `error` to `warning`, since this projects is already using many generics without type arguments.
- Turned off `reportPrivateUsage`, since this project is already using a lot of private type imports.

```toml
[tool.pyright]
reportMissingTypeArgument = "warning"
reportPrivateUsage = "none"
```

| before | after |
| ------ | ----- |
| ![CleanShot 2024-04-20 at 16 20 55@2x](https://github.com/typeddjango/django-stubs/assets/32478597/461bfa0a-8be3-4382-b064-9ee587ed2c53) | ![CleanShot 2024-04-20 at 16 20 33@2x](https://github.com/typeddjango/django-stubs/assets/32478597/2e87b7b5-5461-4eeb-84f1-3b5944f61694) |
