### PR TITLE
Loosen bound on `CurrentSiteManager` manager type var

### DIFF
--- a/django-stubs/contrib/sites/managers.pyi
+++ b/django-stubs/contrib/sites/managers.pyi
@@ -1,9 +1,8 @@
 from typing import TypeVar
 
-from django.contrib.sites.models import Site
 from django.db import models
 
-_T = TypeVar("_T", bound=Site)
+_T = TypeVar("_T", bound=models.Model)
 
 class CurrentSiteManager(models.Manager[_T]):
     def __init__(self, field_name: str | None = ...) -> None: ...


### PR DESCRIPTION
The manager accepts any model. It's intended to work on the _relation_ __to__ `Site`, not the `Site` declaration itself

## Related issues

- Refs #2280 