### PR TITLE
5.1: Deprecate CheckConstraint.check

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -46,8 +46,8 @@ class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
     condition: Q | BaseExpression
 
-    @deprecated("The check keyword argument is deprecated in favor of condition and will be removed in Django 6.0")
     @overload
+    @deprecated("The check keyword argument is deprecated in favor of condition and will be removed in Django 6.0")
     def __init__(
         self,
         *,

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -54,7 +54,6 @@ class CheckConstraint(BaseConstraint):
         violation_error_code: str | None = None,
         violation_error_message: _StrOrPromise | None = None,
     ) -> None: ...
-
     @overload
     def __init__(
         self,

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -45,6 +45,7 @@ class BaseConstraint:
 class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
 
+    @deprecated("The check keyword argument is deprecated in favor of condition and will be removed in Django 6.0")
     @overload
     def __init__(
         self,

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -44,6 +44,7 @@ class BaseConstraint:
 
 class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
+    condition: Q | BaseExpression
 
     @deprecated("The check keyword argument is deprecated in favor of condition and will be removed in Django 6.0")
     @overload

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -44,11 +44,23 @@ class BaseConstraint:
 
 class CheckConstraint(BaseConstraint):
     check: Q | BaseExpression
+
+    @overload
     def __init__(
         self,
         *,
-        check: Q | BaseExpression,
         name: str,
+        check: Q | BaseExpression,
+        violation_error_code: str | None = None,
+        violation_error_message: _StrOrPromise | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        name: str,
+        condition: Q | BaseExpression,
         violation_error_code: str | None = None,
         violation_error_message: _StrOrPromise | None = None,
     ) -> None: ...

--- a/tests/assert_type/db/models/test_constraints.py
+++ b/tests/assert_type/db/models/test_constraints.py
@@ -13,4 +13,4 @@ UniqueConstraint(  # type: ignore[call-overload]
     name="unique_mess",
 )
 
-CheckConstraint(name="less_than_constraint", check=LessThan[Any](F("months"), 1))
+CheckConstraint(name="less_than_constraint", check=LessThan[Any](F("months"), 1))  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION
# I have made things!
> [The check keyword argument of CheckConstraint is deprecated in favor of condition.](https://docs.djangoproject.com/en/5.1/releases/5.1/#features-deprecated-in-5-1)

https://github.com/django/django/blob/ecf13f192de7c26a7606f5ba46a3773a9c84ef72/django/db/models/constraints.py#L137

Added overload to forbid check=None, condition=None at the same
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
