### PR TITLE
5.0: Update `django.contrib.messages.storage.cookie`

### DIFF
--- a/django-stubs/contrib/messages/storage/cookie.pyi
+++ b/django-stubs/contrib/messages/storage/cookie.pyi
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Callable, Sequence
 
 from django.contrib.messages.storage.base import BaseStorage
 
@@ -14,7 +14,20 @@ class MessageEncoder(json.JSONEncoder):
 class MessageDecoder(json.JSONDecoder):
     def process_messages(self, obj: Any) -> Any: ...
 
+class MessagePartSerializer:
+    def dumps(self, obj: Any) -> Sequence[str]: ...
+
+class MessagePartGatherSerializer:
+    def dumps(self, obj: Any) -> bytes: ...
+
+class MessageSerializer:
+    def loads(self, data: bytes | bytearray) -> Any: ...
+
 class CookieStorage(BaseStorage):
     cookie_name: str
     max_cookie_size: int
     not_finished: str
+    not_finished_json: str
+
+def bisect_keep_left(a: list[int], fn: Callable[[list[int]], bool]) -> int: ...
+def bisect_keep_right(a: list[int], fn: Callable[[list[int]], bool]) -> int: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -496,7 +496,6 @@ django.contrib.humanize.templatetags.humanize.intword_converters
 django.contrib.messages.storage.cookie.CookieStorage.key_salt
 django.contrib.messages.storage.cookie.MessageDecoder.decode
 django.contrib.messages.storage.cookie.MessageEncoder.default
-django.contrib.messages.storage.cookie.MessageSerializer
 django.contrib.postgres.fields.ArrayField.formfield
 django.contrib.postgres.fields.CIText.__init__
 django.contrib.postgres.fields.HStoreField.formfield

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -37,11 +37,6 @@ django.contrib.gis.management
 django.contrib.gis.management.commands
 django.contrib.gis.management.commands.inspectdb
 django.contrib.gis.management.commands.ogrinspect
-django.contrib.messages.storage.cookie.CookieStorage.not_finished_json
-django.contrib.messages.storage.cookie.MessagePartGatherSerializer
-django.contrib.messages.storage.cookie.MessagePartSerializer
-django.contrib.messages.storage.cookie.bisect_keep_left
-django.contrib.messages.storage.cookie.bisect_keep_right
 django.contrib.messages.test
 django.db.backends.base.features.BaseDatabaseFeatures.delete_can_self_reference_subquery
 django.db.backends.base.features.BaseDatabaseFeatures.insert_test_table_with_defaults


### PR DESCRIPTION
# I have made things!
Update stubs for `django.contrib.admin.widgets` for Django 5.0.

- [x] `django.contrib.messages.storage.cookie`
  - [x] `django.contrib.messages.storage.cookie.MessagePartSerializer` was added
  - [x]  `django.contrib.messages.storage.cookie.MessagePartGatherSerializer` was added
  - [x]  `django.contrib.messages.storage.cookie.MessageSerializer` was changed
  - [x]  `django.contrib.messages.storage.cookie.CookieStorage.not_finished_json` was added
  - [x]  `django.contrib.messages.storage.cookie.bisect_keep_left `was added
  - [x]  `django.contrib.messages.storage.cookie.bisect_keep_right` was added


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
`django.contrib.messages.storage.cookie.bisect_keep_left `
`django.contrib.messages.storage.cookie.bisect_keep_right` 
- https://github.com/django/django/pull/16602

`django.contrib.messages.storage.cookie.MessagePartSerializer` 
`django.contrib.messages.storage.cookie.MessagePartGatherSerializer` 
`django.contrib.messages.storage.cookie.MessageSerializer` 
`django.contrib.messages.storage.cookie.CookieStorage.not_finished_json
- https://github.com/django/django/pull/16602
