### PR TITLE
walk mro for Field set type annotations

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -203,7 +203,7 @@ class DjangoContext:
         def get_field_set_type_from_model_type_info(info: Optional[TypeInfo], field_name: str) -> Optional[MypyType]:
             if info is None:
                 return None
-            field_node = info.names.get(field_name)
+            field_node = info.get(field_name)
             if field_node is None or not isinstance(field_node.type, Instance):
                 return None
             elif not field_node.type.args:

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -60,6 +60,27 @@
                 class Child4(Child1):
                     value4 = models.IntegerField()
 
+-   case: mro_is_walked_for_field_annotations
+    main: |
+        from myapp.models import Child
+        Child.objects.create(dct={"hello": "world"})  # no errors
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from __future__ import annotations
+
+                from django.db import models
+
+                class JSONField(models.TextField): pass  # incomplete
+
+                class Base(models.Model):
+                    dct: models.Field[dict[str, str], dict[str, str]] = JSONField()
+
+                class Child(Base): pass
+
 -   case: optional_id_fields_for_create_is_error_if_not_autofield
     main: |
         from myapp.models import Publisher, Book


### PR DESCRIPTION
test failed prior to this with:

```
_____________________ mro_is_walked_for_field_annotations ______________________
/home/asottile/workspace/django-stubs/tests/typecheck/models/test_create.yml:64: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Output is not expected: 
E   Actual:
E     main:2: error: Incompatible type for "dct" of "Child" (got "Dict[Any, Any]", expected "Union[str, Combinable]")  [misc] (diff)
E   Expected:
E     (empty)
```

test is a simplified example from sentry code