### PR TITLE
5.0: Update `django.forms.forms`

### DIFF
--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -8,7 +8,6 @@ from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorDict, ErrorList, RenderableFormMixin, _DataT, _FilesT
 from django.forms.widgets import Media, MediaDefiningClass
 from django.utils.functional import _StrOrPromise, cached_property
-from django.utils.safestring import SafeString
 
 class DeclarativeFieldsMetaclass(MediaDefiningClass): ...
 
@@ -71,14 +70,6 @@ class BaseForm(RenderableFormMixin):
     def hidden_fields(self) -> list[BoundField]: ...
     def visible_fields(self) -> list[BoundField]: ...
     def get_initial_for_field(self, field: Field, field_name: str) -> Any: ...
-    def _html_output(
-        self,
-        normal_row: str,
-        error_row: str,
-        row_ender: str,
-        help_text_html: str,
-        errors_on_separate_row: bool,
-    ) -> SafeString: ...
 
 class Form(BaseForm, metaclass=DeclarativeFieldsMetaclass):
     base_fields: ClassVar[dict[str, Field]]

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -22,7 +22,6 @@ django.contrib.gis.db.models.Lookup.allowed_default
 django.contrib.gis.db.models.Prefetch.get_current_querysets
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.db.models.When.allowed_default
-django.contrib.gis.forms.BaseForm._html_output
 django.contrib.gis.forms.ClearableFileInput.checked
 django.contrib.gis.forms.fields_for_model
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
@@ -90,10 +89,8 @@ django.db.models.sql.query.Query.build_filtered_relation_q
 django.db.models.sql.query.Query.join
 django.db.models.sql.query.Query.resolve_lookup_value
 django.db.models.sql.query.Query.setup_joins
-django.forms.BaseForm._html_output
 django.forms.ClearableFileInput.checked
 django.forms.fields_for_model
-django.forms.forms.BaseForm._html_output
 django.forms.models.fields_for_model
 django.forms.widgets.ClearableFileInput.checked
 django.template.autoreload


### PR DESCRIPTION
# I have made things!
Update stubs for `django.forms.forms` for Django 5.0.

- [x]  `django.forms.forms`
  - [x]   `django.forms.forms.BaseForm._html_output` was removed



<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16432