### PR TITLE
5.0: Update `django.contrib.messages.test`

### DIFF
--- a/django-stubs/contrib/messages/test.pyi
+++ b/django-stubs/contrib/messages/test.pyi
@@ -1,0 +1,9 @@
+from typing import Any
+
+from django.contrib.messages.storage.base import Message
+from django.http.response import HttpResponse
+
+class MessagesTestMixin:
+    def assertMessages(
+        self, response: HttpResponse, expected_messages: list[dict[str, Any] | type[Message]], *, ordered: bool = ...
+    ) -> None: ...

--- a/django-stubs/contrib/messages/test.pyi
+++ b/django-stubs/contrib/messages/test.pyi
@@ -1,9 +1,9 @@
 from typing import Any
 
-from django.contrib.messages.storage.base import Message
+from django.contrib.messages.storage.base import BaseStorage
 from django.http.response import HttpResponse
 
 class MessagesTestMixin:
     def assertMessages(
-        self, response: HttpResponse, expected_messages: list[dict[str, Any] | type[Message]], *, ordered: bool = ...
+        self, response: HttpResponse, expected_messages: list[Any] | BaseStorage, *, ordered: bool = ...
     ) -> None: ...

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -28,7 +28,6 @@ django.contrib.gis.management
 django.contrib.gis.management.commands
 django.contrib.gis.management.commands.inspectdb
 django.contrib.gis.management.commands.ogrinspect
-django.contrib.messages.test
 django.db.backends.mysql.features.DatabaseFeatures.allows_group_by_selected_pks
 django.db.backends.mysql.features.DatabaseFeatures.has_native_uuid_field
 django.db.backends.mysql.features.DatabaseFeatures.supports_expression_defaults

--- a/tests/typecheck/test_import_all.yml
+++ b/tests/typecheck/test_import_all.yml
@@ -234,6 +234,7 @@
         import django.contrib.messages.storage.session
         import django.contrib.messages.utils
         import django.contrib.messages.views
+        import django.contrib.messages.test
         import django.contrib.postgres
         import django.contrib.postgres.aggregates
         import django.contrib.postgres.aggregates.general


### PR DESCRIPTION
# I have made things!
Update stubs for `django.contrib.messages.test` for Django 5.0.

- [x]  `django.contrib.messages.test` was added

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/17101