### PR TITLE
5.0: Update `django.forms.widgets`

### DIFF
--- a/django-stubs/forms/widgets.pyi
+++ b/django-stubs/forms/widgets.pyi
@@ -93,6 +93,7 @@ class MultipleHiddenInput(HiddenInput):
     template_name: str
 
 class FileInput(Input):
+    allow_multiple_selected: bool
     input_type: str
     template_name: str
     needs_multipart_form: bool
@@ -108,6 +109,7 @@ class ClearableFileInput(FileInput):
     initial_text: str
     input_text: str
     template_name: str
+    checked: bool
     def clear_checkbox_name(self, name: str) -> str: ...
     def clear_checkbox_id(self, name: str) -> str: ...
     def is_initial(self, value: File | str | None) -> bool: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -424,7 +424,6 @@ django.contrib.gis.forms.EmailInput.__slotnames__
 django.contrib.gis.forms.Field.__deepcopy__
 django.contrib.gis.forms.Field.hidden_widget
 django.contrib.gis.forms.FileField.bound_data
-django.contrib.gis.forms.FileInput.allow_multiple_selected
 django.contrib.gis.forms.HiddenInput.__slotnames__
 django.contrib.gis.forms.InlineForeignKeyField
 django.contrib.gis.forms.Input
@@ -1316,7 +1315,6 @@ django.forms.EmailInput.__slotnames__
 django.forms.Field.__deepcopy__
 django.forms.Field.hidden_widget
 django.forms.FileField.bound_data
-django.forms.FileInput.allow_multiple_selected
 django.forms.HiddenInput.__slotnames__
 django.forms.InlineForeignKeyField
 django.forms.Input
@@ -1373,7 +1371,6 @@ django.forms.renderers.DjangoDivFormRenderer
 django.forms.widgets.ChoiceWidget.subwidgets
 django.forms.widgets.ChoiceWidget.template_name
 django.forms.widgets.EmailInput.__slotnames__
-django.forms.widgets.FileInput.allow_multiple_selected
 django.forms.widgets.HiddenInput.__slotnames__
 django.forms.widgets.Input.input_type
 django.forms.widgets.Media.__html__

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -18,7 +18,6 @@ django.contrib.gis.db.models.Lookup.allowed_default
 django.contrib.gis.db.models.Prefetch.get_current_querysets
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.db.models.When.allowed_default
-django.contrib.gis.forms.ClearableFileInput.checked
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.contrib.gis.management
 django.contrib.gis.management.commands
@@ -81,8 +80,6 @@ django.db.models.sql.Query.setup_joins
 django.db.models.sql.query.Query.build_filtered_relation_q
 django.db.models.sql.query.Query.join
 django.db.models.sql.query.Query.setup_joins
-django.forms.ClearableFileInput.checked
-django.forms.widgets.ClearableFileInput.checked
 django.template.autoreload
 
 # Django + Oracle (new errors after 5.0.5 update)


### PR DESCRIPTION
# I have made things!
Update stubs for `django.forms.widgets` for Django 5.0.

- [x] `django.forms.widgets`
  - [x] `django.forms.widgets.FileInput.allow_multiple_selected` was added
  - [x] `django.forms.widgets.ClearableFileInput.checked` was added
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16785