### PR TITLE
Add `path` signature for async views

### DIFF
--- a/django-stubs/urls/conf.pyi
+++ b/django-stubs/urls/conf.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
 from types import ModuleType
-from typing import Any, overload
+from typing import Any, Coroutine, overload
 
 from django.urls import URLPattern, URLResolver, _AnyURL
 from django.utils.functional import _StrOrPromise
@@ -21,6 +21,13 @@ def path(
     route: _StrOrPromise, view: Callable[..., HttpResponseBase], kwargs: dict[str, Any] = ..., name: str = ...
 ) -> URLPattern: ...
 @overload
+def path(
+    route: _StrOrPromise,
+    view: Callable[..., Coroutine[Any, Any, HttpResponseBase]],
+    kwargs: dict[str, Any] = ...,
+    name: str = ...,
+) -> URLPattern: ...
+@overload
 def path(route: _StrOrPromise, view: IncludedURLConf, kwargs: dict[str, Any] = ..., name: str = ...) -> URLResolver: ...
 @overload
 def path(
@@ -31,6 +38,13 @@ def path(
 @overload
 def re_path(
     route: _StrOrPromise, view: Callable[..., HttpResponseBase], kwargs: dict[str, Any] = ..., name: str = ...
+) -> URLPattern: ...
+@overload
+def re_path(
+    route: _StrOrPromise,
+    view: Callable[..., Coroutine[Any, Any, HttpResponseBase]],
+    kwargs: dict[str, Any] = ...,
+    name: str = ...,
 ) -> URLPattern: ...
 @overload
 def re_path(


### PR DESCRIPTION
# I have made things!

Creates an extra overload that permits async views inside of `path`.

## Related issues

#1874

