### PR TITLE
Remove incorrect `Reversible` base class from `QuerySet`

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -43,7 +43,7 @@ class NamedValuesListIterable(ValuesListIterable[NamedTuple]):
 class FlatValuesListIterable(BaseIterable[_Row]):
     def __iter__(self) -> Iterator[_Row]: ...
 
-class _QuerySet(Generic[_T, _Row], Reversible[_Row], Iterable[_Row], Sized):
+class _QuerySet(Generic[_T, _Row], Iterable[_Row], Sized):
     model: type[_T]
     query: Query
     _iterable_class: type[BaseIterable]

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import AsyncIterator, Collection, Iterable, Iterator, MutableMapping, Reversible, Sequence, Sized
+from collections.abc import AsyncIterator, Collection, Iterable, Iterator, MutableMapping, Sequence, Sized
 from typing import Any, Generic, NamedTuple, TypeVar, overload
 
 from django.db.backends.utils import _ExecuteQuery


### PR DESCRIPTION
I noticed this in https://github.com/typeddjango/django-stubs/pull/1925#issuecomment-2011851938.

`QuerySet` was marked as subclass of `Reversible`, but shouldn't be.

The `Reversible` ABC expects a [`__reversed__()`](https://docs.python.org/3/reference/datamodel.html#object.__reversed__) method, which `QuerySet` has never implemented. QuerySets do have `reverse()` method, but that's not the same thing :)