### PR TITLE
Do many related manager creation during semantic analysis

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -27,6 +27,13 @@ django.core.files.storage.default_storage
 django.contrib.admin.models.LogEntry_RelatedManager
 django.contrib.auth.models.Permission_RelatedManager
 
+# '<Model>_ManyRelatedManager' entries are plugin generated and these subclasses only exist
+# _locally/dynamically_ runtime -- Created via
+# 'django.db.models.fields.related_descriptors.create_forward_many_to_many_manager'
+django.contrib.auth.models.Group_ManyRelatedManager
+django.contrib.auth.models.Permission_ManyRelatedManager
+django.contrib.auth.models.User_ManyRelatedManager
+
 # BaseArchive abstract methods that take no argument, but typed with arguments to match the Archive and TarArchive Implementations
 django.utils.archive.BaseArchive.list
 django.utils.archive.BaseArchive.extract


### PR DESCRIPTION
When finding a `ManyToManyField` we can directly create 2 `ManyRelatedManager`s, one for each side of the relation. This makes the model declaring the `ManyToManyField` be the one who contributes the `ManyRelatedManager`s.

Trying to place some related code closer to each other. This time we move some code out of the type checking phase to semantic analysis.

Refs:
- #1805 
- #2026 