### PR TITLE
Remove some unnecessary defer rounds

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -361,8 +361,8 @@ def create_manager_info_from_from_queryset_call(
     base_manager_info, queryset_info = call_expr.callee.expr.node, call_expr.args[0].node
     if (
         # Handle potentially forwarded types
-        not isinstance(base_manager_info, TypeInfo)
-        or not isinstance(queryset_info, TypeInfo)
+        base_manager_info is None
+        or queryset_info is None
         # In some cases, due to the way the semantic analyzer works, only
         # passed_queryset.name is available. But it should be analyzed again,
         # so this isn't a problem.
@@ -370,10 +370,12 @@ def create_manager_info_from_from_queryset_call(
     ):
         raise helpers.IncompleteDefnException
     elif (
+        not isinstance(base_manager_info, TypeInfo)
+        or not isinstance(queryset_info, TypeInfo)
         # Check that the from_queryset call is on a manager subclass and that a first
         # argument is a QuerySet subclass. Otherwise we've encountered a function call
         # that is not relevant for us
-        not base_manager_info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
+        or not base_manager_info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
         or not queryset_info.has_base(fullnames.QUERYSET_CLASS_FULLNAME)
     ):
         return None

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -338,14 +338,15 @@ class AddManagers(ModelClassInitializer):
 
             if manager_info is None:
                 # We couldn't find a manager type, see if we should create one
-                manager_info = self.create_manager_from_from_queryset(manager_name)
+                try:
+                    manager_info = self.create_manager_from_from_queryset(manager_name)
+                except helpers.IncompleteDefnException:
+                    incomplete_manager_defs.add(manager_name)
+                    continue
 
-            if manager_info is None:
-                incomplete_manager_defs.add(manager_name)
-                continue
-
-            manager_type = Instance(manager_info, [Instance(self.model_classdef.info, [])])
-            self.add_new_node_to_model_class(manager_name, manager_type, is_classvar=True)
+            if manager_info is not None:
+                manager_type = Instance(manager_info, [Instance(self.model_classdef.info, [])])
+                self.add_new_node_to_model_class(manager_name, manager_type, is_classvar=True)
 
         if incomplete_manager_defs:
             if not self.api.final_iteration:

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -748,9 +748,9 @@
                 class TransactionLog(models.Model):
                     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
     out: |
-        myapp/models:11: error: Could not resolve manager type for "myapp.models.Transaction.objects"  [django-manager-missing]
         myapp/models:13: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.TransactionLog]"
-        myapp/models:15: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Transaction]"
+        myapp/models:15: note: Revealed type is "django.db.models.manager.BaseManager[Any]"
+        myapp/models:16: error: "BaseManager[Any]" has no attribute "custom"  [attr-defined]
         myapp/models:16: note: Revealed type is "Any"
 
 

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -906,3 +906,10 @@
         main:12: error: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "<typing special form>"; expected "Type[QuerySet[Model, Model]]"  [arg-type]
         main:17: note: Revealed type is "Type[django.db.models.manager.Manager[django.db.models.base.Model]]"
         main:17: error: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "Type[NonQSGeneric[Any]]"; expected "Type[QuerySet[Model, Model]]"  [arg-type]
+
+-   case: test_from_queryset_handles_passed_a_non_queryset
+    main: |
+        from typing import Any
+        from django.db import models
+        class Invalid: ...
+        manager = models.Manager[Any].from_queryset(Invalid)  # E: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "Type[Invalid]"; expected "Type[QuerySet[Any, Any]]"  [arg-type]

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -519,7 +519,7 @@
                     reveal_type(user.bookingowner_set)
                     reveal_type(user.booking_set)
 
-                    # Check QuerySet methods on UnknownManager
+                    # Check QuerySet methods on unknown manager
                     reveal_type(Booking.objects.all)
                     reveal_type(Booking.objects.custom)
                     reveal_type(Booking.objects.all().filter)
@@ -539,30 +539,27 @@
     out: |
         myapp/models:13: error: Couldn't resolve related manager 'booking_set' for relation 'myapp.models.Booking.renter'.  [django-manager-missing]
         myapp/models:13: error: Couldn't resolve related manager 'bookingowner_set' for relation 'myapp.models.Booking.owner'.  [django-manager-missing]
-        myapp/models:20: error: Could not resolve manager type for "myapp.models.Booking.objects"  [django-manager-missing]
-        myapp/models:23: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.objects"  [django-manager-missing]
-        myapp/models:24: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.second_objects"  [django-manager-missing]
-        myapp/models:27: error: Could not resolve manager type for "myapp.models.AbstractUnresolvable.objects"  [django-manager-missing]
-        myapp/models:32: error: Could not resolve manager type for "myapp.models.InvisibleUnresolvable.objects"  [django-manager-missing]
         myapp/models:36: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
         myapp/models:37: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
-        myapp/models:39: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Booking]"
+        myapp/models:39: note: Revealed type is "django.db.models.manager.Manager[Any]"
         myapp/models:40: note: Revealed type is "django.db.models.manager.Manager[myapp.models.Booking]"
-        myapp/models:42: note: Revealed type is "myapp.models.UnknownManager[myapp.models.TwoUnresolvable]"
-        myapp/models:43: note: Revealed type is "myapp.models.UnknownManager[myapp.models.TwoUnresolvable]"
+        myapp/models:42: note: Revealed type is "django.db.models.manager.Manager[Any]"
+        myapp/models:43: note: Revealed type is "django.db.models.manager.Manager[Any]"
         myapp/models:44: note: Revealed type is "django.db.models.manager.Manager[myapp.models.TwoUnresolvable]"
-        myapp/models:46: note: Revealed type is "myapp.models.UnknownManager[myapp.models.InvisibleUnresolvable]"
+        myapp/models:46: note: Revealed type is "django.db.models.manager.Manager[Any]"
         myapp/models:47: note: Revealed type is "django.db.models.manager.Manager[myapp.models.InvisibleUnresolvable]"
         myapp/models:49: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Booking]"
         myapp/models:50: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Booking]"
-        myapp/models:53: note: Revealed type is "def () -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:53: note: Revealed type is "def () -> django.db.models.query.QuerySet[Any, Any]"
+        myapp/models:54: error: "Manager[Any]" has no attribute "custom"  [attr-defined]
         myapp/models:54: note: Revealed type is "Any"
-        myapp/models:55: note: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:55: note: Revealed type is "def (*args: Any, **kwargs: Any) -> django.db.models.query.QuerySet[Any, Any]"
+        myapp/models:56: error: "QuerySet[Any, Any]" has no attribute "custom"  [attr-defined]
         myapp/models:56: note: Revealed type is "Any"
-        myapp/models:57: note: Revealed type is "Union[myapp.models.Booking, None]"
-        myapp/models:58: note: Revealed type is "myapp.models.Booking"
-        myapp/models:59: note: Revealed type is "builtins.list[myapp.models.Booking]"
-        myapp/models:60: note: Revealed type is "builtins.list[myapp.models.Booking]"
+        myapp/models:57: note: Revealed type is "Union[Any, None]"
+        myapp/models:58: note: Revealed type is "Any"
+        myapp/models:59: note: Revealed type is "builtins.list[Any]"
+        myapp/models:60: note: Revealed type is "builtins.list[Any]"
         myapp/models:64: note: Revealed type is "def () -> django.db.models.query.QuerySet[myapp.models.Booking, myapp.models.Booking]"
         myapp/models:65: error: "RelatedManager[Booking]" has no attribute "custom"  [attr-defined]
         myapp/models:65: note: Revealed type is "Any"


### PR DESCRIPTION
Change so that we don't trigger unnecessary defer rounds during manager creation via the `from_queryset` method call.

Refs:
- #1044 
- #1023