### PR TITLE
Fix annotation for `request.auser`

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from re import Pattern
-from typing import Any, BinaryIO, Callable, Literal, NoReturn, TypeVar, overload, type_check_only
+from typing import Any, Awaitable, BinaryIO, Callable, Literal, NoReturn, TypeVar, overload, type_check_only
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
@@ -57,7 +57,7 @@ class HttpRequest(BytesIO):
     # django.contrib.auth.middleware.AuthenticationMiddleware:
     user: AbstractBaseUser | AnonymousUser
     # django.contrib.auth.middleware.AuthenticationMiddleware:
-    auser: Callable[[], AbstractBaseUser | AnonymousUser]
+    auser: Callable[[], Awaitable[AbstractBaseUser | AnonymousUser]]
     # django.middleware.locale.LocaleMiddleware:
     LANGUAGE_CODE: str
     # django.contrib.sites.middleware.CurrentSiteMiddleware

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -106,3 +106,15 @@
         reveal_type(req.GET)  # N: Revealed type is "django.http.request._ImmutableQueryDict"
         req.GET['foo'] = 'bar'  # E: This QueryDict is immutable.  [misc]
         x = 1  # E: Statement is unreachable  [unreachable]
+
+-   case: request_user_auser
+    main: |
+        from django.contrib.auth.base_user import AbstractBaseUser
+        from django.contrib.auth.models import AnonymousUser
+        from django.http.request import HttpRequest
+
+        async def get_user_async(request: HttpRequest) -> AbstractBaseUser | AnonymousUser:
+            return await request.auser()
+
+        def get_user_sync(request: HttpRequest) -> AbstractBaseUser | AnonymousUser:
+            return request.user

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -106,15 +106,3 @@
         reveal_type(req.GET)  # N: Revealed type is "django.http.request._ImmutableQueryDict"
         req.GET['foo'] = 'bar'  # E: This QueryDict is immutable.  [misc]
         x = 1  # E: Statement is unreachable  [unreachable]
-
--   case: request_user_auser
-    main: |
-        from django.contrib.auth.base_user import AbstractBaseUser
-        from django.contrib.auth.models import AnonymousUser
-        from django.http.request import HttpRequest
-
-        async def get_user_async(request: HttpRequest) -> AbstractBaseUser | AnonymousUser:
-            return await request.auser()
-
-        def get_user_sync(request: HttpRequest) -> AbstractBaseUser | AnonymousUser:
-            return request.user


### PR DESCRIPTION
# I have made things!

Previously type tests failed on function like this because `request.auser` was annotated incorrectly. I fixed this.
```python
async def get_user_async(request: HttpRequest) -> AbstractBaseUser | AnonymousUser:
    return await request.auser()
```

