### PR TITLE
Prepare for a release `5.0.3`

### DIFF
--- a/ext/setup.py
+++ b/ext/setup.py
@@ -13,7 +13,7 @@ dependencies = [
 # It's fine to skip django-stubs-ext releases, but when doing a release, update this to newest django-stubs version.
 setup(
     name="django-stubs-ext",
-    version="5.0.2",
+    version="5.0.3",
     description="Monkey-patching and extensions for django-stubs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md") as f:
 dependencies = [
     "django",
     "asgiref",
-    "django-stubs-ext>=5.0.2",
+    "django-stubs-ext>=5.0.3",
     "tomli; python_version < '3.11'",
     # Types:
     "typing-extensions>=4.11.0",
@@ -39,7 +39,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="5.0.2",
+    version="5.0.3",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Time for `5.0.3`

## Related issues

Ref: https://github.com/typeddjango/django-stubs/pull/2269#issuecomment-2250690058
