### PR TITLE
5.0: Update `django.db.models.functions.datetime`

### DIFF
--- a/django-stubs/db/models/functions/datetime.pyi
+++ b/django-stubs/db/models/functions/datetime.pyi
@@ -1,7 +1,12 @@
+from datetime import tzinfo
 from typing import Any, ClassVar
 
 from django.db import models
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Func, Transform
+from django.db.models.expressions import Expression
+from django.db.models.fields import Field
+from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 
 class TimezoneMixin:
     tzinfo: Any
@@ -33,7 +38,21 @@ class TruncBase(TimezoneMixin, Transform):
     kind: str
     tzinfo: Any
 
-class Trunc(TruncBase): ...
+    def __init__(
+        self, expression: Expression, output_field: Field | None = ..., tzinfo: tzinfo | None = ..., **extra: Any
+    ) -> None: ...
+    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...  # type: ignore[override]
+
+class Trunc(TruncBase):
+    def __init__(
+        self,
+        expression: Expression,
+        kind: str,
+        output_field: Field | None = ...,
+        tzinfo: tzinfo | None = ...,
+        **extra: Any,
+    ) -> None: ...
+
 class TruncYear(TruncBase): ...
 class TruncQuarter(TruncBase): ...
 class TruncMonth(TruncBase): ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1060,9 +1060,6 @@ django.db.models.functions.Pi.as_oracle
 django.db.models.functions.Radians.as_oracle
 django.db.models.functions.Random
 django.db.models.functions.Round.__init__
-django.db.models.functions.Trunc.__init__
-django.db.models.functions.TruncDate.as_sql
-django.db.models.functions.TruncTime.as_sql
 django.db.models.functions.comparison.Cast.as_mysql
 django.db.models.functions.comparison.Cast.as_oracle
 django.db.models.functions.comparison.Cast.as_postgresql
@@ -1079,12 +1076,7 @@ django.db.models.functions.datetime.Extract.as_sql
 django.db.models.functions.datetime.Extract.lookup_name
 django.db.models.functions.datetime.Now.as_mysql
 django.db.models.functions.datetime.Now.as_postgresql
-django.db.models.functions.datetime.Trunc.__init__
-django.db.models.functions.datetime.TruncBase.__init__
-django.db.models.functions.datetime.TruncBase.as_sql
 django.db.models.functions.datetime.TruncBase.kind
-django.db.models.functions.datetime.TruncDate.as_sql
-django.db.models.functions.datetime.TruncTime.as_sql
 django.db.models.functions.math.Ceil.as_oracle
 django.db.models.functions.math.Cot.as_oracle
 django.db.models.functions.math.Degrees.as_oracle


### PR DESCRIPTION
# I have made things!

Update stubs for `django.db.models.functions.datetime` for Django 5.0.

- [x] `django.db.models.functions.datetime`
  - [x]  `django.db.models.functions.datetime.TruncBase.__init__`'s `is_dst` argument was removed
  - [x]  `django.db.models.functions.datetime.TruncBase.is_dst` was removed
  - [x]  `django.db.models.functions.datetime.Trunc.__init__`'s `is_dst` argument was removed

I have added the necessary `__init__ `and `as_sql` methods to accommodate the updates in Django 5.0.


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16432