### PR TITLE
5.0: Update `django.db.models.functions.datetime.Now`

### DIFF
--- a/django-stubs/db/models/functions/datetime.pyi
+++ b/django-stubs/db/models/functions/datetime.pyi
@@ -34,6 +34,8 @@ class ExtractSecond(Extract): ...
 class Now(Func):
     output_field: ClassVar[models.DateTimeField]
 
+    def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
+
 class TruncBase(TimezoneMixin, Transform):
     kind: str
     tzinfo: Any

--- a/scripts/stubtest/allowlist_todo_django50.txt
+++ b/scripts/stubtest/allowlist_todo_django50.txt
@@ -48,8 +48,6 @@ django.db.models.fields.related.ForwardManyToOneDescriptor.get_prefetch_queryset
 django.db.models.fields.related.ReverseOneToOneDescriptor.get_prefetch_querysets
 django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor.get_prefetch_querysets
 django.db.models.fields.related_descriptors.ReverseOneToOneDescriptor.get_prefetch_querysets
-django.db.models.functions.Now.as_oracle
-django.db.models.functions.datetime.Now.as_oracle
 django.db.models.lookups.Lookup.allowed_default
 django.db.models.sql.Query.build_filtered_relation_q
 django.db.models.sql.Query.join


### PR DESCRIPTION
# I have made things!
Update stubs for `django.db.models.functions.datetime` for Django 5.0.

- [x] `django.db.models.functions.datetime`
  - [x] `django.db.models.functions.datetime.Now.as_oracle` was added 

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/16847