### PR TITLE
5.0: Update `django.db.models.enums`

### DIFF
--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -8,10 +8,18 @@ _Self = TypeVar("_Self")
 
 if sys.version_info >= (3, 11):
     _enum_property = enum.property
+    EnumType = enum.EnumType
+    IntEnum = enum.IntEnum
+    StrEnum = enum.StrEnum
 else:
     _enum_property = property
+    EnumType = enum.EnumMeta
 
-class ChoicesMeta(enum.EnumMeta):
+    class ReprEnum(enum.Enum): ...
+    class IntEnum(int, ReprEnum): ...
+    class StrEnum(str, ReprEnum): ...
+
+class ChoicesMeta(EnumType):
     # There's a contradiction between mypy and PYI019 regarding metaclasses. Where mypy
     # disallows 'typing_extensions.Self' on metaclasses, while PYI019 try to enforce
     # 'typing_extensions.Self' for '__new__' methods.. We've chosen to ignore the
@@ -31,7 +39,7 @@ class ChoicesMeta(enum.EnumMeta):
 
 ChoicesType: TypeAlias = ChoicesMeta
 
-class Choices(enum.Enum, metaclass=ChoicesMeta):
+class Choices(enum.Enum, metaclass=ChoicesType):
     @property
     def label(self) -> str: ...
     @_enum_property
@@ -41,26 +49,26 @@ class Choices(enum.Enum, metaclass=ChoicesMeta):
 
 # fake, to keep simulate class properties
 @type_check_only
-class _IntegerChoicesMeta(ChoicesMeta):
+class _IntegerChoicesMeta(ChoicesType):
     @property
     def choices(self) -> list[tuple[int, str]]: ...
     @property
     def values(self) -> list[int]: ...
 
-class IntegerChoices(int, Choices, metaclass=_IntegerChoicesMeta):
+class IntegerChoices(Choices, IntEnum, metaclass=_IntegerChoicesMeta):
     def __new__(cls, value: int) -> Self: ...
     @_enum_property
     def value(self) -> int: ...
 
 # fake, to keep simulate class properties
 @type_check_only
-class _TextChoicesMeta(ChoicesMeta):
+class _TextChoicesMeta(ChoicesType):
     @property
     def choices(self) -> list[tuple[str, str]]: ...
     @property
     def values(self) -> list[str]: ...
 
-class TextChoices(str, Choices, metaclass=_TextChoicesMeta):
+class TextChoices(Choices, StrEnum, metaclass=_TextChoicesMeta):
     def __new__(cls, value: str) -> Self: ...
     @_enum_property
     def value(self) -> str: ...


### PR DESCRIPTION
# I have made things!
Update stubs for `django.forms.widgets` for Django 5.0.

- [x] `django.db.models.enums`
  - [x] `django.db.models.enums.IntegerChoices` was changed
  - [x] `django.db.models.enums.TextChoices` was changed

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/17186
- https://github.com/django/django/pull/17249