### PR TITLE
fix: UserAdmin accepts AbstractUser

### DIFF
--- a/django-stubs/contrib/auth/admin.pyi
+++ b/django-stubs/contrib/auth/admin.pyi
@@ -5,9 +5,10 @@ from django.contrib.auth.models import AbstractUser, Group
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 
+_AbstractUserT = TypeVar("_AbstractUserT", bound=AbstractUser)
+
 csrf_protect_m: Any
 sensitive_post_parameters_m: Any
-_AbstractUserT = TypeVar("_AbstractUserT", bound=AbstractUser)
 
 class GroupAdmin(admin.ModelAdmin[Group]): ...
 

--- a/django-stubs/contrib/auth/admin.pyi
+++ b/django-stubs/contrib/auth/admin.pyi
@@ -7,11 +7,11 @@ from django.http.response import HttpResponse
 
 csrf_protect_m: Any
 sensitive_post_parameters_m: Any
-_M = TypeVar("_M", bound=AbstractUser)
+_AbstractUserT = TypeVar("_AbstractUserT", bound=AbstractUser)
 
 class GroupAdmin(admin.ModelAdmin[Group]): ...
 
-class UserAdmin(admin.ModelAdmin[_M]):
+class UserAdmin(admin.ModelAdmin[_AbstractUserT]):
     change_user_password_template: Any
     add_fieldsets: Any
     add_form: Any

--- a/django-stubs/contrib/auth/admin.pyi
+++ b/django-stubs/contrib/auth/admin.pyi
@@ -1,16 +1,17 @@
-from typing import Any
+from typing import Any, TypeVar
 
 from django.contrib import admin
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import AbstractUser, Group
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 
 csrf_protect_m: Any
 sensitive_post_parameters_m: Any
+_M = TypeVar("_M", bound=AbstractUser)
 
 class GroupAdmin(admin.ModelAdmin[Group]): ...
 
-class UserAdmin(admin.ModelAdmin[User]):
+class UserAdmin(admin.ModelAdmin[_M]):
     change_user_password_template: Any
     add_fieldsets: Any
     add_form: Any


### PR DESCRIPTION
# I have made things!
Currently when CustomUser is created Admin doesn't accept it.

There was initial PR wih this fix #1783, but comments weren't addressed yet but I also need this merged.

Let me know if we can do it better.


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
