### PR TITLE
Add django 5.1 to the test matrix and add its classifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12']
-        django-version: ['4.2', '5.0']
+        django-version: ['4.2', '5.0', '5.1']
         include:
           - python-version: '3.8'
             django-version: '4.2'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,7 @@ This rule helps us avoid tying in too closely to Django’s undocumented interna
     - Update `django-stubs-ext>=` dependency in root `setup.py` to the same version number.
     - Add a new row at the top of ['Version compatibility' table in README.md](README.md#version-compatibility).
     - Use pull request title "Version x.y.z release" by convention.
+    - Add the correct classifiers to `setup.py` if support is added for a new Python or Django version
 
 2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a version bump, no need
    to wait for a second maintainer's approval.

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
     ],
     project_urls={
         "Funding": "https://github.com/sponsors/typeddjango",


### PR DESCRIPTION
Thank you for bringing the 5.1.0 release!

According to the table in the README.md, there is support for Django 5.1. To ensure we're aligned, I've added 5.1 to the test matrix and updated the classifier in setup.py. Additionally, I included a task to the contributiong guidelines in case there is support for new Python or Django versions. 
