### PR TITLE
Bump `django-stubs-ext` dependency to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
+| 5.0.2          | 1.10.x       | 5.0            | 4.2                    | 3.8 - 3.12     |
 | 5.0.1          | 1.10.x       | 5.0            | 4.2                    | 3.8 - 3.12     |
 | 5.0.0          | 1.10.x       | 5.0            | 4.2, 4.1               | 3.8 - 3.12     |
 | 4.2.7          | 1.7.x        | 4.2            | 4.1, 3.2               | 3.8 - 3.12     |

--- a/ext/setup.py
+++ b/ext/setup.py
@@ -13,7 +13,7 @@ dependencies = [
 # It's fine to skip django-stubs-ext releases, but when doing a release, update this to newest django-stubs version.
 setup(
     name="django-stubs-ext",
-    version="5.0.1",
+    version="5.0.2",
     description="Monkey-patching and extensions for django-stubs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md") as f:
 dependencies = [
     "django",
     "asgiref",
-    "django-stubs-ext>=5.0.0",
+    "django-stubs-ext>=5.0.2",
     "tomli; python_version < '3.11'",
     # Types:
     "typing-extensions>=4.11.0",
@@ -39,7 +39,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="5.0.1",
+    version="5.0.2",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Aligning release numbers for a `5.0.2` release

Ref: https://github.com/typeddjango/django-stubs/pull/2183#issuecomment-2133304665