### PR TITLE
5.0: Update `django.db.models.sql.compiler`

### DIFF
--- a/django-stubs/db/models/sql/compiler.pyi
+++ b/django-stubs/db/models/sql/compiler.pyi
@@ -20,7 +20,6 @@ _AsSqlType: TypeAlias = tuple[str, _ParamsT]
 
 class PositionRef(Ref):
     def __init__(self, ordinal: str, refs: str, source: Expression) -> None: ...
-    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...
 
 class SQLCompiler:
     query: Query

--- a/django-stubs/db/models/sql/compiler.pyi
+++ b/django-stubs/db/models/sql/compiler.pyi
@@ -7,7 +7,7 @@ from uuid import UUID
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.utils import CursorWrapper
 from django.db.models.base import Model
-from django.db.models.expressions import BaseExpression, Expression
+from django.db.models.expressions import BaseExpression, Expression, Ref
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import AggregateQuery, DeleteQuery, InsertQuery, UpdateQuery
 from django.utils.functional import cached_property
@@ -17,6 +17,10 @@ _ParamT: TypeAlias = str | int
 
 _ParamsT: TypeAlias = list[_ParamT]
 _AsSqlType: TypeAlias = tuple[str, _ParamsT]
+
+class PositionRef(Ref):
+    def __init__(self, ordinal: str, refs: str, source: Expression) -> None: ...
+    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...
 
 class SQLCompiler:
     query: Query

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1231,7 +1231,6 @@ django.db.models.sql.Query.names_to_path
 django.db.models.sql.Query.solve_lookup_type
 django.db.models.sql.Query.table_alias
 django.db.models.sql.XOR
-django.db.models.sql.compiler.PositionRef
 django.db.models.sql.compiler.SQLCompiler.__init__
 django.db.models.sql.compiler.SQLCompiler.deferred_to_columns
 django.db.models.sql.compiler.SQLCompiler.get_default_columns


### PR DESCRIPTION
# I have made things!
Update stubs for `django.db.models.sql.compiler` for Django 5.0.

- [x]  `django.db.models.sql.compiler`
  - [x]  `django.db.models.sql.compiler.PositionRef` was added

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16571