### PR TITLE
don't copy magic or private methods in from_queryset managers

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -454,6 +454,10 @@ def populate_manager_from_queryset(manager_info: TypeInfo, queryset_info: TypeIn
         for name, sym in class_mro_info.names.items():
             if not isinstance(sym.node, (FuncDef, OverloadedFuncDef, Decorator)):
                 continue
+            # private, magic methods are not copied
+            # https://github.com/django/django/blob/5.0.4/django/db/models/manager.py#L101
+            elif name.startswith("_"):
+                continue
             # Insert the queryset method name as a class member. Note that the type of
             # the method is set as Any. Figuring out the type is the job of the
             # 'resolve_manager_method' attribute hook, which comes later.

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -791,6 +791,37 @@
 
               StrCallable = BaseManager.from_queryset(ModelQuerySet, class_name=str(1))
 
+-   case: queryset_inheritable_does_not_clobber_super_init
+    main: |
+        from myapp.models import BaseManager
+
+        reveal_type(BaseManager().ttl)  # N: Revealed type is "builtins.int"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+            from typing import Any, TYPE_CHECKING
+            from django.db import models
+            from django.db.models.manager import Manager
+            from django.db.models.query import QuerySet
+
+            if TYPE_CHECKING:
+                from django.db.models.manager import _T
+                from django.db.models.query import _Model, _Row
+
+            class MyQuerySet(QuerySet["_Model", "_Row"]):
+                def __init__(self, *a: Any, **k: Any) -> None:
+                    super().__init__(*a, **k)
+
+            _base = Manager.from_queryset(MyQuerySet)
+
+            class BaseManager(_base["_T"]):
+                def __init__(self, *a: Any, ttl: int = 0, **k: Any) -> None:
+                    self.ttl = ttl
+                    super().__init__(*a, **k)
+
 -   case: test_queryset_arg_as_unsupported_expressions
     main: |
         from typing import Union, Generic, TypeVar


### PR DESCRIPTION
failing before this change with:

```
_______________ queryset_inheritable_does_not_clobber_super_init _______________
/home/asottile/workspace/django-stubs/tests/typecheck/managers/querysets/test_from_queryset.yml:795: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Invalid output: 
E   Actual:
E     myapp/models:19: error: Unable to resolve return type of queryset/manager method  [misc] (diff)
E   Expected:
E     (empty)
```

the error came from inspecting `super().__init__(...)` in the manager, trying to look up queryset's `__init__`