### PR TITLE
Treat `QuerySet.alias` like `QuerySet.annotate`

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -169,6 +169,7 @@ class NewSemanalDjangoPlugin(Plugin):
             "values_list": partial(
                 querysets.extract_proper_type_queryset_values_list, django_context=self.django_context
             ),
+            "alias": partial(querysets.extract_proper_type_queryset_annotate, django_context=self.django_context),
             "annotate": partial(querysets.extract_proper_type_queryset_annotate, django_context=self.django_context),
             "create": partial(init_create.redefine_and_typecheck_model_create, django_context=self.django_context),
             "filter": typecheck_filtering_method,

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -368,6 +368,7 @@
     qs.filter(annotate_wrong__gt=5)
 
     qs2 = qs.alias(alias_entries=models.Count("entry"))
+    qs2.filter(alias_entries__gt=5)
     qs2.filter(alias_wrong__gt=5, annotate_wrong__gt=5)
 
     Blog.objects.annotate().filter(xyz=1)
@@ -378,10 +379,10 @@
     )
   out: |
     main:6: error: Cannot resolve keyword 'annotate_wrong' into field. Choices are: entry, id, xyz  [misc]
-    main:9: error: Cannot resolve keyword 'alias_wrong' into field. Choices are: entry, id, xyz  [misc]
-    main:9: error: Cannot resolve keyword 'annotate_wrong' into field. Choices are: entry, id, xyz  [misc]
-    main:11: error: Cannot resolve keyword 'xyz' into field. Choices are: entry, id  [misc]
-    main:13: error: Cannot resolve keyword 'xyz' into field. Choices are: entry, id  [misc]
+    main:10: error: Cannot resolve keyword 'alias_wrong' into field. Choices are: entry, id, xyz, alias_entries  [misc]
+    main:10: error: Cannot resolve keyword 'annotate_wrong' into field. Choices are: entry, id, xyz, alias_entries  [misc]
+    main:12: error: Cannot resolve keyword 'xyz' into field. Choices are: entry, id  [misc]
+    main:14: error: Cannot resolve keyword 'xyz' into field. Choices are: entry, id  [misc]
   installed_apps:
     - myapp
   files:


### PR DESCRIPTION
Although this incorrectly allows some misuses of `alias` that only work at runtime with `annotate`, that is better than incorrectly forbidding all uses of `alias`.

- Fixes #2302.