### PR TITLE
5.0.5: Enable import `aprefetch_related_objects` from `django.db.models`

### DIFF
--- a/django-stubs/db/models/__init__.pyi
+++ b/django-stubs/db/models/__init__.pyi
@@ -91,6 +91,7 @@ from .lookups import Transform as Transform
 from .manager import Manager as Manager
 from .query import Prefetch as Prefetch
 from .query import QuerySet as QuerySet
+from .query import aprefetch_related_objects as aprefetch_related_objects
 from .query import prefetch_related_objects as prefetch_related_objects
 from .query_utils import FilteredRelation as FilteredRelation
 from .query_utils import Q as Q


### PR DESCRIPTION
# I have made things!

Captures `aprefetch_related_objects` import fix slated for 5.0.5 per https://github.com/django/django/pull/18091.

## Related issues
#1493 
