### PR TITLE
Allow lookups on `.annotate` fields

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -482,12 +482,12 @@ class DjangoContext:
         try:
             solved_lookup = self.solve_lookup_type(model_cls, lookup)
         except FieldError as exc:
-            if (
-                helpers.is_annotated_model(model_instance.type)
-                and model_instance.extra_attrs
-                and lookup in model_instance.extra_attrs.attrs
-            ):
-                return model_instance.extra_attrs.attrs[lookup]
+            if helpers.is_annotated_model(model_instance.type) and model_instance.extra_attrs:
+                # If the field comes from .annotate(), we assume Any for it
+                # and allow chaining any lookups.
+                lookup_base_field, *_ = lookup.split("__")
+                if lookup_base_field in model_instance.extra_attrs.attrs:
+                    return model_instance.extra_attrs.attrs[lookup_base_field]
 
             msg = exc.args[0]
             if model_instance.extra_attrs:

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -257,7 +257,7 @@
                     username = models.CharField(max_length=100)
 
 
--   case: annotate_currently_allows_lookups_of_non_existent_field
+-   case: annotate_rejects_lookups_of_non_existent_field
     main: |
         from myapp.models import User
         from django.db.models.expressions import F
@@ -395,3 +395,22 @@
 
         class Entry(models.Model):
             blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
+
+- case: test_annotate_allows_any_lookups_in_filter
+  main: |
+    from django.db import models
+    from myapp.models import Blog
+
+    qs = Blog.objects.annotate(distance=0)
+    qs.filter(distance=10)
+    qs.filter(distance__lt=10)
+    qs.filter(distance__lt__lt=10)
+    qs.filter(distance__unknown_lookup=10)
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+        class Blog(models.Model): pass

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -402,10 +402,15 @@
     from myapp.models import Blog
 
     qs = Blog.objects.annotate(distance=0)
-    qs.filter(distance=10)
-    qs.filter(distance__lt=10)
+    reveal_type(qs)
+    reveal_type(qs.filter(distance=10))
+    reveal_type(qs.filter(distance__lt=10))
     qs.filter(distance__lt__lt=10)
     qs.filter(distance__unknown_lookup=10)
+  out: |
+    main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
+    main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
+    main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
   installed_apps:
     - myapp
   files:


### PR DESCRIPTION
# Allow lookups on fields coming from `.annotate()`

Django does not object when fields introduced via `QuerySet.annotate` are used in `.filter` with lookup chains:

```
from django.db import models

class Blog(models.Model): pass

Blog.objects.annotate(id2=models.F('id')).filter(id2__gt=10)
```

`mypy`, however, rejects this with a really cryptic error message:

```
error: Cannot resolve keyword 'id2' into field. Choices are: id, id2  [misc]
```

Since now all `.annotate` fields are resolved as plain `Any`, I think it's fair to allow chaining any lookups with them. This PR does exactly that: when a `id2__something` lookup is encountered and `id2` is not a model field, proceed with checking that `id2` is `.annotate` field and accept if so, ignoring the chained lookups.