### PR TITLE
Declare `ManyToManyField.description` a `_StrOrPromise`

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -242,7 +242,7 @@ _Through = TypeVar("_Through", bound=Model)
 _To = TypeVar("_To", bound=Model)
 
 class ManyToManyField(RelatedField[Any, Any], Generic[_To, _Through]):
-    description: str
+    description: _StrOrPromise
     has_null_arg: bool
     swappable: bool
 


### PR DESCRIPTION
The default set by Django is a translate:able string:

https://github.com/django/django/blob/617bcf611f3daa796e4054ba041089ece30a32fc/django/db/models/fields/related.py#L1342

## Related issues

- Refs #754 