### PR TITLE
match Field TypeVar variance in models.fields.related

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -27,9 +27,9 @@ RECURSIVE_RELATIONSHIP_CONSTANT: Literal["self"]
 def resolve_relation(scope_model: type[Model], relation: str | type[Model]) -> str | type[Model]: ...
 
 # __set__ value type
-_ST = TypeVar("_ST")
+_ST = TypeVar("_ST", contravariant=True)
 # __get__ return type
-_GT = TypeVar("_GT", default=_ST)
+_GT = TypeVar("_GT", covariant=True, default=_ST)
 
 class RelatedField(FieldCacheMixin, Field[_ST, _GT]):
     one_to_many: bool

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -86,6 +86,29 @@
                                                   related_name='books')
                     publisher2 = models.ForeignKey(to=Publisher, related_name='books2', on_delete=models.CASCADE)
 
+-   case: foreign_key_subclass
+    main: |
+        from myapp.models import A
+        reveal_type(A.objects.get().b)  # N: Revealed type is "myapp.models.B"
+    installed_apps:
+        -   myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import TypeVar
+                from django.db import models
+
+                _ST = TypeVar("_ST", contravariant=True)
+                _GT = TypeVar("_GT", covariant=True)
+
+                class MyForeignKey(models.ForeignKey[_ST, _GT]): ...
+
+                class B(models.Model): ...
+
+                class A(models.Model):
+                    b = models.ForeignKey(B, on_delete=models.CASCADE)
+
 -   case: to_parameter_as_string_with_application_name__model_imported
     main: |
         from myapp2.models import Book


### PR DESCRIPTION
previously failing with:

```
_____________________________ foreign_key_subclass _____________________________
/home/asottile/workspace/django-stubs/tests/typecheck/fields/test_related.yml:90: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Invalid output: 
E   Actual:
E     myapp/models:7: error: Variance of TypeVar "_ST" incompatible with variance in parent type  [type-var] (diff)
E     myapp/models:7: error: Variance of TypeVar "_GT" incompatible with variance in parent type  [type-var] (diff)
E   Expected:
E     (empty)
```

I'm not sure how this wasn't a problem before 5.0.4 for us but it certainly is now!

I'm also surprised mypy doesn't report this same error for `related.pyi` itself -- there must be some special-cased rules that `.pyi` files don't have to follow