### PR TITLE
Enable `mypy.plugins.proper_plugin`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -20,7 +20,8 @@ force_union_syntax = true
 
 
 plugins =
-    mypy_django_plugin.main
+    mypy_django_plugin.main,
+    mypy.plugins.proper_plugin
 
 # Ignore incomplete hints in yaml-stubs
 [mypy-yaml.*]

--- a/mypy_django_plugin/transformers/forms.py
+++ b/mypy_django_plugin/transformers/forms.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from mypy.plugin import ClassDefContext, MethodContext
-from mypy.types import CallableType, Instance, NoneTyp, TypeType
+from mypy.types import CallableType, Instance, NoneTyp, TypeType, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.lib import helpers
@@ -18,8 +18,10 @@ def make_meta_nested_class_inherit_from_any(ctx: ClassDefContext) -> None:
 
 def get_specified_form_class(object_type: Instance) -> Optional[TypeType]:
     form_class_sym = object_type.type.get("form_class")
-    if form_class_sym and isinstance(form_class_sym.type, CallableType):
-        return TypeType(form_class_sym.type.ret_type)
+    if form_class_sym:
+        form_class_type = get_proper_type(form_class_sym.type)
+        if isinstance(form_class_type, CallableType):
+            return TypeType(form_class_type.ret_type)
     return None
 
 
@@ -27,15 +29,17 @@ def extract_proper_type_for_get_form(ctx: MethodContext) -> MypyType:
     object_type = ctx.type
     assert isinstance(object_type, Instance)
 
-    form_class_type = helpers.get_call_argument_type_by_name(ctx, "form_class")
+    form_class_type = get_proper_type(helpers.get_call_argument_type_by_name(ctx, "form_class"))
     if form_class_type is None or isinstance(form_class_type, NoneTyp):
         form_class_type = get_specified_form_class(object_type)
 
     if isinstance(form_class_type, TypeType) and isinstance(form_class_type.item, Instance):
         return form_class_type.item
 
-    if isinstance(form_class_type, CallableType) and isinstance(form_class_type.ret_type, Instance):
-        return form_class_type.ret_type
+    if isinstance(form_class_type, CallableType):
+        form_class_ret_type = get_proper_type(form_class_type.ret_type)
+        if isinstance(form_class_ret_type, Instance):
+            return form_class_ret_type
 
     return ctx.default_return_type
 

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type, Union
 
 from django.db.models.base import Model
 from mypy.plugin import FunctionContext, MethodContext
-from mypy.types import Instance
+from mypy.types import Instance, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext
@@ -53,9 +53,10 @@ def typecheck_model_method(
 
 
 def redefine_and_typecheck_model_init(ctx: FunctionContext, django_context: DjangoContext) -> MypyType:
-    assert isinstance(ctx.default_return_type, Instance)
+    default_return_type = get_proper_type(ctx.default_return_type)
+    assert isinstance(default_return_type, Instance)
 
-    model_fullname = ctx.default_return_type.type.fullname
+    model_fullname = default_return_type.type.fullname
     model_cls = django_context.get_model_class_by_fullname(model_fullname)
     if model_cls is None:
         return ctx.default_return_type
@@ -64,11 +65,12 @@ def redefine_and_typecheck_model_init(ctx: FunctionContext, django_context: Djan
 
 
 def redefine_and_typecheck_model_create(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
-    if not isinstance(ctx.default_return_type, Instance):
+    default_return_type = get_proper_type(ctx.default_return_type)
+    if not isinstance(default_return_type, Instance):
         # only work with ctx.default_return_type = model Instance
         return ctx.default_return_type
 
-    model_fullname = ctx.default_return_type.type.fullname
+    model_fullname = default_return_type.type.fullname
     model_cls = django_context.get_model_class_by_fullname(model_fullname)
     if model_cls is None:
         return ctx.default_return_type

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -123,7 +123,7 @@ def _process_dynamic_method(
     variables = method_type.variables
     ret_type = method_type.ret_type
 
-    manager_model = find_member("model", manager_instance, manager_instance)
+    manager_model = get_proper_type(find_member("model", manager_instance, manager_instance))
     assert isinstance(manager_model, TypeType), manager_model
     manager_model_type = manager_model.item
 
@@ -140,12 +140,12 @@ def _process_dynamic_method(
         typed_var = manager_instance.args or queryset_info.bases[0].args
         if (
             typed_var
-            and isinstance(typed_var[0], Instance)
-            and typed_var[0].type.has_base(fullnames.MODEL_CLASS_FULLNAME)
+            and isinstance((model_arg := get_proper_type(typed_var[0])), Instance)
+            and model_arg.type.has_base(fullnames.MODEL_CLASS_FULLNAME)
         ):
-            ret_type = _replace_type_var(ret_type, base_that_has_method.defn.type_vars[0].fullname, typed_var[0])
+            ret_type = _replace_type_var(ret_type, base_that_has_method.defn.type_vars[0].fullname, model_arg)
             args_types = [
-                _replace_type_var(arg_type, base_that_has_method.defn.type_vars[0].fullname, typed_var[0])
+                _replace_type_var(arg_type, base_that_has_method.defn.type_vars[0].fullname, model_arg)
                 for arg_type in args_types
             ]
     if base_that_has_method.self_type:
@@ -243,9 +243,11 @@ def _replace_type_var(ret_type: MypyType, to_replace: str, replace_by: MypyType)
     """
     if isinstance(ret_type, TypeVarType) and ret_type.fullname == to_replace:
         return replace_by
-    elif isinstance(ret_type, Instance):
+    elif isinstance((instance := get_proper_type(ret_type)), Instance):
         # Since it is an instance, recursively find the type var for all its args.
-        ret_type.args = tuple(_replace_type_var(item, to_replace, replace_by) for item in ret_type.args)
+        instance.args = tuple(_replace_type_var(item, to_replace, replace_by) for item in instance.args)
+        return instance
+
     if isinstance(ret_type, ProperType) and hasattr(ret_type, "item"):
         # For example TypeType has an item. find the type_var for this item
         ret_type.item = _replace_type_var(ret_type.item, to_replace, replace_by)
@@ -267,9 +269,10 @@ def resolve_manager_method(ctx: AttributeContext) -> MypyType:
     an attribute on a class that has 'django.db.models.BaseManager' as a base.
     """
     # Skip (method) type that is currently something other than Any of type `implementation_artifact`
-    if not isinstance(ctx.default_attr_type, AnyType):
+    default_attr_type = get_proper_type(ctx.default_attr_type)
+    if not isinstance(default_attr_type, AnyType):
         return ctx.default_attr_type
-    elif ctx.default_attr_type.type_of_any != TypeOfAny.implementation_artifact:
+    elif default_attr_type.type_of_any != TypeOfAny.implementation_artifact:
         return ctx.default_attr_type
 
     # (Current state is:) We wouldn't end up here when looking up a method from a custom _manager_.
@@ -284,13 +287,15 @@ def resolve_manager_method(ctx: AttributeContext) -> MypyType:
 
     if isinstance(ctx.type, Instance):
         return resolve_manager_method_from_instance(instance=ctx.type, method_name=method_name, ctx=ctx)
-    elif isinstance(ctx.type, UnionType) and all(isinstance(instance, Instance) for instance in ctx.type.items):
+    elif isinstance(ctx.type, UnionType) and all(
+        isinstance(get_proper_type(item), Instance) for item in ctx.type.items
+    ):
         resolved = tuple(
             resolve_manager_method_from_instance(instance=instance, method_name=method_name, ctx=ctx)
-            for instance in ctx.type.items
-            if isinstance(instance, Instance)
+            for item in ctx.type.items
+            if isinstance((instance := get_proper_type(item)), Instance)
         )
-        return get_proper_type(UnionType(resolved))
+        return UnionType(resolved)
     else:
         ctx.api.fail(f'Unable to resolve return type of queryset/manager method "{method_name}"', ctx.context)
         return AnyType(TypeOfAny.from_error)
@@ -499,15 +504,16 @@ def add_as_manager_to_queryset_class(ctx: ClassDefContext) -> None:
         return
 
     base_as_manager = queryset_info.get("as_manager")
-    if (
-        base_as_manager is None
-        or not isinstance(base_as_manager.type, CallableType)
-        or not isinstance(base_as_manager.type.ret_type, Instance)
-    ):
+    if base_as_manager is None:
+        return
+    base_as_manager_type = get_proper_type(base_as_manager.type)
+    if not isinstance(base_as_manager_type, CallableType):
+        return
+    base_as_manager_ret_type = get_proper_type(base_as_manager_type.ret_type)
+    if not isinstance(base_as_manager_ret_type, Instance):
         return
 
-    base_ret_type = base_as_manager.type.ret_type.type
-
+    base_ret_type = base_as_manager_ret_type.type
     manager_sym = semanal_api.lookup_fully_qualified_or_none(fullnames.MANAGER_CLASS_FULLNAME)
     if manager_sym is None or not isinstance(manager_sym.node, TypeInfo):
         return _defer()
@@ -592,15 +598,11 @@ def reparametrize_any_manager_hook(ctx: ClassDefContext) -> None:
         (base for base in manager.node.bases if base.type.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)),
         None,
     )
-    if parent_manager is None:
+    if parent_manager is None or len(parent_manager.args) != 1:
         return
 
-    is_missing_params = (
-        len(parent_manager.args) == 1
-        and isinstance(parent_manager.args[0], AnyType)
-        and parent_manager.args[0].type_of_any is TypeOfAny.from_omitted_generics
-    )
-    if not is_missing_params:
+    model_param = get_proper_type(parent_manager.args[0])
+    if not isinstance(model_param, AnyType) or model_param.type_of_any is not TypeOfAny.from_omitted_generics:
         return
 
     type_vars = tuple(parent_manager.type.defn.type_vars)

--- a/mypy_django_plugin/transformers/meta.py
+++ b/mypy_django_plugin/transformers/meta.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import FieldDoesNotExist
 from mypy.plugin import MethodContext
-from mypy.types import AnyType, Instance, TypeOfAny
+from mypy.types import AnyType, Instance, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext
@@ -22,7 +22,7 @@ def return_proper_field_type_from_get_field(ctx: MethodContext, django_context: 
     if len(ctx.type.args) == 0:
         return ctx.default_return_type
 
-    model_type = ctx.type.args[0]
+    model_type = get_proper_type(ctx.type.args[0])
     if not isinstance(model_type, Instance):
         return ctx.default_return_type
 

--- a/mypy_django_plugin/transformers/request.py
+++ b/mypy_django_plugin/transformers/request.py
@@ -1,5 +1,5 @@
 from mypy.plugin import AttributeContext, MethodContext
-from mypy.types import Instance, UninhabitedType, UnionType
+from mypy.types import Instance, UninhabitedType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext
@@ -37,7 +37,7 @@ def set_auth_user_model_as_type_for_request_user(ctx: AttributeContext, django_c
 
 
 def check_querydict_is_mutable(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
-    ret_type = ctx.default_return_type
+    ret_type = get_proper_type(ctx.default_return_type)
     if isinstance(ret_type, UninhabitedType):
         ctx.api.fail("This QueryDict is immutable.", ctx.context)
-    return ret_type
+    return ctx.default_return_type


### PR DESCRIPTION
Refs: https://mypy.readthedocs.io/en/stable/extending_mypy.html#useful-tools

This resulted in quite a lot of changes.. I think there are multiple places in our plugin functions where we should use `ProperType` as return type instead of `MypyType`(our alias for `mypy.types.Type`), which could perhaps remove a couple of `get_proper_type`.

Not at all sure how much impact this could have, if any.