### PR TITLE
Model._meta.pk is non-None

### DIFF
--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -66,7 +66,7 @@ class Options(Generic[_M]):
     required_db_features: list[str]
     required_db_vendor: Literal["sqlite", "postgresql", "mysql", "oracle"] | None
     meta: type | None
-    pk: Field | None
+    pk: Field
     auto_field: AutoField | None
     abstract: bool
     managed: bool


### PR DESCRIPTION
django internals frequently reference (for example [this](https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/base.py#L655)) this as if it is always a field and looking at the source it is always set to some field during _prepare:

- https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/options.py#L302-L320
    - first branch through `setup_pk`: https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/options.py#L361-L362
    - second branch through:
        - add_to_class: https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/base.py#L371
        - contribute_to_class: https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/fields/__init__.py#L951
        - add_field: https://github.com/django/django/blob/e99187e5c94516ee35f37cc41a36d906b395808d/django/db/models/options.py#L337
        - (and then again setup_pk)
