### PR TITLE
Don't modify return values of manager methods in place, modify a copy instead

### DIFF
--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -236,6 +236,7 @@
         reveal_type(MyModel.objects.dummy_override())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.example_mixin(MyModel()))  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.example_other_mixin())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.example_union())  # N: Revealed type is "Union[myapp.models.MyModel, builtins.list[myapp.models.MyModel]]"
         reveal_type(MyOtherModel.objects.example())  # N: Revealed type is "myapp.models.MyOtherModel"
         reveal_type(MyOtherModel.objects.example_2())  # N: Revealed type is "myapp.models.MyOtherModel"
         reveal_type(MyOtherModel.objects.override())  # N: Revealed type is "myapp.models.MyOtherModel"
@@ -245,13 +246,14 @@
         reveal_type(MyOtherModel.objects.example_other_mixin())  # N: Revealed type is "myapp.models.MyOtherModel"
         reveal_type(MyOtherModel.objects.test_self())  # N: Revealed type is "myapp.models._MyModelQuerySet2[myapp.models.MyOtherModel]"
         reveal_type(MyOtherModel.objects.test_sub_self())  # N: Revealed type is "myapp.models._MyModelQuerySet2[myapp.models.MyOtherModel]"
+        reveal_type(MyOtherModel.objects.example_union())  # N: Revealed type is "Union[myapp.models.MyOtherModel, builtins.list[myapp.models.MyOtherModel]]"
     installed_apps:
         - myapp
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-              from typing import TypeVar, Generic
+              from typing import TypeVar, Generic, Union, List
               from django.db import models
               from typing_extensions import Self
 
@@ -263,6 +265,7 @@
 
               class OtherMixin(models.QuerySet[T]):
                   def example_other_mixin(self) -> T: ...
+                  def example_union(self) -> Union[T, List[T]]: ...
 
               class _MyModelQuerySet(OtherMixin[T], models.QuerySet[T], Generic[T]):
                   def example(self) -> T: ...


### PR DESCRIPTION
# I have made things!

#2343 and #1917 seem to be caused by `_process_dynamic_method` modifying the return types of QuerySet methods, while they're still being referenced by the base QuerySet class's methods. This works fine the first time a method's type is resolved, but since it modifies the base QuerySet's return value too (if it's a Union or something like list[T]), it gets rid of the TypeVar on the base QuerySet class. When we try to resolve the return type again from another manager from another model, the Generic is no longer there and we end up with whatever first replaced that Generic.

Creating a copy seems to fix it, but then again, I have no idea what I'm doing :shrug:

## Related issues

- Closes #2343
- Closes #1917

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
