### PR TITLE
Break what apparently is a cycle involving custom User model and `QuerySet.as_manager()`

### DIFF
--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -446,7 +446,7 @@
             content: |
                 from __future__ import annotations
 
-                from typing import Self
+                from typing_extensions import Self
 
                 from django.contrib.auth import get_user_model
                 from django.db import models

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -431,3 +431,47 @@
                     class MyQuerySet(models.QuerySet):
                         pass
                     objects = MyQuerySet.as_manager()
+
+-   case: queryset_as_manager_foreignkey_cycle
+    main: |
+        from payments.models import Payout
+        reveal_type(Payout.objects)  # N: Revealed type is "payments.models.ManagerFromPayoutQuerySet[payments.models.Payout]"
+
+    custom_settings: |
+        INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth", "payments", "accounts")
+        AUTH_USER_MODEL = "accounts.Account"
+    files:
+        -   path: payments/__init__.py
+        -   path: payments/models.py
+            content: |
+                from __future__ import annotations
+
+                from typing import Self
+
+                from django.contrib.auth import get_user_model
+                from django.db import models
+
+                UserModel = get_user_model()
+
+                class Transaction(models.Model):
+                    user = models.ForeignKey(
+                        UserModel, on_delete=models.CASCADE, related_name="transactions"
+                    )
+
+                class PayoutQuerySet(models.QuerySet["Payout"]):
+                    def unapplied(self) -> Self:
+                        return self
+
+                class Payout(models.Model):
+                    triggered_by = models.ForeignKey(
+                        Transaction, on_delete=models.CASCADE, related_name="payouts"
+                    )
+
+                    objects = PayoutQuerySet.as_manager()
+
+        -   path: accounts/__init__.py
+        -   path: accounts/models.py
+            content: |
+                from django.contrib.auth.models import AbstractUser
+
+                class Account(AbstractUser): pass


### PR DESCRIPTION
# Break a cycle resulting in `[django-manager-missing]`

I'm not sure if my treatment is correct, perhaps I'm just treating symptoms of some deeper problem. However, this at least makes a test case extracted from my real system pass, and removes a dozen of `django-manager-missing` errors in my code (actually all of them!).

See the contributed test case for details - I don't really see how to summarize it any better.

There seems to be some cycle during semanal, where `base_as_manager.type` remains `None` during all iterations (yes, I tried deferring first). This seems to only affect the base `QuerySet` and require custom `AUTH_USER_MODEL`.

Prior to the fix, the test failed with the following:

```
main:2: note: Revealed type is "payments.models.UnknownManager[payments.models.Payout]" (diff)
payments/models:10: error: Couldn't resolve related manager 'payouts' for relation 'payments.models.Payout.triggered_by'.  [django-manager-missing] (diff)
payments/models:24: error: Could not resolve manager type for "payments.models.Payout.objects"  [django-manager-missing] (diff)
```