### PR TITLE
Update enums to reflect typing spec changes

### DIFF
--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Generic, Literal, TypeVar, type_check_only
+from typing import Any, Generic, Literal, TypeVar, cast, type_check_only
 
 from django import forms
 from django.contrib.admin.filters import FieldListFilter, ListFilter
@@ -45,9 +45,9 @@ VERTICAL: Literal[2]
 _Direction: TypeAlias = Literal[1, 2]
 
 class ShowFacets(enum.Enum):
-    NEVER: str
-    ALLOW: str
-    ALWAYS: str
+    NEVER = cast(str, ...)
+    ALLOW = cast(str, ...)
+    ALWAYS = cast(str, ...)
 
 def get_content_type_for_model(obj: type[Model] | Model) -> ContentType: ...
 def get_ul_class(radio_style: int) -> str: ...

--- a/django-stubs/contrib/gis/gdal/srs.pyi
+++ b/django-stubs/contrib/gis/gdal/srs.pyi
@@ -1,12 +1,12 @@
 from enum import IntEnum
-from typing import Any, AnyStr
+from typing import Any, AnyStr, cast
 
 from django.contrib.gis.gdal.base import GDALBase
 from typing_extensions import Self
 
 class AxisOrder(IntEnum):
-    TRADITIONAL: int
-    AUTHORITY: int
+    TRADITIONAL = cast(int, ...)
+    AUTHORITY = cast(int, ...)
 
 class SpatialReference(GDALBase):
     destructor: Any

--- a/django-stubs/db/models/constants.pyi
+++ b/django-stubs/db/models/constants.pyi
@@ -1,7 +1,8 @@
 from enum import Enum
+from typing import cast
 
 LOOKUP_SEP: str
 
 class OnConflict(Enum):
-    IGNORE: str
-    UPDATE: str
+    IGNORE = cast(str, ...)
+    UPDATE = cast(str, ...)

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, overload, cast
+from typing import Any, cast, overload
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.base import Model

--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, overload
+from typing import Any, overload, cast
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.base import Model
@@ -10,8 +10,8 @@ from django.utils.functional import _StrOrPromise
 from typing_extensions import Self, deprecated
 
 class Deferrable(Enum):
-    DEFERRED: str
-    IMMEDIATE: str
+    DEFERRED = cast(str, ...)
+    IMMEDIATE = cast(str, ...)
 
 class BaseConstraint:
     name: str

--- a/django-stubs/template/base.pyi
+++ b/django-stubs/template/base.pyi
@@ -2,7 +2,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from enum import Enum
 from logging import Logger
 from re import Pattern
-from typing import Any
+from typing import Any, cast
 
 from django.template.context import Context as Context  # Django: imported for backwards compatibility
 from django.template.engine import Engine
@@ -26,10 +26,10 @@ tag_re: Pattern[str]
 logger: Logger
 
 class TokenType(Enum):
-    TEXT: int
-    VAR: int
-    BLOCK: int
-    COMMENT: int
+    TEXT = cast(int, ...)
+    VAR = cast(int, ...)
+    BLOCK = cast(int, ...)
+    COMMENT = cast(int, ...)
 
 class VariableDoesNotExist(Exception):
     msg: str


### PR DESCRIPTION
See https://typing.readthedocs.io/en/latest/spec/enums.html#defining-members

https://github.com/python/typing-council/issues/11

The next version of mypy will obey the spec change: https://github.com/python/mypy/pull/18068

pyright already requires this