### PR TITLE
Refactor support for `annotate` to utilise `mypy.types.Instance.extra_attrs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ class MyManager(models.Manager["MyModel"]):
 
 ### How do I annotate cases where I called QuerySet.annotate?
 
-Django-stubs provides a special type, `django_stubs_ext.WithAnnotations[Model]`, which indicates that the `Model` has
-been annotated, meaning it allows getting/setting extra attributes on the model instance.
+Django-stubs provides a special type, `django_stubs_ext.WithAnnotations[Model, <Annotations>]`, which indicates that
+the `Model` has been annotated, meaning it requires extra attributes on the model instance.
 
-Optionally, you can provide a `TypedDict` of these attributes,
-e.g. `WithAnnotations[MyModel, MyTypedDict]`, to specify which annotated attributes are present.
+You should provide a `TypedDict` of these attributes, e.g. `WithAnnotations[MyModel, MyTypedDict]`, to specify which
+annotated attributes are present.
 
 Currently, the mypy plugin can recognize that specific names were passed to `QuerySet.annotate` and
 include them in the type, but does not record the types of these attributes.
@@ -235,21 +235,11 @@ class MyModel(models.Model):
     username = models.CharField(max_length=100)
 
 
-def func(m: WithAnnotations[MyModel]) -> str:
-    return m.asdf  # OK, since the model is annotated as allowing any attribute
-
-
-func(MyModel.objects.annotate(foo=Value("")).get(id=1))  # OK
-func(
-    MyModel.objects.get(id=1)
-)  # Error, since this model will not allow access to any attribute
-
-
 class MyTypedDict(TypedDict):
     foo: str
 
 
-def func2(m: WithAnnotations[MyModel, MyTypedDict]) -> str:
+def func(m: WithAnnotations[MyModel, MyTypedDict]) -> str:
     print(m.bar)  # Error, since field "bar" is not in MyModel or MyTypedDict.
     return m.foo  # OK, since we said field "foo" was allowed
 

--- a/ext/django_stubs_ext/annotations.py
+++ b/ext/django_stubs_ext/annotations.py
@@ -17,7 +17,7 @@ _T = TypeVar("_T", bound=Model)
 
 WithAnnotations = Annotated[_T, Annotations[_Annotations]]
 """Alias to make it easy to annotate the model `_T` as having annotations
-`_Annotations` (a `TypedDict` or `Any` if not provided).
+`_Annotations` (a `TypedDict`).
 
-Use as `WithAnnotations[MyModel]` or `WithAnnotations[MyModel, MyTypedDict]`.
+Use as `WithAnnotations[MyModel, MyTypedDict]`.
 """

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -36,7 +36,6 @@ from mypy.types import Type as MypyType
 
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
-from mypy_django_plugin.lib.fullnames import WITH_ANNOTATIONS_FULLNAME
 
 # This import fails when `psycopg2` is not installed, avoid crashing the plugin.
 try:
@@ -142,15 +141,6 @@ class DjangoContext:
 
     def get_model_class_by_fullname(self, fullname: str) -> Optional[Type[Model]]:
         """Returns None if Model is abstract"""
-        annotated_prefix = WITH_ANNOTATIONS_FULLNAME + "["
-        if fullname.startswith(annotated_prefix):
-            # For our "annotated models", extract the original model fullname
-            fullname = fullname[len(annotated_prefix) :].rstrip("]")
-            if "," in fullname:
-                # Remove second type arg, which might be present
-                fullname = fullname[: fullname.index(",")]
-            fullname = fullname.replace("__", ".")
-
         module, _, model_cls_name = fullname.rpartition(".")
         return self.model_modules.get(module, {}).get(model_cls_name)
 

--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -19,7 +19,7 @@ BASE_MANAGER_CLASS_FULLNAME = "django.db.models.manager.BaseManager"
 MANAGER_CLASS_FULLNAME = "django.db.models.manager.Manager"
 RELATED_MANAGER_CLASS = "django.db.models.fields.related_descriptors.RelatedManager"
 
-WITH_ANNOTATIONS_FULLNAME = "django_stubs_ext.WithAnnotations"
+WITH_ANNOTATIONS_FULLNAME = "django_stubs_ext.annotations.WithAnnotations"
 ANNOTATIONS_FULLNAME = "django_stubs_ext.annotations.Annotations"
 
 BASEFORM_CLASS_FULLNAME = "django.forms.forms.BaseForm"

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -296,7 +296,7 @@ class NewSemanalDjangoPlugin(Plugin):
             "typing_extensions.Annotated",
             "django_stubs_ext.annotations.WithAnnotations",
         ):
-            return partial(handle_annotated_type, django_context=self.django_context)
+            return partial(handle_annotated_type, fullname=fullname)
         else:
             return None
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -22,19 +22,29 @@ from mypy.nodes import (
     TypeInfo,
     Var,
 )
-from mypy.plugin import AnalyzeTypeContext, AttributeContext, CheckerPluginInterface, ClassDefContext
+from mypy.plugin import AnalyzeTypeContext, AttributeContext, ClassDefContext
 from mypy.plugins import common
 from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
-from mypy.types import AnyType, Instance, ProperType, TypedDictType, TypeOfAny, TypeType, TypeVarType, get_proper_type
+from mypy.types import (
+    AnyType,
+    ExtraAttrs,
+    Instance,
+    ProperType,
+    TypedDictType,
+    TypeOfAny,
+    TypeType,
+    TypeVarType,
+    get_proper_type,
+)
 from mypy.types import Type as MypyType
-from mypy.typevars import fill_typevars
+from mypy.typevars import fill_typevars, fill_typevars_with_any
 
 from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.errorcodes import MANAGER_MISSING
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
-from mypy_django_plugin.lib.fullnames import ANNOTATIONS_FULLNAME, ANY_ATTR_ALLOWED_CLASS_FULLNAME, MODEL_CLASS_FULLNAME
+from mypy_django_plugin.lib.fullnames import ANNOTATIONS_FULLNAME, MODEL_CLASS_FULLNAME
 from mypy_django_plugin.transformers.fields import FieldDescriptorTypes, get_field_descriptor_types
 from mypy_django_plugin.transformers.managers import (
     MANAGER_METHODS_RETURNING_QUERYSET,
@@ -198,6 +208,50 @@ class ModelClassInitializer:
 
     def run_with_model_cls(self, model_cls: Type[Model]) -> None:
         raise NotImplementedError(f"Implement this in subclass {self.__class__.__name__}")
+
+
+class AddAnnotateUtilities(ModelClassInitializer):
+    """
+    Creates a model subclass that will be used when the model's manager/queryset calls
+    'annotate' to hold on to attributes that Django adds to a model instance.
+
+    Example:
+
+        class MyModel(models.Model):
+            ...
+
+        class MyModel_AnnotatedWith(MyModel, django_stubs_ext.Annotations[_Annotations]):
+            ...
+    """
+
+    def run(self) -> None:
+        annotations = self.lookup_typeinfo_or_incomplete_defn_error("django_stubs_ext.Annotations")
+        object_does_not_exist = self.lookup_typeinfo_or_incomplete_defn_error(fullnames.OBJECT_DOES_NOT_EXIST)
+        multiple_objects_returned = self.lookup_typeinfo_or_incomplete_defn_error(fullnames.MULTIPLE_OBJECTS_RETURNED)
+        annotated_model_name = self.model_classdef.info.name + "_AnnotatedWith"
+        annotated_model = self.lookup_typeinfo(self.model_classdef.info.module_name + "." + annotated_model_name)
+        if annotated_model is None:
+            model_type = fill_typevars_with_any(self.model_classdef.info)
+            assert isinstance(model_type, Instance)
+            annotations_type = fill_typevars(annotations)
+            assert isinstance(annotations_type, Instance)
+            annotated_model = self.add_new_class_for_current_module(
+                annotated_model_name, bases=[model_type, annotations_type]
+            )
+            annotated_model.defn.type_vars = annotations.defn.type_vars
+            annotated_model.add_type_vars()
+            helpers.mark_as_annotated_model(annotated_model)
+            if self.is_model_abstract:
+                # Below are abstract attributes, and in a stub file mypy requires
+                # explicit ABCMeta if not all abstract attributes are implemented i.e.
+                # class is kept abstract. So we add the attributes to get mypy off our
+                # back
+                helpers.add_new_sym_for_info(
+                    annotated_model, "DoesNotExist", TypeType(Instance(object_does_not_exist, []))
+                )
+                helpers.add_new_sym_for_info(
+                    annotated_model, "MultipleObjectsReturned", TypeType(Instance(multiple_objects_returned, []))
+                )
 
 
 class InjectAnyAsBaseForNestedMeta(ModelClassInitializer):
@@ -1034,6 +1088,7 @@ class MetaclassAdjustments(ModelClassInitializer):
 
 def process_model_class(ctx: ClassDefContext, django_context: DjangoContext) -> None:
     initializers = [
+        AddAnnotateUtilities,
         InjectAnyAsBaseForNestedMeta,
         AddDefaultPrimaryKey,
         AddPrimaryKeyAlias,
@@ -1059,8 +1114,11 @@ def set_auth_user_model_boolean_fields(ctx: AttributeContext, django_context: Dj
     return Instance(boolinfo, [])
 
 
-def handle_annotated_type(ctx: AnalyzeTypeContext, django_context: DjangoContext) -> MypyType:
+def handle_annotated_type(ctx: AnalyzeTypeContext, fullname: str) -> MypyType:
+    is_with_annotations = fullname == fullnames.WITH_ANNOTATIONS_FULLNAME
     args = ctx.type.args
+    if not args:
+        return AnyType(TypeOfAny.from_omitted_generics) if is_with_annotations else ctx.type
     type_arg = ctx.api.analyze_type(args[0])
     if not isinstance(type_arg, Instance) or not type_arg.type.has_base(MODEL_CLASS_FULLNAME):
         return type_arg
@@ -1068,7 +1126,7 @@ def handle_annotated_type(ctx: AnalyzeTypeContext, django_context: DjangoContext
     fields_dict = None
     if len(args) > 1:
         second_arg_type = get_proper_type(ctx.api.analyze_type(args[1]))
-        if isinstance(second_arg_type, TypedDictType):
+        if isinstance(second_arg_type, TypedDictType) and is_with_annotations:
             fields_dict = second_arg_type
         elif isinstance(second_arg_type, Instance) and second_arg_type.type.fullname == ANNOTATIONS_FULLNAME:
             annotations_type_arg = get_proper_type(second_arg_type.args[0])
@@ -1076,14 +1134,19 @@ def handle_annotated_type(ctx: AnalyzeTypeContext, django_context: DjangoContext
                 fields_dict = annotations_type_arg
             elif not isinstance(annotations_type_arg, AnyType):
                 ctx.api.fail("Only TypedDicts are supported as type arguments to Annotations", ctx.context)
+            elif annotations_type_arg.type_of_any == TypeOfAny.from_omitted_generics:
+                ctx.api.fail("Missing required TypedDict parameter for generic type Annotations", ctx.context)
+
+    if fields_dict is None:
+        return type_arg
 
     assert isinstance(ctx.api, TypeAnalyser)
     assert isinstance(ctx.api.api, SemanticAnalyzer)
-    return get_or_create_annotated_type(ctx.api.api, type_arg, fields_dict=fields_dict)
+    return get_annotated_type(ctx.api.api, type_arg, fields_dict=fields_dict)
 
 
-def get_or_create_annotated_type(
-    api: Union[SemanticAnalyzer, CheckerPluginInterface], model_type: Instance, fields_dict: Optional[TypedDictType]
+def get_annotated_type(
+    api: Union[SemanticAnalyzer, TypeChecker], model_type: Instance, fields_dict: TypedDictType
 ) -> ProperType:
     """
 
@@ -1094,42 +1157,31 @@ def get_or_create_annotated_type(
     If the user wanted to annotate their code using this type, then this is the annotation they would use.
     This is a bit of a hack to make a pretty type for error messages and which would make sense for users.
     """
-    model_module_name = "django_stubs_ext"
-
-    if helpers.is_annotated_model_fullname(model_type.type.fullname):
-        # If it's already a generated class, we want to use the original model as a base
-        model_type = model_type.type.bases[0]
-
-    if fields_dict is not None:
-        type_name = f"WithAnnotations[{model_type.type.fullname.replace('.', '__')}, {fields_dict}]"
-    else:
-        type_name = f"WithAnnotations[{model_type.type.fullname.replace('.', '__')}]"
-
-    annotated_typeinfo = helpers.lookup_fully_qualified_typeinfo(
-        cast(TypeChecker, api), model_module_name + "." + type_name
-    )
-    if annotated_typeinfo is None:
-        model_module_file = api.modules.get(model_module_name)  # type: ignore[union-attr]
-        if model_module_file is None:
-            return AnyType(TypeOfAny.from_error)
-
-        if isinstance(api, SemanticAnalyzer):
-            annotated_model_type = api.named_type_or_none(ANY_ATTR_ALLOWED_CLASS_FULLNAME, [])
-            assert annotated_model_type is not None
-        else:
-            annotated_model_type = api.named_generic_type(ANY_ATTR_ALLOWED_CLASS_FULLNAME, [])
-
-        annotated_typeinfo = helpers.add_new_class_for_module(
-            model_module_file,
-            type_name,
-            bases=[model_type] if fields_dict is not None else [model_type, annotated_model_type],
-            fields=fields_dict.items if fields_dict is not None else None,
-            no_serialize=True,
+    if model_type.extra_attrs:
+        extra_attrs = ExtraAttrs(
+            attrs={**model_type.extra_attrs.attrs, **(fields_dict.items if fields_dict is not None else {})},
+            immutable=model_type.extra_attrs.immutable.copy(),
+            mod_name=None,
         )
-        if fields_dict is not None:
-            # To allow structural subtyping, make it a Protocol
-            annotated_typeinfo.is_protocol = True
-            # Save for later to easily find which field types were annotated
-            annotated_typeinfo.metadata["annotated_field_types"] = fields_dict.items
-    annotated_type = Instance(annotated_typeinfo, [])
-    return annotated_type
+    else:
+        extra_attrs = ExtraAttrs(
+            attrs=fields_dict.items if fields_dict is not None else {},
+            immutable=None,
+            mod_name=None,
+        )
+
+    annotated_model: Optional[TypeInfo]
+    if helpers.is_annotated_model(model_type.type):
+        annotated_model = model_type.type
+        if model_type.args and isinstance(model_type.args[0], TypedDictType):
+            fields_dict = helpers.make_typeddict(
+                api,
+                fields={**model_type.args[0].items, **fields_dict.items},
+                required_keys={*model_type.args[0].required_keys, *fields_dict.required_keys},
+            )
+    else:
+        annotated_model = helpers.lookup_fully_qualified_typeinfo(api, model_type.type.fullname + "_AnnotatedWith")
+
+    if annotated_model is None:
+        return model_type
+    return Instance(annotated_model, [fields_dict], extra_attrs=extra_attrs)

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -5,7 +5,6 @@ from mypy.types import Type as MypyType
 from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
-from mypy_django_plugin.lib.helpers import is_annotated_model_fullname
 
 
 def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
@@ -33,13 +32,10 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
             provided_type = resolve_combinable_type(provided_type, django_context)
 
         lookup_type: MypyType
-        if is_annotated_model_fullname(model_cls_fullname):
-            lookup_type = AnyType(TypeOfAny.implementation_artifact)
-        else:
-            try:
-                lookup_type = django_context.resolve_lookup_expected_type(ctx, model_cls, lookup_kwarg)
-            except UnregisteredModelError:
-                lookup_type = AnyType(TypeOfAny.from_error)
+        try:
+            lookup_type = django_context.resolve_lookup_expected_type(ctx, model_cls, lookup_kwarg)
+        except UnregisteredModelError:
+            lookup_type = AnyType(TypeOfAny.from_error)
         # Managers as provided_type is not supported yet
         if isinstance(provided_type, Instance) and helpers.has_any_of_bases(
             provided_type.type, (fullnames.MANAGER_CLASS_FULLNAME, fullnames.QUERYSET_CLASS_FULLNAME)

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -15,8 +15,8 @@ from mypy.typevars import fill_typevars
 from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
 from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.lib.fullnames import ANY_ATTR_ALLOWED_CLASS_FULLNAME
-from mypy_django_plugin.lib.helpers import is_annotated_model_fullname, parse_bool
-from mypy_django_plugin.transformers.models import get_or_create_annotated_type
+from mypy_django_plugin.lib.helpers import parse_bool
+from mypy_django_plugin.transformers.models import get_annotated_type
 
 
 def _extract_model_type_from_queryset(queryset_type: Instance, api: TypeChecker) -> Optional[Instance]:
@@ -177,7 +177,12 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
     if model_type is None:
         return AnyType(TypeOfAny.from_omitted_generics)
 
-    model_cls = django_context.get_model_class_by_fullname(model_type.type.fullname)
+    is_annotated = helpers.is_annotated_model(model_type.type)
+    model_cls = (
+        django_context.get_model_class_by_fullname(model_type.type.bases[0].type.fullname)
+        if is_annotated
+        else django_context.get_model_class_by_fullname(model_type.type.fullname)
+    )
     if model_cls is None:
         return default_return_type
 
@@ -201,7 +206,6 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
     flat = flat or False
     named = named or False
 
-    is_annotated = is_annotated_model_fullname(model_type.type.fullname)
     row_type = get_values_list_row_type(
         ctx, django_context, model_cls, is_annotated=is_annotated, flat=flat, named=named
     )
@@ -237,25 +241,48 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
     if model_type is None:
         return AnyType(TypeOfAny.from_omitted_generics)
 
-    api = ctx.api
+    api = helpers.get_typechecker_api(ctx)
 
-    field_types = model_type.type.metadata.get("annotated_field_types")
+    field_types: Optional[Dict[str, MypyType]] = None
     kwargs = gather_kwargs(ctx)
     if kwargs:
         # For now, we don't try to resolve the output_field of the field would be, but use Any.
-        added_field_types = {name: AnyType(TypeOfAny.implementation_artifact) for name, typ in kwargs.items()}
-        if field_types is not None:
-            # Annotate was called more than once, so add/update existing field types
-            field_types.update(added_field_types)
-        else:
-            field_types = added_field_types
+        # NOTE: It's important that we use 'special_form' for 'Any' as otherwise we can
+        # get stuck with mypy interpreting an overload ambiguity towards the
+        # overloaded 'Field.__get__' method when its 'model' argument gets matched. This
+        # is because the model argument gets matched with a model subclass that is
+        # parametrized with a type that contains the 'Any' below and then mypy runs in
+        # to a (false?) ambiguity, due to 'Any', and can't decide what overload/return
+        # type to select
+        #
+        # Example:
+        #   class MyModel(models.Model):
+        #       field = models.CharField()
+        #
+        #   # Our plugin auto generates the following subclass
+        #   class MyModel_WithAnnotations(MyModel, django_stubs_ext.Annotations[_Annotations]):
+        #       ...
+        #   # Assume
+        #   x = MyModel.objects.annotate(foo=F("id")).get()
+        #   reveal_type(x)  # MyModel_WithAnnotations[TypedDict({"foo": Any})]
+        #   # Then, on an attribute access of 'field' like
+        #   reveal_type(x.field)
+        #
+        # Now 'CharField.__get__', which is overloaded, is passed 'x' as the 'model'
+        # argument and mypy consider it ambiguous to decide which overload method to
+        # select due to the 'Any' in 'TypedDict({"foo": Any})'. But if we specify the
+        # 'Any' as 'TypeOfAny.special_form' mypy doesn't consider the model instance to
+        # contain 'Any' and the ambiguity goes away.
+        field_types = {name: AnyType(TypeOfAny.special_form) for name, _ in kwargs.items()}
 
     fields_dict = None
     if field_types is not None:
-        fields_dict = helpers.make_typeddict(
-            api, fields=OrderedDict(field_types), required_keys=set(field_types.keys())
-        )
-    annotated_type = get_or_create_annotated_type(api, model_type, fields_dict=fields_dict)
+        fields_dict = helpers.make_typeddict(api, fields=field_types, required_keys=set(field_types.keys()))
+
+    if fields_dict is not None:
+        annotated_type = get_annotated_type(api, model_type, fields_dict=fields_dict)
+    else:
+        annotated_type = model_type
 
     row_type: MypyType
     if len(default_return_type.args) > 1:
@@ -306,9 +333,6 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
 
     model_cls = django_context.get_model_class_by_fullname(model_type.type.fullname)
     if model_cls is None:
-        return default_return_type
-
-    if is_annotated_model_fullname(model_type.type.fullname):
         return default_return_type
 
     field_lookups = resolve_field_lookups(ctx.args[0], django_context)

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -450,3 +450,25 @@ django.contrib.gis.db.models.ManyToManyField.m2m_target_field_name
 
 # Defined inside a signature (using the walrus operator)
 django.core.management.utils.sentinel
+
+# Plugin generated model instances for '.annotate' support
+django.contrib.admin.models.LogEntry@AnnotatedWith
+django.contrib.auth.base_user.AbstractBaseUser@AnnotatedWith
+django.contrib.auth.models.AbstractUser@AnnotatedWith
+django.contrib.auth.models.Group@AnnotatedWith
+django.contrib.auth.models.Permission@AnnotatedWith
+django.contrib.auth.models.PermissionsMixin@AnnotatedWith
+django.contrib.auth.models.User@AnnotatedWith
+django.contrib.contenttypes.models.ContentType@AnnotatedWith
+django.contrib.flatpages.models.FlatPage@AnnotatedWith
+django.contrib.gis.db.backends.oracle.models.OracleGeometryColumns@AnnotatedWith
+django.contrib.gis.db.backends.oracle.models.OracleSpatialRefSys@AnnotatedWith
+django.contrib.gis.db.backends.postgis.models.PostGISGeometryColumns@AnnotatedWith
+django.contrib.gis.db.backends.postgis.models.PostGISSpatialRefSys@AnnotatedWith
+django.contrib.gis.db.backends.spatialite.models.SpatialiteGeometryColumns@AnnotatedWith
+django.contrib.gis.db.backends.spatialite.models.SpatialiteSpatialRefSys@AnnotatedWith
+django.contrib.redirects.models.Redirect@AnnotatedWith
+django.contrib.sessions.base_session.AbstractBaseSession@AnnotatedWith
+django.contrib.sessions.models.Session@AnnotatedWith
+django.contrib.sites.models.Site@AnnotatedWith
+django.db.migrations.recorder.Migration@AnnotatedWith

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -8,20 +8,31 @@
 
         unannotated_user = User.objects.get(id=1)
 
-        print(annotated_user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "asdf"  [attr-defined]
+        print(annotated_user.asdf) # E: "User_AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "asdf"  [attr-defined]
         print(unannotated_user.asdf) # E: "User" has no attribute "asdf"  [attr-defined]
 
-        def func(user: Annotated[User, Annotations]) -> str:
-            return user.asdf
+        def func(user: Annotated[User, Annotations]) -> str:  # E: Missing required TypedDict parameter for generic type Annotations  [misc]
+            return user.asdf  # E: "User" has no attribute "asdf"  [attr-defined]
 
-        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
-        func(annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
+        # Due to the error on 'func' it should fall back to expecting 'User'
+        reveal_type(func)  # N: Revealed type is "def (user: myapp.models.User) -> builtins.str"
+        func(unannotated_user)
+        func(annotated_user)
 
         def func2(user: WithAnnotations[User]) -> str:
-            return user.asdf
+            return user.asdf  # E: "User" has no attribute "asdf"  [attr-defined]
 
-        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
-        func2(annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"; expected "WithAnnotations[myapp__models__User]"  [arg-type]
+        # With only one argument to 'WithAnnotations' it should fall back to expecting 'User'
+        reveal_type(func2)  # N: Revealed type is "def (user: myapp.models.User) -> builtins.str"
+        func2(unannotated_user)
+        func2(annotated_user)
+
+        def func3(user: WithAnnotations) -> str: ...
+
+        # With no arguments to 'WithAnnotations' it should become 'Any'
+        reveal_type(func3)  # N: Revealed type is "def (user: Any) -> builtins.str"
+        func3(unannotated_user)
+        func3(annotated_user)
     installed_apps:
         - myapp
     files:
@@ -44,26 +55,28 @@
             foo: str
 
         def func(user: Annotated[User, Annotations[MyDict]]) -> str:
-            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"  [attr-defined]
+            print(user.asdf) # E: "User_AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
         unannotated_user = User.objects.get(id=1)
         annotated_user = User.objects.annotate(foo=Value("")).get()
         other_annotated_user = User.objects.annotate(other=Value("")).get()
 
-        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
+        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
         x: WithAnnotations[User]
-        func(x)
+        # Declaring nothing annotated returns a user
+        reveal_type(x)  # N: Revealed type is "myapp.models.User"
+        func(x)  # E: Argument 1 to "func" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
         func(annotated_user)
-        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
+        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "User_AnnotatedWith[TypedDict({'other': Any})]"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
 
         def func2(user: WithAnnotations[User, MyDict]) -> str:
-            print(user.asdf) # E: "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]" has no attribute "asdf"  [attr-defined]
+            print(user.asdf) # E: "User_AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
-        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
+        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
         func2(annotated_user)
-        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "WithAnnotations[myapp__models__User, TypedDict({'other': Any})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.MyDict', {'foo': builtins.str})]"  [arg-type]
+        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "User_AnnotatedWith[TypedDict({'other': Any})]"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
     installed_apps:
         - myapp
     files:
@@ -100,7 +113,7 @@
         func(y)
 
         z: WithAnnotations[User, OtherDict]
-        func(z) # E: Argument 1 to "func" has incompatible type "WithAnnotations[myapp__models__User, TypedDict('main.OtherDict', {'other': builtins.str})]"; expected "WithAnnotations[myapp__models__User, TypedDict('main.NarrowDict', {'foo': builtins.str})]"  [arg-type]
+        func(z) # E: Argument 1 to "func" has incompatible type "User_AnnotatedWith[OtherDict]"; expected "User_AnnotatedWith[NarrowDict]"  [arg-type]
 
     installed_apps:
         - myapp
@@ -119,12 +132,12 @@
         from django.db.models.expressions import F
 
         qs = User.objects.annotate(foo=F('id'))
-        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__User, TypedDict({'foo': Any})], django_stubs_ext.WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]]"
+        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})], myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})]]"
 
         annotated = qs.get()
-        reveal_type(annotated) # N: Revealed type is "django_stubs_ext.WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]"
+        reveal_type(annotated) # N: Revealed type is "myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})]"
         reveal_type(annotated.foo) # N: Revealed type is "Any"
-        print(annotated.bar) # E: "WithAnnotations[myapp__models__User, TypedDict({'foo': Any})]" has no attribute "bar"  [attr-defined]
+        print(annotated.bar) # E: "User_AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "bar"  [attr-defined]
         reveal_type(annotated.username) # N: Revealed type is "builtins.str"
 
     installed_apps:
@@ -144,7 +157,7 @@
         from django.db.models import Count
 
         qs = User.objects.annotate(Count('id'))
-        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__User], django_stubs_ext.WithAnnotations[myapp__models__User]]"
+        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User, myapp.models.User]"
 
     installed_apps:
         - myapp
@@ -166,8 +179,8 @@
 
         def animals_only(param: Animal) -> None:
             pass
-        # Make sure that even though attr access falls back to Any, the type is still checked
-        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "WithAnnotations[myapp__models__User]"; expected "Animal"  [arg-type]
+        # Make sure that the type is still checked when no annotation was produced
+        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "User"; expected "Animal"  [arg-type]
 
         def users_allowed(param: User) -> None:
             # But this function accepts only the original User type, so any attr access is not allowed within this function
@@ -196,7 +209,7 @@
         qs = User.objects.annotate(foo=F('id'))
         qs = qs.annotate(bar=F('id'))
         annotated = qs.get()
-        reveal_type(annotated) # N: Revealed type is "django_stubs_ext.WithAnnotations[myapp__models__User, TypedDict({'foo': Any, 'bar': Any})]"
+        reveal_type(annotated) # N: Revealed type is "myapp.models.User_AnnotatedWith[TypedDict({'foo': Any, 'bar': Any})]"
         reveal_type(annotated.foo) # N: Revealed type is "Any"
         reveal_type(annotated.bar) # N: Revealed type is "Any"
         reveal_type(annotated.username) # N: Revealed type is "builtins.str"
@@ -227,11 +240,11 @@
           return qs.annotate(foo=F('id'))
 
         def add_wrong_annotation(qs: QuerySet[User]) -> QuerySet[WithAnnotations[User, FooDict]]:
-          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "QuerySet[WithAnnotations[myapp__models__User, TypedDict({'bar': Any})], WithAnnotations[myapp__models__User, TypedDict({'bar': Any})]]", expected "QuerySet[WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})], WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]]")  [return-value]
+          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "QuerySet[User_AnnotatedWith[TypedDict({'bar': Any})], User_AnnotatedWith[TypedDict({'bar': Any})]]", expected "QuerySet[User_AnnotatedWith[FooDict], User_AnnotatedWith[FooDict]]")  [return-value]
 
         qs = add_annotation(qs)
-        qs.get().foo
-        qs.get().bar # E: "WithAnnotations[myapp__models__User, TypedDict('main.FooDict', {'foo': builtins.str})]" has no attribute "bar"  [attr-defined]
+        reveal_type(qs.get().foo)  # N: Revealed type is "builtins.str"
+        qs.get().bar # E: "User_AnnotatedWith[FooDict]" has no attribute "bar"  [attr-defined]
 
     installed_apps:
         - myapp
@@ -308,9 +321,9 @@
         # It's possible to provide more precise types than than this, but without inspecting the
         # arguments to .annotate, these are the best types we can infer.
         qs1 = Blog.objects.values('text').annotate(foo=F('id'))
-        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__Blog, TypedDict({'foo': Any})], builtins.dict[builtins.str, Any]]"
+        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.dict[builtins.str, Any]]"
         qs2 = Blog.objects.values_list('text').annotate(foo=F('id'))
-        reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__Blog, TypedDict({'foo': Any})], builtins.tuple[Any, ...]]"
+        reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.tuple[Any, ...]]"
         qs3 = Blog.objects.values_list('text', named=True).annotate(foo=F('id'))
         # TODO: Would be nice to infer a NamedTuple which contains the field 'text' (str) + any number of other fields.
         #  The reason it would have to appear to have any other fields is that annotate could potentially be called with
@@ -318,9 +331,9 @@
         #  But it's not trivial to make such a NamedTuple, partly because since it is also an ordinary tuple, it would
         #  have to have an arbitrary length, but still have certain fields at certain indices with specific types.
         #  For now, Any :)
-        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__Blog, TypedDict({'foo': Any})], Any]"
+        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], Any]"
         qs4 = Blog.objects.values_list('text', flat=True).annotate(foo=F('id'))
-        reveal_type(qs4) # N: Revealed type is "django.db.models.query.QuerySet[django_stubs_ext.WithAnnotations[myapp__models__Blog, TypedDict({'foo': Any})], builtins.str]"
+        reveal_type(qs4) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.str]"
 
 
         before_values_no_params = Blog.objects.values().annotate(foo=F('id')).get()

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -8,7 +8,7 @@
 
         unannotated_user = User.objects.get(id=1)
 
-        print(annotated_user.asdf) # E: "User_AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "asdf"  [attr-defined]
+        print(annotated_user.asdf) # E: "User@AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "asdf"  [attr-defined]
         print(unannotated_user.asdf) # E: "User" has no attribute "asdf"  [attr-defined]
 
         def func(user: Annotated[User, Annotations]) -> str:  # E: Missing required TypedDict parameter for generic type Annotations  [misc]
@@ -55,28 +55,28 @@
             foo: str
 
         def func(user: Annotated[User, Annotations[MyDict]]) -> str:
-            print(user.asdf) # E: "User_AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
+            print(user.asdf) # E: "User@AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
         unannotated_user = User.objects.get(id=1)
         annotated_user = User.objects.annotate(foo=Value("")).get()
         other_annotated_user = User.objects.annotate(other=Value("")).get()
 
-        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
+        func(unannotated_user) # E: Argument 1 to "func" has incompatible type "User"; expected "User@AnnotatedWith[MyDict]"  [arg-type]
         x: WithAnnotations[User]
         # Declaring nothing annotated returns a user
         reveal_type(x)  # N: Revealed type is "myapp.models.User"
-        func(x)  # E: Argument 1 to "func" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
+        func(x)  # E: Argument 1 to "func" has incompatible type "User"; expected "User@AnnotatedWith[MyDict]"  [arg-type]
         func(annotated_user)
-        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "User_AnnotatedWith[TypedDict({'other': Any})]"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
+        func(other_annotated_user) # E: Argument 1 to "func" has incompatible type "User@AnnotatedWith[TypedDict({'other': Any})]"; expected "User@AnnotatedWith[MyDict]"  [arg-type]
 
         def func2(user: WithAnnotations[User, MyDict]) -> str:
-            print(user.asdf) # E: "User_AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
+            print(user.asdf) # E: "User@AnnotatedWith[MyDict]" has no attribute "asdf"  [attr-defined]
             return user.foo
 
-        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
+        func2(unannotated_user) # E: Argument 1 to "func2" has incompatible type "User"; expected "User@AnnotatedWith[MyDict]"  [arg-type]
         func2(annotated_user)
-        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "User_AnnotatedWith[TypedDict({'other': Any})]"; expected "User_AnnotatedWith[MyDict]"  [arg-type]
+        func2(other_annotated_user) # E: Argument 1 to "func2" has incompatible type "User@AnnotatedWith[TypedDict({'other': Any})]"; expected "User@AnnotatedWith[MyDict]"  [arg-type]
     installed_apps:
         - myapp
     files:
@@ -113,7 +113,7 @@
         func(y)
 
         z: WithAnnotations[User, OtherDict]
-        func(z) # E: Argument 1 to "func" has incompatible type "User_AnnotatedWith[OtherDict]"; expected "User_AnnotatedWith[NarrowDict]"  [arg-type]
+        func(z) # E: Argument 1 to "func" has incompatible type "User@AnnotatedWith[OtherDict]"; expected "User@AnnotatedWith[NarrowDict]"  [arg-type]
 
     installed_apps:
         - myapp
@@ -132,12 +132,12 @@
         from django.db.models.expressions import F
 
         qs = User.objects.annotate(foo=F('id'))
-        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})], myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})]]"
+        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User@AnnotatedWith[TypedDict({'foo': Any})], myapp.models.User@AnnotatedWith[TypedDict({'foo': Any})]]"
 
         annotated = qs.get()
-        reveal_type(annotated) # N: Revealed type is "myapp.models.User_AnnotatedWith[TypedDict({'foo': Any})]"
+        reveal_type(annotated) # N: Revealed type is "myapp.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
         reveal_type(annotated.foo) # N: Revealed type is "Any"
-        print(annotated.bar) # E: "User_AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "bar"  [attr-defined]
+        print(annotated.bar) # E: "User@AnnotatedWith[TypedDict({'foo': Any})]" has no attribute "bar"  [attr-defined]
         reveal_type(annotated.username) # N: Revealed type is "builtins.str"
 
     installed_apps:
@@ -209,7 +209,7 @@
         qs = User.objects.annotate(foo=F('id'))
         qs = qs.annotate(bar=F('id'))
         annotated = qs.get()
-        reveal_type(annotated) # N: Revealed type is "myapp.models.User_AnnotatedWith[TypedDict({'foo': Any, 'bar': Any})]"
+        reveal_type(annotated) # N: Revealed type is "myapp.models.User@AnnotatedWith[TypedDict({'foo': Any, 'bar': Any})]"
         reveal_type(annotated.foo) # N: Revealed type is "Any"
         reveal_type(annotated.bar) # N: Revealed type is "Any"
         reveal_type(annotated.username) # N: Revealed type is "builtins.str"
@@ -240,11 +240,11 @@
           return qs.annotate(foo=F('id'))
 
         def add_wrong_annotation(qs: QuerySet[User]) -> QuerySet[WithAnnotations[User, FooDict]]:
-          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "QuerySet[User_AnnotatedWith[TypedDict({'bar': Any})], User_AnnotatedWith[TypedDict({'bar': Any})]]", expected "QuerySet[User_AnnotatedWith[FooDict], User_AnnotatedWith[FooDict]]")  [return-value]
+          return qs.annotate(bar=F('id')) # E: Incompatible return value type (got "QuerySet[User@AnnotatedWith[TypedDict({'bar': Any})], User@AnnotatedWith[TypedDict({'bar': Any})]]", expected "QuerySet[User@AnnotatedWith[FooDict], User@AnnotatedWith[FooDict]]")  [return-value]
 
         qs = add_annotation(qs)
         reveal_type(qs.get().foo)  # N: Revealed type is "builtins.str"
-        qs.get().bar # E: "User_AnnotatedWith[FooDict]" has no attribute "bar"  [attr-defined]
+        qs.get().bar # E: "User@AnnotatedWith[FooDict]" has no attribute "bar"  [attr-defined]
 
     installed_apps:
         - myapp
@@ -321,9 +321,9 @@
         # It's possible to provide more precise types than than this, but without inspecting the
         # arguments to .annotate, these are the best types we can infer.
         qs1 = Blog.objects.values('text').annotate(foo=F('id'))
-        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.dict[builtins.str, Any]]"
+        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], builtins.dict[builtins.str, Any]]"
         qs2 = Blog.objects.values_list('text').annotate(foo=F('id'))
-        reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.tuple[Any, ...]]"
+        reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], builtins.tuple[Any, ...]]"
         qs3 = Blog.objects.values_list('text', named=True).annotate(foo=F('id'))
         # TODO: Would be nice to infer a NamedTuple which contains the field 'text' (str) + any number of other fields.
         #  The reason it would have to appear to have any other fields is that annotate could potentially be called with
@@ -331,9 +331,9 @@
         #  But it's not trivial to make such a NamedTuple, partly because since it is also an ordinary tuple, it would
         #  have to have an arbitrary length, but still have certain fields at certain indices with specific types.
         #  For now, Any :)
-        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], Any]"
+        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], Any]"
         qs4 = Blog.objects.values_list('text', flat=True).annotate(foo=F('id'))
-        reveal_type(qs4) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog_AnnotatedWith[TypedDict({'foo': Any})], builtins.str]"
+        reveal_type(qs4) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], builtins.str]"
 
 
         before_values_no_params = Blog.objects.values().annotate(foo=F('id')).get()

--- a/tests/typecheck/test_annotated.yml
+++ b/tests/typecheck/test_annotated.yml
@@ -1,8 +1,9 @@
 # Regression test for #893
--   case: annotated_should_not_iterfere
+-   case: annotated_should_not_interfere
     main: |
         from dataclasses import dataclass
-        from typing_extensions import Annotated
+        from typing_extensions import Annotated, TypedDict
+        from myapp.models import Blog
 
         class IntegerType:
             def __init__(self, min_value: int, max_value: int) -> None:
@@ -11,3 +12,20 @@
         @dataclass(unsafe_hash=True)
         class RatingComposite:
             max_value: Annotated[int, IntegerType(min_value=1, max_value=10)] = 5
+
+        class Obj(TypedDict):
+            foo: int
+
+        class X:
+            x: Annotated[Blog, Obj]
+        reveal_type(X().x)  # N: Revealed type is "myapp.models.Blog"
+
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class Blog(models.Model):
+                    text = models.CharField(max_length=100)

--- a/tests/typecheck/test_annotated.yml
+++ b/tests/typecheck/test_annotated.yml
@@ -19,6 +19,7 @@
         class X:
             x: Annotated[Blog, Obj]
         reveal_type(X().x)  # N: Revealed type is "myapp.models.Blog"
+        reveal_type(X().x.foo)  # E: "Blog" has no attribute "foo"  [attr-defined]  # N: Revealed type is "Any"
 
     installed_apps:
         - myapp


### PR DESCRIPTION
I figured out that the implementation in mypy for `functools.partial`, in https://github.com/python/mypy/pull/16939, added some pieces that we can utilise to get better support for `.annotate`.

Namely that https://github.com/python/mypy/pull/16939 added support for writing `Instance.extra_attrs` to cache.

There are 2 main pieces at play in this implementation:

1. Annotated attributes are written to `mypy.types.Instance.extra_attrs`. This allows `.annotate` calls to bring in temporary attributes on same model instances.
2. The approach in 1. does not help out when comparing instance `A´1` with `A´2` for annotated attributes. Essentially nothing in `.extra_attrs` is considered when comparing instances, there could be completely different attributes in there and mypy still considers the instances equal/compatible. To be able to resolve that, the plugin creates a subclass for each model that also has `django_stubs_ext.Annotations` as base with a generic parameter. This subclass will be replace any encounter of `WithAnnotations[<Model>, <TypedDict>]`, where `<TypedDict>` populates the generic parameter of the model subclass. This allows for falling back on mypy for type compatibility depending on annotated attributes.

The description in 2. is something like this in code

```python
class MyModel(models.Model):
    username = models.CharField(max_length=100)

class MyModel_AnnotatedWith(models.Model, django_stubs_ext.Annotations[django_stubs_ext.annotations._Annotations]):
    ...
```

Then with a use case example

```python
class AnnotatedAttrs(TypedDict):
    foo: int

def func(instance: django_stubs_ext.WithAnnotations[MyModel, AnnotatedAttrs]) -> int:
    return instance.foo

func(MyModel.objects.annotate(foo=Value("")).get())  # OK
func(MyModel.objects.annotate(bar=Value("")).get())  # Error

reveal_type(func)  # Revealed type is "def (instance: MyModel@AnnotatedWith[TypedDict('AnnotatedAttrs', {'foo': builtins.int})]) -> builtins.int"
```

The main downside here is the subclass and that it needs a name, which is set to `{Model name}@AnnotatedWith`

---

Most of this is backwards compatible with our old `WithAnnotations` except for the fact that;

- `WithAnnotations[MyModel]` is no longer supported, it didn't really make sense to ask for an annotation of nothing. Though this enabled support for accepting any attribute in the previous version, but IMO `# type: ignore` will make do for that.

It might be more compatibility issues but our test suite is kind of lacking cases for using `.annotate`.

Let me know what you think, any feedback is greatly appreciated here.

## Related issues

There are a whole bunch of issues reported in regards to `annotate`: https://github.com/typeddjango/django-stubs/issues?q=is%3Aissue+is%3Aopen+annotate

I'm not going to hunt down and include which repro cases are resolved with _this PR_, but was thinking to do that subsequently to close off resolved issues. Though I will include closing one (major) cache issue we've had forever, since that should no longer be any issue with this implementation.

- Closes #760 
