### PR TITLE
Fix type hints for `SimpleTestCase`

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -61,7 +61,6 @@ class SimpleTestCase(unittest.TestCase):
     client: Client
     async_client_class: type[AsyncClient]
     async_client: AsyncClient
-    allow_database_queries: bool
     # TODO: str -> Literal['__all__']
     databases: set[str] | str
     def __call__(self, result: unittest.TestResult | None = ...) -> None: ...
@@ -131,7 +130,7 @@ class SimpleTestCase(unittest.TestCase):
         count: int | None = ...,
     ) -> _AssertTemplateUsedContext | None: ...
     def assertTemplateNotUsed(
-        self, response: HttpResponseBase | str = ..., template_name: str | None = ..., msg_prefix: str = ...
+        self, response: HttpResponseBase | str | None = ..., template_name: str | None = ..., msg_prefix: str = ...
     ) -> _AssertTemplateNotUsedContext | None: ...
     def assertRaisesMessage(
         self, expected_exception: type[Exception], expected_message: str, *args: Any, **kwargs: Any

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -1308,7 +1308,6 @@ django.template.utils.EngineHandler.__init__
 django.templatetags.i18n.BlockTranslateNode.__init__
 django.templatetags.static.PrefixNode.__init__
 django.templatetags.static.StaticNode.__init__
-django.test.SimpleTestCase.assertTemplateNotUsed
 django.test.runner.DiscoverRunner.log
 django.test.runner.DiscoverRunner.reorder_by
 django.test.runner.DummyList
@@ -1347,7 +1346,6 @@ django.test.selenium.SeleniumTestCaseBase.selenium_hub
 django.test.testcases.LiveServerThread.__init__
 django.test.testcases.LiveServerThread.server_class
 django.test.testcases.SerializeMixin.tearDownClass
-django.test.testcases.SimpleTestCase.assertTemplateNotUsed
 django.test.testcases._AssertTemplateUsedContext.__init__
 django.test.testcases._AssertTemplateUsedContext.message
 django.urls.ResolverMatch.__iter__


### PR DESCRIPTION
- Remove deprecated attribute `allow_database_queries`
- Fix incorrect argument type hints for `assertTemplateNotUsed`

## Related issues

- Closes #759
