### PR TITLE
A workaround for #2299

### DIFF
--- a/django-stubs/contrib/contenttypes/fields.pyi
+++ b/django-stubs/contrib/contenttypes/fields.pyi
@@ -66,7 +66,7 @@ class GenericRel(ForeignObjectRel):
         limit_choices_to: dict[str, Any] | Callable[[], Any] | None = ...,
     ) -> None: ...
 
-class GenericRelation(ForeignObject):
+class GenericRelation(ForeignObject[Any, Any]):
     rel_class: Any
     mti_inherited: bool
     object_id_field_name: str


### PR DESCRIPTION
This is not a fix, but a workaround for https://github.com/typeddjango/django-stubs/issues/2299

We would need to add proper generic type params later.
