### PR TITLE
Run mypy with `--strict` on `assert_type` tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run pytest tests
         run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} tests
       - name: Run mypy on the test cases
-        run: mypy tests/assert_type
+        run: mypy --strict tests/assert_type
 
   stubtest:
     timeout-minutes: 10


### PR DESCRIPTION
I think we should because we can