### PR TITLE
Version 5.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We rely on different `django` and `mypy` versions:
 
 | django-stubs   | Mypy version | Django version | Django partial support | Python version |
 |----------------|--------------|----------------|------------------------|----------------|
+| 5.1.0          | 1.11.x       | 5.1            | 4.2                    | 3.8 - 3.12     |
 | 5.0.4          | 1.11.x       | 5.0            | 4.2                    | 3.8 - 3.12     |
 | 5.0.3          | 1.11.x       | 5.0            | 4.2                    | 3.8 - 3.12     |
 | 5.0.2          | 1.10.x       | 5.0            | 4.2                    | 3.8 - 3.12     |

--- a/ext/setup.py
+++ b/ext/setup.py
@@ -13,7 +13,7 @@ dependencies = [
 # It's fine to skip django-stubs-ext releases, but when doing a release, update this to newest django-stubs version.
 setup(
     name="django-stubs-ext",
-    version="5.0.4",
+    version="5.1.0",
     description="Monkey-patching and extensions for django-stubs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md") as f:
 dependencies = [
     "django",
     "asgiref",
-    "django-stubs-ext>=5.0.4",
+    "django-stubs-ext>=5.1.0",
     "tomli; python_version < '3.11'",
     # Types:
     "typing-extensions>=4.11.0",
@@ -39,7 +39,7 @@ extras_require = {
 
 setup(
     name="django-stubs",
-    version="5.0.4",
+    version="5.1.0",
     description="Mypy stubs for Django",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Blindly following the instructions in [Contributing.md](https://github.com/typeddjango/django-stubs/blob/master/CONTRIBUTING.md#releasing-django-stubs). pre-commit passes, stubtest passes, I hope that means that this PR makes sense and there are no release blockers.

Version 5.0.4 broke with with Django 5.1 in one of the projects I'm working on due to the `check`/`condition` rename that was fixed in #2331 but not yet released.