### PR TITLE
5.0: Update `django.contrib.admin.views` and `django.forms.forms.Form` metaclass

### DIFF
--- a/django-stubs/contrib/admin/views/main.pyi
+++ b/django-stubs/contrib/admin/views/main.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Literal
 
+from django import forms
 from django.contrib.admin.filters import ListFilter
 from django.contrib.admin.options import ModelAdmin, _DisplayT, _ListFilterT
 from django.db.models.base import Model
@@ -17,7 +18,10 @@ SEARCH_VAR: str
 ERROR_FLAG: str
 IGNORED_PARAMS: tuple[str, ...]
 
+class ChangeListSearchForm(forms.Form): ...
+
 class ChangeList:
+    search_form_class: type[forms.Form]
     model: type[Model]
     opts: Options
     lookup_opts: Options
@@ -37,8 +41,13 @@ class ChangeList:
     page_num: int
     show_all: bool
     is_popup: bool
+    add_facets: bool
+    is_facets_optional: bool
     to_field: Any
     params: dict[str, Any]
+    filter_params: dict[str, Any]
+    remove_facet_link: str
+    add_facet_link: str
     list_editable: Sequence[str]
     query: str
     queryset: Any

--- a/django-stubs/contrib/admin/views/main.pyi
+++ b/django-stubs/contrib/admin/views/main.pyi
@@ -45,7 +45,7 @@ class ChangeList:
     is_facets_optional: bool
     to_field: Any
     params: dict[str, Any]
-    filter_params: dict[str, Any]
+    filter_params: dict[str, list[str]]
     remove_facet_link: str
     add_facet_link: str
     list_editable: Sequence[str]

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -80,6 +80,6 @@ class BaseForm(RenderableFormMixin):
         errors_on_separate_row: bool,
     ) -> SafeString: ...
 
-class Form(BaseForm):
+class Form(BaseForm, metaclass=DeclarativeFieldsMetaclass):
     base_fields: ClassVar[dict[str, Field]]
     declared_fields: ClassVar[dict[str, Field]]

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -21,9 +21,6 @@ django.contrib.admin.decorators.action
 django.contrib.admin.decorators.display
 django.contrib.admin.display
 django.contrib.admin.filters.FieldListFilter.title
-django.contrib.admin.forms.AdminAuthenticationForm
-django.contrib.admin.forms.AdminPasswordChangeForm
-django.contrib.admin.helpers.ActionForm
 django.contrib.admin.helpers.AdminForm.fields
 django.contrib.admin.helpers.AdminForm.is_bound
 django.contrib.admin.helpers.AdminReadonlyField.get_admin_url
@@ -68,7 +65,6 @@ django.contrib.admin.views.autocomplete.AutocompleteJsonView.admin_site
 django.contrib.admin.views.autocomplete.AutocompleteJsonView.process_request
 django.contrib.admin.views.autocomplete.AutocompleteJsonView.serialize_result
 django.contrib.admin.views.main.ChangeList.search_form_class
-django.contrib.admin.views.main.ChangeListSearchForm
 django.contrib.admin.widgets.AutocompleteMixin.media
 django.contrib.admin.widgets.BaseAdminDateWidget
 django.contrib.admin.widgets.BaseAdminTimeWidget
@@ -89,12 +85,7 @@ django.contrib.auth.base_user.AbstractBaseUser.get_session_auth_fallback_hash
 django.contrib.auth.base_user.AbstractBaseUser.last_login
 django.contrib.auth.base_user.AbstractBaseUser.password
 django.contrib.auth.decorators.login_required
-django.contrib.auth.forms.AdminPasswordChangeForm
-django.contrib.auth.forms.AuthenticationForm
 django.contrib.auth.forms.BaseUserCreationForm.declared_fields
-django.contrib.auth.forms.PasswordChangeForm
-django.contrib.auth.forms.PasswordResetForm
-django.contrib.auth.forms.SetPasswordForm
 django.contrib.auth.forms.UserChangeForm.declared_fields
 django.contrib.auth.forms.UserCreationForm.declared_fields
 django.contrib.auth.forms.UserModel
@@ -442,7 +433,6 @@ django.contrib.gis.forms.Field.__deepcopy__
 django.contrib.gis.forms.Field.hidden_widget
 django.contrib.gis.forms.FileField.bound_data
 django.contrib.gis.forms.FileInput.allow_multiple_selected
-django.contrib.gis.forms.Form
 django.contrib.gis.forms.HiddenInput.__slotnames__
 django.contrib.gis.forms.InlineForeignKeyField
 django.contrib.gis.forms.Input
@@ -1342,7 +1332,6 @@ django.forms.Field.__deepcopy__
 django.forms.Field.hidden_widget
 django.forms.FileField.bound_data
 django.forms.FileInput.allow_multiple_selected
-django.forms.Form
 django.forms.HiddenInput.__slotnames__
 django.forms.InlineForeignKeyField
 django.forms.Input
@@ -1375,12 +1364,10 @@ django.forms.fields.MultipleChoiceField.hidden_widget
 django.forms.fields.SplitDateTimeField.hidden_widget
 django.forms.forms.BaseForm.__init__
 django.forms.forms.DeclarativeFieldsMetaclass.__new__
-django.forms.forms.Form
 django.forms.formset_factory
 django.forms.formsets.BaseFormSet.__init__
 django.forms.formsets.BaseFormSet.deletion_widget
 django.forms.formsets.BaseFormSet.ordering_widget
-django.forms.formsets.ManagementForm
 django.forms.formsets.ManagementForm.__init__
 django.forms.formsets.formset_factory
 django.forms.inlineformset_factory


### PR DESCRIPTION
# I have made things!

Update stubs for `django.contrib.admin.views.main` for Django 5.0.

- [x] `django.contrib.admin.views.main`
  - [x] `django.contrib.admin.views.main.ChangeList.add_facets` was added
  - [x] `django.contrib.admin.views.main.ChangeList.is_facets_optional` was added
  - [x] `django.contrib.admin.views.main.ChangeList.filter_params` was added
  - [x] `django.contrib.admin.views.main.ChangeList.remove_facet_link` was added
  - [x] `django.contrib.admin.views.main.ChangeList.add_facet_link` was added

Missing type stubs were added.

- [x] `django.contrib.admin.views.main`
  - [x] `django.contrib.admin.views.main.ChangeListSearchForm`
  - [x] `django.contrib.admin.views.main.ChangeList.search_form_class`

## Related issues

Refs #1493