### PR TITLE
Check model fields on filtering methods of queryset types

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -33,7 +33,6 @@ from mypy.plugin import (
     DynamicClassDefContext,
     FunctionContext,
     MethodContext,
-    SemanticAnalyzerPluginInterface,
 )
 from mypy.semanal import SemanticAnalyzer
 from mypy.types import AnyType, Instance, LiteralType, NoneTyp, TupleType, TypedDictType, TypeOfAny, UnionType
@@ -63,9 +62,7 @@ def get_django_metadata(model_info: TypeInfo) -> DjangoTypeMetadata:
     return cast(DjangoTypeMetadata, model_info.metadata.setdefault("django", {}))
 
 
-def get_django_metadata_bases(
-    model_info: TypeInfo, key: Literal["baseform_bases", "manager_bases", "queryset_bases"]
-) -> Dict[str, int]:
+def get_django_metadata_bases(model_info: TypeInfo, key: Literal["baseform_bases", "queryset_bases"]) -> Dict[str, int]:
     return get_django_metadata(model_info).setdefault(key, cast(Dict[str, int], {}))
 
 
@@ -420,13 +417,6 @@ def add_new_sym_for_info(
     var.is_inferred = True
     var.is_classvar = is_classvar
     info.names[name] = SymbolTableNode(MDEF, var, plugin_generated=True, no_serialize=no_serialize)
-
-
-def add_new_manager_base(api: SemanticAnalyzerPluginInterface, fullname: str) -> None:
-    sym = api.lookup_fully_qualified_or_none(fullnames.MANAGER_CLASS_FULLNAME)
-    if sym is not None and isinstance(sym.node, TypeInfo):
-        bases = get_django_metadata_bases(sym.node, "manager_bases")
-        bases[fullname] = 1
 
 
 def is_abstract_model(model: TypeInfo) -> bool:

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -324,9 +324,6 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
             ctx.api.defer()
         return
 
-    # So that the plugin will reparameterize the manager when it is constructed inside of a Model definition
-    helpers.add_new_manager_base(semanal_api, new_manager_info.fullname)
-
 
 def register_dynamically_created_manager(fullname: str, manager_name: str, manager_base: TypeInfo) -> None:
     manager_base.metadata.setdefault("from_queryset_managers", {})
@@ -557,9 +554,6 @@ def create_new_manager_class_from_as_manager_method(ctx: DynamicClassDefContext)
             manager_name=manager_class_name,
             manager_base=manager_base,
         )
-
-        # So that the plugin will reparameterize the manager when it is constructed inside of a Model definition
-        helpers.add_new_manager_base(semanal_api, new_manager_info.fullname)
 
     # Whenever `<QuerySet>.as_manager()` isn't called at class level, we want to ensure
     # that the variable is an instance of our generated manager. Instead of the return

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -934,7 +934,6 @@ class ProcessManyToManyFields(ModelClassInitializer):
         helpers.set_many_to_many_manager_info(
             to=model.type, derived_from="_default_manager", manager_info=related_manager_info
         )
-        helpers.add_new_manager_base(self.api, related_manager_info.fullname)
 
 
 class MetaclassAdjustments(ModelClassInitializer):

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -653,3 +653,20 @@
                         def get_instance(self) -> int:
                             pass
                     objects = MyManager()
+
+-   case: test_typechecks_filter_methods_of_queryset_type
+    main: |
+        from myapp.models import MyModel
+        MyModel.objects.filter(id=1).filter(invalid=1)  # E: Cannot resolve keyword 'invalid' into field. Choices are: id  [misc]
+        MyModel.objects.filter(id=1).get(invalid=1)  # E: Cannot resolve keyword 'invalid' into field. Choices are: id  [misc]
+        MyModel.objects.filter(id=1).exclude(invalid=1)  # E: Cannot resolve keyword 'invalid' into field. Choices are: id  [misc]
+        MyModel.objects.filter(id=1).create(invalid=1)  # E: Unexpected attribute "invalid" for model "MyModel"  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class MyModel(models.Model): ...


### PR DESCRIPTION
I noticed that we should check some methods on both `Manager` and `QuerySet` since the `Manager` class is a bit special as it is a type "merged" from `BaseManager` and `QuerySet`.

@sobolevn I think this could be a nice addition before releasing `5.0.3`, or what do you think?

Thinking that the use cases from the test included here aren't too foreign:

```python
MyModel.objects.filter(id=1).filter(invalid=1)
MyModel.objects.filter(id=1).get(invalid=1)
MyModel.objects.filter(id=1).exclude(invalid=1)
MyModel.objects.filter(id=1).create(invalid=1)
```