### PR TITLE
Allow single generic param for Field in ForeignKey

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -29,7 +29,7 @@ def resolve_relation(scope_model: type[Model], relation: str | type[Model]) -> s
 # __set__ value type
 _ST = TypeVar("_ST")
 # __get__ return type
-_GT = TypeVar("_GT")
+_GT = TypeVar("_GT", default=_ST)
 
 class RelatedField(FieldCacheMixin, Field[_ST, _GT]):
     one_to_many: bool

--- a/tests/typecheck/models/test_related_fields.yml
+++ b/tests/typecheck/models/test_related_fields.yml
@@ -142,3 +142,58 @@
 
         class Other(models.Model):
             field = models.ForeignKey(MyModel, related_name="others", on_delete=models.CASCADE)
+
+
+- case: test_related_fields_with_two_generic_parameters
+  main: |
+        from myapp.models import Address, School, Student
+        reveal_type(Student().school)  # N: Revealed type is "myapp.models.School"
+        reveal_type(Student().address)  # N: Revealed type is "myapp.models.Address"
+        s = Student()
+        s.school = School()
+        s.address = Address()
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class School(models.Model):
+            pass
+
+        class Address(models.Model):
+            pass
+
+        class Student(models.Model):
+            school = models.ForeignKey["School","School"](to="School", on_delete=models.CASCADE)
+            address = models.OneToOneField["Address","Address"](to="Address", on_delete=models.CASCADE)
+
+
+- case: test_related_fields_with_one_generic_parameter
+  expect_fail: True
+  main: |
+        from myapp.models import Address, School, Student
+        reveal_type(Student().school)  # N: Revealed type is "myapp.models.School"
+        reveal_type(Student().address)  # N: Revealed type is "myapp.models.Address"
+        s = Student()
+        s.school = School()
+        s.address = Address()
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class School(models.Model):
+            pass
+
+        class Address(models.Model):
+            pass
+
+        class Student(models.Model):
+            school = models.ForeignKey["School"](to="School", on_delete=models.CASCADE)
+            address = models.OneToOneField["Address"](to="Address", on_delete=models.CASCADE)


### PR DESCRIPTION
# Allow a less verbose specification of foreign keys

This set he default type of getter so that the user can choose to specify the foreign key using one or two generic params.

Recently, I've moved from django-types to django-stubs, and this modification allowed for a smooth transition.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

- Refs #579
- Refs  #1264  

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
