### PR TITLE
Add `serialized_aliases` parameter to `setup_databases` function in `django.test.utils`

### DIFF
--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -164,6 +164,7 @@ def setup_databases(
     debug_sql: bool = ...,
     parallel: int = ...,
     aliases: Mapping[str, Any] | None = ...,
+    serialized_aliases: Iterable[str] | None = ...,
     **kwargs: Any,
 ) -> list[tuple[BaseDatabaseWrapper, str, bool]]: ...
 def teardown_databases(

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1407,7 +1407,6 @@ django.test.testcases.SerializeMixin.tearDownClass
 django.test.testcases.SimpleTestCase.assertTemplateNotUsed
 django.test.testcases._AssertTemplateUsedContext.__init__
 django.test.testcases._AssertTemplateUsedContext.message
-django.test.utils.setup_databases
 django.urls.ResolverMatch.__iter__
 django.urls.conf.path
 django.urls.conf.re_path


### PR DESCRIPTION
# I have made things!

This PR adds a new parameter, `serialized_aliases`, to the `setup_databases` function in `django.test.utils` with an appropriate type hint.