### PR TITLE
Expect a `QuerySet` for multiple defaults in `MultipleObjectMixin`

### DIFF
--- a/django-stubs/views/generic/list.pyi
+++ b/django-stubs/views/generic/list.pyi
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Any, Generic, TypeVar
 
 from django.core.paginator import Page, Paginator, _SupportsPagination
-from django.db.models import Model
+from django.db.models import Model, QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 
@@ -10,7 +10,7 @@ _M = TypeVar("_M", bound=Model, covariant=True)
 
 class MultipleObjectMixin(Generic[_M], ContextMixin):
     allow_empty: bool
-    queryset: _SupportsPagination[_M] | None
+    queryset: QuerySet[_M] | None
     model: type[_M] | None
     paginate_by: int | None
     paginate_orphans: int
@@ -18,12 +18,12 @@ class MultipleObjectMixin(Generic[_M], ContextMixin):
     paginator_class: type[Paginator]
     page_kwarg: str
     ordering: str | Sequence[str] | None
-    def get_queryset(self) -> _SupportsPagination[_M]: ...
+    def get_queryset(self) -> QuerySet[_M]: ...
     def get_ordering(self) -> str | Sequence[str] | None: ...
     def paginate_queryset(
         self, queryset: _SupportsPagination[_M], page_size: int
     ) -> tuple[Paginator, Page, _SupportsPagination[_M], bool]: ...
-    def get_paginate_by(self, queryset: _SupportsPagination[_M]) -> int | None: ...
+    def get_paginate_by(self, queryset: QuerySet[_M]) -> int | None: ...
     def get_paginator(
         self,
         queryset: _SupportsPagination[_M],

--- a/tests/typecheck/views/generic/test_list.yml
+++ b/tests/typecheck/views/generic/test_list.yml
@@ -48,5 +48,5 @@
                     ...
     out: |
       main:7: error: Incompatible types in assignment (expression has type "Type[MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[Type[Other]]")  [assignment]
-      main:8: error: Incompatible types in assignment (expression has type "QuerySet[MyModel, MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[_SupportsPagination[Other]]")  [assignment]
-      main:10: error: Return type "QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "_SupportsPagination[Other]" in supertype "MultipleObjectMixin"  [override]
+      main:8: error: Incompatible types in assignment (expression has type "QuerySet[MyModel, MyModel]", base class "MultipleObjectMixin" defined the type as "Optional[QuerySet[Other, Other]]")  [assignment]
+      main:10: error: Return type "QuerySet[MyModel, MyModel]" of "get_queryset" incompatible with return type "QuerySet[Other, Other]" in supertype "MultipleObjectMixin"  [override]


### PR DESCRIPTION
When `MultipleObjectMixin` adds a more specific type than "something that can be sliced" (i.e. `_SupportsPagination`) for default types of queryset attributes/arguments a couple of subclass views gets a better default behaviour.

The changes here go under the same argument as in https://github.com/typeddjango/django-stubs/pull/2174#issuecomment-2124394572

## Related issues

- Closes #1928 
- Refs #2174 