### PR TITLE
FIx test looking for env options

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,6 @@
 [mypy]
 allow_redefinition = true
 check_untyped_defs = true
-ignore_missing_imports = false
 incremental = true
 strict_optional = true
 show_traceback = true

--- a/tests/typecheck/test_config.yml
+++ b/tests/typecheck/test_config.yml
@@ -58,6 +58,8 @@
     mypy_config: |
         [mypy.plugins.django-stubs]
         django_settings_module = mysettings
+    env:
+      - MYPYPATH=./extras
     files:
         -   path: extras/extra_module.py
             content: |


### PR DESCRIPTION
Originally this PR was about how I wanted to remove the `from db.models` imports so I could remove the option that made mypy ignore missing imports (because https://github.com/python/mypy/issues/7777)

Turns out that's all been fixed in latest master. So this PR only removes the option ignoring mypy types and fixes the test for testing adding `MYPYPATH` to the yml `env`.


