### PR TITLE
Remove `BaseManager.cache` attribute

### DIFF
--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import AsyncIterator, Callable, Collection, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Generic, NoReturn, TypeVar, overload
 
 from django.db.models.base import Model
@@ -10,7 +10,6 @@ from typing_extensions import Self
 _T = TypeVar("_T", bound=Model, covariant=True)
 
 class BaseManager(Generic[_T]):
-    cache: Callable[[], Self]  # django-cacheops
     creation_counter: int
     auto_created: bool
     use_in_migrations: bool


### PR DESCRIPTION
It doesn't exist at runtime and, for some reason, sneaked in via #1873 

## Related issues

- Refs #1873 