### PR TITLE
Do `models.Model` adjustments from `get_metaclass_hook`

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -223,9 +223,6 @@ class NewSemanalDjangoPlugin(Plugin):
         return None
 
     def get_customize_class_mro_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
-        if fullname == fullnames.MODEL_CLASS_FULLNAME:
-            return MetaclassAdjustments.adjust_model_class
-
         sym = self.lookup_fully_qualified(fullname)
         if (
             sym is not None
@@ -235,6 +232,11 @@ class NewSemanalDjangoPlugin(Plugin):
             return reparametrize_any_manager_hook
         else:
             return None
+
+    def get_metaclass_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
+        if fullname == fullnames.MODEL_METACLASS_FULLNAME:
+            return MetaclassAdjustments.adjust_model_class
+        return None
 
     def get_base_class_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
         # Base class is a Model class definition

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -761,3 +761,53 @@
                     generic_manager = models.Manager()
                     generic_manager_from_generic_queryset = GenericManagerFromGenericQuerySet()
                     generic_manager_from_populated_queryset = GenericManagerFromPopulatedQuerySet()
+
+# Regression test for #2304
+-   case: test_objects_managers_is_kept_with_specific_import_graph
+    main: |
+        from zerver.models import RealmFilter
+        reveal_type(RealmFilter.objects)  # N: Revealed type is "django.db.models.manager.Manager[zerver.models.linkifiers.RealmFilter]"
+    installed_apps:
+        - django.contrib.auth
+        - django.contrib.contenttypes
+        - confirmation
+        - zerver
+    files:
+        -   path: confirmation/__init__.py
+        -   path: confirmation/models.py
+            content: |
+                from django.db import models
+                from zerver.models import Realm
+                class Confirmation(models.Model):
+                    realm = models.ForeignKey(Realm, on_delete=models.CASCADE)
+        -   path: zerver/__init__.py
+        -   path: zerver/models/__init__.py
+            content: |
+                from zerver.models.linkifiers import RealmFilter as RealmFilter
+                from zerver.models.realms import Realm as Realm
+                from zerver.models.streams import Stream as Stream
+                from zerver.models.users import UserProfile as UserProfile
+                RealmFilter.objects
+        -   path: zerver/models/linkifiers.py
+            content: |
+                from django.db import models
+                class RealmFilter(models.Model):
+                    pass
+        -   path: zerver/models/realms.py
+            content: |
+                from django.db import models
+                class Realm(models.Model):
+                    pass
+        -   path: zerver/models/streams.py
+            content: |
+                from django.db import models
+                from zerver.models.realms import Realm
+                from zerver.models.users import UserProfile
+                class Stream(models.Model):
+                    realm = models.ForeignKey(Realm, on_delete=models.RESTRICT)
+                    creator = models.ForeignKey(UserProfile, on_delete=models.RESTRICT)
+        -   path: zerver/models/users.py
+            content: |
+                from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+                class UserProfile(AbstractBaseUser, PermissionsMixin):
+                    pass


### PR DESCRIPTION
The called hook expects/wants the class body analyzed, but the `get_customize_class_mro_hook` hook, that it was previously called from, invokes the hook before the class body has been analyzed..

Docs: https://mypy.readthedocs.io/en/stable/extending_mypy.html#current-list-of-plugin-hooks

> __get_customize_class_mro_hook()__ can be used to modify class MRO (for example insert some entries there) before the class body is analyzed.

## Related issues

- Closes #2304 
- Refs #2280 