### PR TITLE
`AbstractBaseSession`: Use model fields for subclassed cases

### DIFF
--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -11,9 +11,9 @@ class BaseSessionManager(models.Manager[_T]):
     def save(self, session_key: str, session_dict: dict[str, Any], expire_date: datetime) -> _T: ...
 
 class AbstractBaseSession(models.Model):
-    expire_date: datetime
-    session_data: str
-    session_key: str
+    session_key = models.CharField(primary_key=True)
+    session_data = models.TextField()
+    expire_date = models.DateTimeField()
     objects: Any
 
     @classmethod

--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Any, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 from django.contrib.sessions.backends.base import SessionBase
 from django.db import models
+from typing_extensions import Self
 
 _T = TypeVar("_T", bound=AbstractBaseSession)
 
@@ -14,6 +15,7 @@ class AbstractBaseSession(models.Model):
     session_key = models.CharField(primary_key=True)
     session_data = models.TextField()
     expire_date = models.DateTimeField()
+    objects: ClassVar[BaseSessionManager[Self]]
 
     @classmethod
     def get_session_store_class(cls) -> type[SessionBase] | None: ...

--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -14,7 +14,6 @@ class AbstractBaseSession(models.Model):
     session_key = models.CharField(primary_key=True)
     session_data = models.TextField()
     expire_date = models.DateTimeField()
-    objects: Any
 
     @classmethod
     def get_session_store_class(cls) -> type[SessionBase] | None: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -509,6 +509,7 @@ django.contrib.sessions.backends.signed_cookies.SessionStore.exists
 django.contrib.sessions.base_session.AbstractBaseSession.expire_date
 django.contrib.sessions.base_session.AbstractBaseSession.get_next_by_expire_date
 django.contrib.sessions.base_session.AbstractBaseSession.get_previous_by_expire_date
+django.contrib.sessions.base_session.AbstractBaseSession.objects
 django.contrib.sessions.base_session.AbstractBaseSession.session_data
 django.contrib.sessions.base_session.AbstractBaseSession.session_key
 django.contrib.sessions.base_session.BaseSessionManager.__slotnames__


### PR DESCRIPTION
# Changes

## `AbstractBaseSession` fields

These currently raise on mypy when overridden, such as by overriding `max_length`, see example in #2179.

In situations where these fields are overridden in custom models, for instance extending 'session_key`'s `max_length`. Follow a similar style to `AbstractBaseUser` (django: [5.0.6](https://github.com/django/django/blob/5.0.6/django/contrib/auth/base_user.py#L60-L61), django-stubs: [5.0.0](https://github.com/typeddjango/django-stubs/blob/5.0.0/django-stubs/contrib/auth/base_user.pyi#L16-L21)).

See also:
- https://docs.djangoproject.com/en/5.0/topics/http/sessions/#extending-database-backed-session-engines
- https://github.com/django/django/blob/5.0.6/django/contrib/sessions/base_session.py
- https://github.com/typeddjango/django-stubs/blob/5.0.0/django-stubs/contrib/sessions/base_session.pyi#L13-L21

## Related issues

- Fixes #2179