### PR TITLE
Update Django 4.2 LTS version to 4.2.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-shard==0.1.2
 
 # Django deps:
 psycopg2-binary
-Django==4.2.13; python_version < '3.10'
+Django==4.2.16; python_version < '3.10'
 Django==5.1.1; python_version >= '3.10'
 -e ./ext
 -e .[redis,compatible-mypy,oracle]


### PR DESCRIPTION
This solves GitHub's Dependabot security alerts. The alerts are created because we still use an older Django version in `requirements.txt` when testing with older Python versions. But there is no security impact, because Django is only used in CI and not exposed as a web service.

## Related issues

* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/7
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/9
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/10
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/13
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/15
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/16
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/17
* Fixes https://github.com/typeddjango/django-stubs/security/dependabot/18
