### PR TITLE
Update `admin.sites._ViewType` bound to allow `StreamingHttpResponse`

### DIFF
--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -10,7 +10,7 @@ from django.core.checks import CheckMessage
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
 from django.http.request import HttpRequest
-from django.http.response import HttpResponse
+from django.http.response import HttpResponse, StreamingHttpResponse
 from django.template.response import TemplateResponse
 from django.urls import URLPattern, URLResolver
 from django.utils.functional import LazyObject, _StrOrPromise
@@ -25,7 +25,7 @@ else:
 
     all_sites: MutableSet[AdminSite]
 
-_ViewType = TypeVar("_ViewType", bound=Callable[..., HttpResponse])
+_ViewType = TypeVar("_ViewType", bound=Callable[..., HttpResponse | StreamingHttpResponse])
 _ModelT = TypeVar("_ModelT", bound=Model)
 _ActionCallback: TypeAlias = Callable[[ModelAdmin, HttpRequest, QuerySet], TemplateResponse | None]
 

--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -10,7 +10,7 @@ from django.core.checks import CheckMessage
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
 from django.http.request import HttpRequest
-from django.http.response import HttpResponse, StreamingHttpResponse
+from django.http.response import HttpResponse, HttpResponseBase
 from django.template.response import TemplateResponse
 from django.urls import URLPattern, URLResolver
 from django.utils.functional import LazyObject, _StrOrPromise
@@ -25,7 +25,7 @@ else:
 
     all_sites: MutableSet[AdminSite]
 
-_ViewType = TypeVar("_ViewType", bound=Callable[..., HttpResponse | StreamingHttpResponse])
+_ViewType = TypeVar("_ViewType", bound=Callable[..., HttpResponseBase])
 _ModelT = TypeVar("_ModelT", bound=Model)
 _ActionCallback: TypeAlias = Callable[[ModelAdmin, HttpRequest, QuerySet], TemplateResponse | None]
 


### PR DESCRIPTION
### Issue

From the [Django documentation](https://docs.djangoproject.com/en/5.0/ref/request-response/#streaminghttpresponse-objects):
> The `StreamingHttpResponse` is not a subclass of `HttpResponse` ...

Because of this, creating an admin view that returned a `StreamingHttpResponse` was causing the following Mypy error:

```
testing/admin.py:14: error: Value of type variable "_ViewType" of "admin_view" of "AdminSite" cannot be "Callable[[HttpRequest], StreamingHttpResponse]"  [type-var]
```

### Changes
This updates the admin `_ViewType` type-var bound to allow a Callable that can return ~a union of `HttpResponse | StreamingHttpResponse`~ `HttpResponseBase`.

After this update to the stubs file, the Mypy error is no longer reproducible.

---

I was not able to find any open issues related to this. This change can be tested using the following code snippets:
```python
# testing/models.py
from django.db import models


class Model(models.Model):
    pass
```
```python
# testing/admin.py
from __future__ import annotations

from django.contrib import admin
from django.http import HttpRequest, StreamingHttpResponse
from django.urls import URLPattern, path

from testing.models import Model


@admin.register(Model)
class Admin(admin.ModelAdmin[Model]):
    def get_urls(self) -> list[URLPattern]:
        return [
            path("_stream/", self.admin_site.admin_view(self.get_stream), name="get_stream"),
            *super().get_urls(),
        ]

    def get_stream(self, _request: HttpRequest) -> StreamingHttpResponse:
        return StreamingHttpResponse(("a", "b", "c"))
```

### Testing
I tested this manually by running Mypy before and after the change. 

I was **not** able to run `pytest` successfully before or after the change (388 failures with `ModuleNotFoundError: No module named 'scripts'`). 

I was **not** able to run `stubtest.sh` successfully before or after the change (1928 failures with `unused allowlist entry ...`).

All `pre-commit run --all-files` checks passed.