### PR TITLE
Make plugin handle explicitly declared reverse descriptors for FKs

### DIFF
--- a/tests/assert_type/db/models/fields/test_related_descriptors.py
+++ b/tests/assert_type/db/models/fields/test_related_descriptors.py
@@ -1,0 +1,18 @@
+from typing import ClassVar
+
+from django.db import models
+from django.db.models.fields.related_descriptors import RelatedManager, ReverseManyToOneDescriptor
+from typing_extensions import assert_type
+
+
+class Other(models.Model):
+    explicit_descriptor: ClassVar[ReverseManyToOneDescriptor["MyModel"]]
+
+
+class MyModel(models.Model):
+    rel = models.ForeignKey[Other, Other](Other, on_delete=models.CASCADE, related_name="explicit_descriptor")
+
+
+# Pyright doesn't allow "runtime" usage of @type_check_only 'RelatedManager' but we're
+# only type checking these files so it should be fine.
+assert_type(Other().explicit_descriptor, RelatedManager[MyModel])  # pyright: ignore[reportGeneralTypeIssues]

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1035,6 +1035,36 @@
                 class Book(PrintedGood):
                     name = models.CharField()
 
+-   case: test_explicit_reverse_many_to_one_descriptor
+    main: |
+        from myapp.models import Other
+        reveal_type(Other.explicit_descriptor)  # N: Revealed type is "django.db.models.fields.related_descriptors.ReverseManyToOneDescriptor[myapp.models.MyModel]"
+        reveal_type(Other().explicit_descriptor)  # N: Revealed type is "myapp.models.MyModel_RelatedManager"
+        reveal_type(Other().explicit_descriptor.custom_method())  # N: Revealed type is "builtins.int"
+    installed_apps:
+        -   myapp
+    monkeypatch: true
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models/__init__.py
+            content: |
+                from typing import ClassVar
+                from django.db import models
+                from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
+
+                class Other(models.Model):
+                    explicit_descriptor: ClassVar[ReverseManyToOneDescriptor["MyModel"]]
+
+                class CustomManager(models.Manager["MyModel"]):
+                    def custom_method(self) -> int: ...
+
+                class MyModel(models.Model):
+                    rel = models.ForeignKey(
+                        Other, on_delete=models.CASCADE, related_name="explicit_descriptor"
+                    )
+
+                    objects = CustomManager()
+
 -   case: test_reverse_one_to_one_descriptor
     main: |
         from myapp.models import MyModel, Other


### PR DESCRIPTION
If a reverse descriptor was explicitly declared on a model, the plugin skipped to create a more specific subclass for its related manager.

Refs: #2227 