### PR TITLE
5.0: Update `django.db.models.expressions`

### DIFF
--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -61,6 +61,7 @@ class BaseExpression:
     is_summary: bool
     filterable: bool
     window_compatible: bool
+    allowed_default: bool
     def __init__(self, output_field: Field | None = ...) -> None: ...
     def get_db_converters(self, connection: BaseDatabaseWrapper) -> list[Callable]: ...
     def get_source_expressions(self) -> list[Any]: ...
@@ -193,6 +194,7 @@ class RawSQL(Expression):
     def __init__(self, sql: str, params: Sequence[Any], output_field: Field | None = ...) -> None: ...
 
 class Star(Expression): ...
+class DatabaseDefault(Expression): ...
 
 class Col(Expression):
     target: Field
@@ -237,6 +239,7 @@ class Case(Expression):
 
 class Subquery(BaseExpression, Combinable):
     template: str
+    subquery: bool
     query: Query
     extra: dict[Any, Any]
     def __init__(self, queryset: Query | QuerySet, output_field: Field | None = ..., **extra: Any) -> None: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -388,7 +388,6 @@ django.contrib.gis.db.models.Subquery.as_sql
 django.contrib.gis.db.models.Subquery.empty_result_set_value
 django.contrib.gis.db.models.Subquery.external_aliases
 django.contrib.gis.db.models.Subquery.get_external_cols
-django.contrib.gis.db.models.Subquery.subquery
 django.contrib.gis.db.models.TextField.formfield
 django.contrib.gis.db.models.TimeField.formfield
 django.contrib.gis.db.models.URLField.formfield
@@ -835,7 +834,6 @@ django.db.models.Subquery.as_sql
 django.db.models.Subquery.empty_result_set_value
 django.db.models.Subquery.external_aliases
 django.db.models.Subquery.get_external_cols
-django.db.models.Subquery.subquery
 django.db.models.TextField.formfield
 django.db.models.TimeField.formfield
 django.db.models.URLField.formfield
@@ -894,7 +892,6 @@ django.db.models.expressions.Subquery.as_sql
 django.db.models.expressions.Subquery.empty_result_set_value
 django.db.models.expressions.Subquery.external_aliases
 django.db.models.expressions.Subquery.get_external_cols
-django.db.models.expressions.Subquery.subquery
 django.db.models.expressions.Value.empty_result_set_value
 django.db.models.expressions.Value.for_save
 django.db.models.expressions.When.as_sql

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -24,7 +24,6 @@ django.contrib.gis.db.models.Func.allowed_default
 django.contrib.gis.db.models.Lookup.allowed_default
 django.contrib.gis.db.models.Prefetch.get_current_querysets
 django.contrib.gis.db.models.Q.identity
-django.contrib.gis.db.models.Value.allowed_default
 django.contrib.gis.db.models.When.allowed_default
 django.contrib.gis.forms.BaseForm._html_output
 django.contrib.gis.forms.BoundField.get_context
@@ -89,18 +88,12 @@ django.db.models.Func.allowed_default
 django.db.models.Lookup.allowed_default
 django.db.models.Prefetch.get_current_querysets
 django.db.models.Q.identity
-django.db.models.Value.allowed_default
 django.db.models.When.allowed_default
-django.db.models.expressions.BaseExpression.allowed_default
 django.db.models.expressions.Case.allowed_default
 django.db.models.expressions.CombinedExpression.allowed_default
-django.db.models.expressions.DatabaseDefault
 django.db.models.expressions.ExpressionWrapper.allowed_default
 django.db.models.expressions.F.allowed_default
 django.db.models.expressions.Func.allowed_default
-django.db.models.expressions.OrderByList.allowed_default
-django.db.models.expressions.RawSQL.allowed_default
-django.db.models.expressions.Value.allowed_default
 django.db.models.expressions.When.allowed_default
 django.db.models.fields.Field._get_flatchoices
 django.db.models.fields.Field.generated
@@ -113,9 +106,7 @@ django.db.models.fields.related.ReverseOneToOneDescriptor.get_prefetch_querysets
 django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor.get_prefetch_querysets
 django.db.models.fields.related_descriptors.ReverseOneToOneDescriptor.get_prefetch_querysets
 django.db.models.fields.reverse_related.ForeignObjectRel.get_joining_fields
-django.db.models.functions.Collate.allowed_default
 django.db.models.functions.Now.as_oracle
-django.db.models.functions.comparison.Collate.allowed_default
 django.db.models.functions.datetime.Now.as_oracle
 django.db.models.lookups.Lookup.allowed_default
 django.db.models.query.Prefetch.get_current_querysets


### PR DESCRIPTION
# I have made things!
Update stubs for `django.db.models.expressions` for Django 5.0.

- [x]  `django.db.models.expressions`
  - [x]  `django.db.models.expressions.BaseExpression.allowed_default` was added
  - [x]  `django.db.models.expressions.DatabaseDefault` was added
  - [x]  `django.db.models.expressions.Subquery.subquery` was added

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
 `django.db.models.expressions.Subquery.subquery`
- https://github.com/django/django/pull/16879

`django.db.models.expressions.BaseExpression.allowed_default` 
`django.db.models.expressions.DatabaseDefault`
- https://github.com/django/django/pull/16092
