### PR TITLE
Add attributes set by application/middleware to `HttpRequest`

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -49,6 +49,7 @@ class HttpRequest(BytesIO):
     resolver_match: ResolverMatch | None
     content_type: str | None
     content_params: dict[str, str] | None
+    urlconf: str | None
     _body: bytes
     _stream: BinaryIO
     # Attributes added by optional parts of Django

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -54,6 +54,7 @@ class HttpRequest:
     resolver_match: ResolverMatch | None
     content_type: str | None
     content_params: dict[str, str] | None
+    urlconf: str | None
     _body: bytes
     _stream: BinaryIO
     # Attributes added by optional parts of Django

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -10,6 +10,7 @@ from django.core.files import uploadedfile, uploadhandler
 from django.urls import ResolverMatch
 from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, MultiValueDict
 from django.utils.functional import cached_property
+from django.views.debug import ExceptionReporter, SafeExceptionReporterFilter
 from typing_extensions import Self, TypeVar, override
 
 RAISE_ERROR: object
@@ -54,22 +55,25 @@ class HttpRequest:
     resolver_match: ResolverMatch | None
     content_type: str | None
     content_params: dict[str, str] | None
-    urlconf: str | None
     _body: bytes
     _stream: BinaryIO
-    # Attributes added by optional parts of Django
-    # django.contrib.admin views:
-    current_app: str
+    # Attributes set by middleware:
+    # https://docs.djangoproject.com/en/stable/ref/request-response/#attributes-set-by-middleware
+    # django.contrib.sessions.middleware.SessionMiddleware:
+    session: SessionBase
+    # django.contrib.sites.middleware.CurrentSiteMiddleware:
+    site: Site
     # django.contrib.auth.middleware.AuthenticationMiddleware:
     user: _AnyUser
-    # django.contrib.auth.middleware.AuthenticationMiddleware:
     auser: Callable[[], Awaitable[_AnyUser]]
     # django.middleware.locale.LocaleMiddleware:
     LANGUAGE_CODE: str
-    # django.contrib.sites.middleware.CurrentSiteMiddleware
-    site: Site
-    # django.contrib.sessions.middleware.SessionMiddleware
-    session: SessionBase
+    # Attributes set by application code:
+    # https://docs.djangoproject.com/en/stable/ref/request-response/#attributes-set-by-application-code
+    current_app: str
+    urlconf: str | None
+    exception_reporter_filter: SafeExceptionReporterFilter
+    exception_reporter_class: type[ExceptionReporter]
     def __init__(self) -> None: ...
     def get_host(self) -> str: ...
     def get_port(self) -> str: ...


### PR DESCRIPTION
# I have made things!

Ref the docs: https://docs.djangoproject.com/en/5.0/topics/http/urls/#how-django-processes-a-request

> Django determines the root URLconf module to use. Ordinarily, this is the value of the ROOT_URLCONF setting, but if the incoming HttpRequest object has a urlconf attribute (set by middleware), its value will be used in place of the ROOT_URLCONF setting.

## Related issues

N/A