### PR TITLE
Improve typing of `django.db.backends.mysql.base.DatabaseWrapper` attributes

### DIFF
--- a/django-stubs/db/backends/mysql/base.pyi
+++ b/django-stubs/db/backends/mysql/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Container, Iterator
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 
@@ -14,6 +14,8 @@ from .validation import DatabaseValidation
 version: Any
 django_conversions: Any
 server_version_re: Any
+
+class MySQLDatabase(Protocol): ...
 
 class CursorWrapper:
     codes_for_integrityerror: Any
@@ -40,12 +42,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     validation_class: type[DatabaseValidation]
 
     vendor: str
-    data_types: dict[str, str]
     operators: dict[str, str]
     pattern_esc: str
     pattern_ops: dict[str, str]
     isolation_levels: set[str]
-    Database: Any
+    Database: MySQLDatabase
     SchemaEditorClass: type[DatabaseSchemaEditor]
     isolation_level: set[str]
     def get_connection_params(self) -> dict[str, Any]: ...
@@ -53,7 +54,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def init_connection_state(self) -> None: ...
     def create_cursor(self, name: Any | None = ...) -> CursorWrapper: ...
     def disable_constraint_checking(self) -> Literal[True]: ...
-    needs_rollback: bool
     def enable_constraint_checking(self) -> None: ...
     def check_constraints(self, table_names: Any | None = ...) -> None: ...
     def is_usable(self) -> bool: ...

--- a/django-stubs/db/backends/mysql/base.pyi
+++ b/django-stubs/db/backends/mysql/base.pyi
@@ -8,6 +8,7 @@ from .creation import DatabaseCreation
 from .features import DatabaseFeatures
 from .introspection import DatabaseIntrospection
 from .operations import DatabaseOperations
+from .schema import DatabaseSchemaEditor
 from .validation import DatabaseValidation
 
 version: Any
@@ -39,20 +40,20 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     validation_class: type[DatabaseValidation]
 
     vendor: str
-    data_types: Any
-    operators: Any
+    data_types: dict[str, str]
+    operators: dict[str, str]
     pattern_esc: str
-    pattern_ops: Any
-    isolation_levels: Any
+    pattern_ops: dict[str, str]
+    isolation_levels: set[str]
     Database: Any
-    SchemaEditorClass: Any
-    isolation_level: Any
+    SchemaEditorClass: type[DatabaseSchemaEditor]
+    isolation_level: set[str]
     def get_connection_params(self) -> dict[str, Any]: ...
     def get_new_connection(self, conn_params: Any) -> Any: ...
     def init_connection_state(self) -> None: ...
     def create_cursor(self, name: Any | None = ...) -> CursorWrapper: ...
     def disable_constraint_checking(self) -> Literal[True]: ...
-    needs_rollback: Any
+    needs_rollback: bool
     def enable_constraint_checking(self) -> None: ...
     def check_constraints(self, table_names: Any | None = ...) -> None: ...
     def is_usable(self) -> bool: ...


### PR DESCRIPTION
# I have made things!
I modified the `Any` value of the `django.db.backends.mysql.base.DatabaseWrapper`'s arguments .

- [x] `django.db.backends.mysql.base.DatabaseWrapper.data_types`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.operators`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.pattern_ops`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.isolation_levels`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.SchemaEditorClass`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.isolation_level`
- [x] `django.db.backends.mysql.base.DatabaseWrapper.needs_rollback`

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
