### PR TITLE
Prepare django-stubs-ext for QuerySet typevar refactor

### DIFF
--- a/ext/django_stubs_ext/aliases.py
+++ b/ext/django_stubs_ext/aliases.py
@@ -1,12 +1,12 @@
 import typing
 
 if typing.TYPE_CHECKING:
-    from django.db.models.query import _T, _QuerySet, _QuerySetAny, _Row
+    from django.db.models.query import _QuerySet
     from django.utils.functional import _StrOrPromise as StrOrPromise
     from django.utils.functional import _StrPromise as StrPromise
 
-    QuerySetAny = _QuerySetAny
-    ValuesQuerySet = _QuerySet[_T, _Row]
+    QuerySetAny = _QuerySet
+    ValuesQuerySet = _QuerySet
 else:
     from django.db.models.query import QuerySet
     from django.utils.functional import Promise as StrPromise


### PR DESCRIPTION
* Preparation for: #2104

If we merge this first, and don't change `aliases.py` later, then we can be sure that next `django-stubs-ext 5.0.1` remains compatible with `django-stubs 5.0.0` (since CI will have checked both combinations)
