### PR TITLE
Fix 'Import cycle from Django settings module' errors function context

### DIFF
--- a/mypy_django_plugin/transformers/settings.py
+++ b/mypy_django_plugin/transformers/settings.py
@@ -38,10 +38,8 @@ def get_type_of_settings_attribute(
             sym = module.names.get(setting_name)
             if sym is not None:
                 if sym.type is None:
-                    ctx.api.fail(
-                        f"Import cycle from Django settings module prevents type inference for {setting_name!r}",
-                        ctx.context,
-                    )
+                    # When analysing a function, mypy will defer analysis to a later pass
+                    typechecker_api.handle_cannot_determine_type(setting_name, ctx.context)
                     return ctx.default_attr_type
                 return sym.type
 

--- a/tests/typecheck/conf/test_settings.yml
+++ b/tests/typecheck/conf/test_settings.yml
@@ -8,12 +8,13 @@
         -   path: myapp/__init__.py
         -   path: myapp/settings.py
             content: |
-                from myapp.lib import function_returning_int, const_with_circular_import
+                from myapp.lib import function_returning_int, const_with_circular_import, const_unresolvable_circular
 
                 IMMEDIATE_VALUE = 123
                 CIRCULAR_WITH_HINT: int = function_returning_int()
                 CIRCULAR_WITHOUT_HINT_FUNCTION = function_returning_int()
                 CIRCULAR_WITHOUT_HINT_CONST = const_with_circular_import
+                UNRESOLVABLE_CIRCULAR = const_unresolvable_circular
         -   path: myapp/lib.py
             content: |
                 from typing import TYPE_CHECKING
@@ -24,13 +25,16 @@
                 def test() -> None:
                     reveal_type(settings.IMMEDIATE_VALUE)        # N: Revealed type is "builtins.int"
                     reveal_type(settings.CIRCULAR_WITH_HINT)     # N: Revealed type is "builtins.int"
-                    reveal_type(settings.CIRCULAR_WITHOUT_HINT_FUNCTION)  # E: Import cycle from Django settings module prevents type inference for 'CIRCULAR_WITHOUT_HINT_FUNCTION'  [misc]  # N: Revealed type is "Any"
-                    reveal_type(settings.CIRCULAR_WITHOUT_HINT_CONST)     # E: Import cycle from Django settings module prevents type inference for 'CIRCULAR_WITHOUT_HINT_CONST'  [misc]     # N: Revealed type is "Any"
+                    reveal_type(settings.CIRCULAR_WITHOUT_HINT_FUNCTION)  # N: Revealed type is "builtins.int"
+                    reveal_type(settings.CIRCULAR_WITHOUT_HINT_CONST)     # N: Revealed type is "builtins.int"
+                    reveal_type(settings.UNRESOLVABLE_CIRCULAR)  # N: Revealed type is "Any"
 
                 def function_returning_int() -> int:
                     return 42
 
                 if TYPE_CHECKING:
                     const_with_circular_import = settings.IMMEDIATE_VALUE
+                    const_unresolvable_circular = settings.UNRESOLVABLE_CIRCULAR  # E: Cannot determine type of "UNRESOLVABLE_CIRCULAR"  [has-type]
                 else:
                     const_with_circular_import = 0
+                    const_unresolvable_circular = ...


### PR DESCRIPTION
Remaining unresolvable cases will have a different error message 'Cannot determine type of "SETTING_NAME"  [has-type]'

Special thanks to Anthony Sottile @asottile-sentry for suggesting this solution in https://github.com/typeddjango/django-stubs/pull/2127#issuecomment-2096943735

## Related issues

* https://github.com/typeddjango/django-stubs/discussions/2097#discussioncomment-9321035
* https://github.com/typeddjango/django-stubs/pull/2127
