### PR TITLE
5.0: Update `django.forms.formsets`

### DIFF
--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -3,6 +3,7 @@ from typing import Any, Generic, TypeVar
 
 from django.db.models.fields import _ErrorMessagesDict
 from django.forms.forms import BaseForm, Form
+from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorList, RenderableFormMixin, _DataT, _FilesT
 from django.forms.widgets import Media, Widget
 from django.utils.functional import cached_property
@@ -61,6 +62,8 @@ class BaseFormSet(Generic[_F], Sized, RenderableFormMixin):
         error_class: type[ErrorList] = ...,
         form_kwargs: dict[str, Any] | None = ...,
         error_messages: Mapping[str, str] | None = ...,
+        form_renderer: BaseRenderer = ...,
+        renderer: BaseRenderer = ...,
     ) -> None: ...
     def __iter__(self) -> Iterator[_F]: ...
     def __getitem__(self, index: int) -> _F: ...

--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -5,7 +5,7 @@ from django.db.models.fields import _ErrorMessagesDict
 from django.forms.forms import BaseForm, Form
 from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorList, RenderableFormMixin, _DataT, _FilesT
-from django.forms.widgets import Media, Widget
+from django.forms.widgets import Media, MediaDefiningClass, Widget
 from django.utils.functional import cached_property
 
 TOTAL_FORM_COUNT: str
@@ -45,8 +45,8 @@ class BaseFormSet(Generic[_F], Sized, RenderableFormMixin):
     initial: Sequence[Mapping[str, Any]] | None
     form_kwargs: dict[str, Any]
     error_class: type[ErrorList]
-    deletion_widget: type[Widget]
-    ordering_widget: type[Widget]
+    deletion_widget: MediaDefiningClass
+    ordering_widget: MediaDefiningClass
     default_error_messages: _ErrorMessagesDict
     template_name_div: str
     template_name_p: str

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -414,8 +414,6 @@ django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql
 django.contrib.gis.forms.ALL_FIELDS
 django.contrib.gis.forms.BaseForm.__init__
 django.contrib.gis.forms.BaseFormSet.__init__
-django.contrib.gis.forms.BaseFormSet.deletion_widget
-django.contrib.gis.forms.BaseFormSet.ordering_widget
 django.contrib.gis.forms.BaseModelForm.__init__
 django.contrib.gis.forms.BaseModelForm.save_m2m
 django.contrib.gis.forms.BaseModelFormSet.model
@@ -1310,8 +1308,6 @@ django.db.utils.DatabaseErrorWrapper.__call__
 django.forms.ALL_FIELDS
 django.forms.BaseForm.__init__
 django.forms.BaseFormSet.__init__
-django.forms.BaseFormSet.deletion_widget
-django.forms.BaseFormSet.ordering_widget
 django.forms.BaseModelForm.__init__
 django.forms.BaseModelForm.save_m2m
 django.forms.BaseModelFormSet.model
@@ -1359,8 +1355,6 @@ django.forms.forms.BaseForm.__init__
 django.forms.forms.DeclarativeFieldsMetaclass.__new__
 django.forms.formset_factory
 django.forms.formsets.BaseFormSet.__init__
-django.forms.formsets.BaseFormSet.deletion_widget
-django.forms.formsets.BaseFormSet.ordering_widget
 django.forms.formsets.ManagementForm.__init__
 django.forms.formsets.formset_factory
 django.forms.inlineformset_factory


### PR DESCRIPTION
# I have made things!
Update stubs for `django.forms.formsets` for Django 5.0.

- [x] `django.forms.formsets`
  - [x] `django.forms.formsets.BaseFormSet.form_renderer` was added
  - [x] `django.forms.formsets.BaseFormSet.renderer` was added

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/17107