### PR TITLE
Release workflow: publish `django-stubs-ext` before `django-stubs`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,29 +4,10 @@ on:
   release:
     types: [published]
 
-jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/p/django-stubs
-    permissions:
-      id-token: write
-    steps:
-      - name: Setup python to build package
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install build
-        run: python -m pip install build
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Build package
-        run: python -m build
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
 
+jobs:
   build-and-publish-ext:
     runs-on: ubuntu-latest
     environment:
@@ -50,3 +31,26 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           packages-dir: ext/dist/
+
+  build-and-publish:
+    runs-on: ubuntu-latest
+    needs: [build-and-publish-ext]
+    environment:
+      name: release
+      url: https://pypi.org/p/django-stubs
+    permissions:
+      id-token: write
+    steps:
+      - name: Setup python to build package
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build
+        run: python -m pip install build
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.14


### PR DESCRIPTION
Also set up a concurrency group, per release name, so that we don't run releases in parallel.

Refs:
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release
- https://docs.github.com/en/actions/using-jobs/using-concurrency
- #2183 
- From now on we're depending on solving #2187 to get _any_ automatic releasing