### PR TITLE
Add arbitrary named arguments to @receiver decorator

### DIFF
--- a/django-stubs/dispatch/dispatcher.pyi
+++ b/django-stubs/dispatch/dispatcher.pyi
@@ -36,4 +36,5 @@ def receiver(
     sender: object | None = ...,
     weak: bool = ...,
     dispatch_uid: Hashable | None = ...,
+    **named: Any,
 ) -> Callable[[_F], _F]: ...


### PR DESCRIPTION

`@receiver` accepts arbitrary keyword arguments - per [the docs](https://docs.djangoproject.com/en/5.1/topics/signals/#django.dispatch.receiver)

This comes in handy for some third party apps.
