### PR TITLE
add missing type argument to `Paginator`

### DIFF
--- a/django-stubs/core/paginator.pyi
+++ b/django-stubs/core/paginator.pyi
@@ -51,12 +51,12 @@ class Paginator(Generic[_T]):
 class Page(Sequence[_T]):
     object_list: _SupportsPagination[_T]
     number: int
-    paginator: Paginator
+    paginator: Paginator[_T]
     def __init__(
         self,
         object_list: _SupportsPagination[_T],
         number: int,
-        paginator: Paginator,
+        paginator: Paginator[_T],
     ) -> None: ...
     @overload
     def __getitem__(self, index: int) -> _T: ...


### PR DESCRIPTION
# I have made things!

I didn't open an issue for this, but I can if desired. Just added a missing generic type to the `Paginator` for `Page`.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
