### PR TITLE
5.0: Update `django.forms.models`

### DIFF
--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -50,6 +50,7 @@ def fields_for_model(
     field_classes: Mapping[str, type[Field]] | None = ...,
     *,
     apply_limit_choices_to: bool = ...,
+    form_declared_fields: _Fields | None = ...,
 ) -> dict[str, Any]: ...
 
 class ModelFormOptions(Generic[_M]):

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -22,7 +22,6 @@ django.contrib.gis.db.models.Prefetch.get_current_querysets
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.db.models.When.allowed_default
 django.contrib.gis.forms.ClearableFileInput.checked
-django.contrib.gis.forms.fields_for_model
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.contrib.gis.management
 django.contrib.gis.management.commands
@@ -89,7 +88,5 @@ django.db.models.sql.query.Query.join
 django.db.models.sql.query.Query.resolve_lookup_value
 django.db.models.sql.query.Query.setup_joins
 django.forms.ClearableFileInput.checked
-django.forms.fields_for_model
-django.forms.models.fields_for_model
 django.forms.widgets.ClearableFileInput.checked
 django.template.autoreload


### PR DESCRIPTION
# I have made things!
Update stubs for `django.forms.models` for Django 5.0.

- [x] `django.forms.models`
  - [x] `django.forms.models.fields_for_model`'s `form_declared_fields` argument was added

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16804