### PR TITLE
fix .values_list returns incorrect type for field with same name when selected from related model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 .DS_Store
 .idea/
+.vscode/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -63,7 +63,7 @@ def get_field_type_from_lookup(
     silent_on_error: bool = False,
 ) -> Optional[MypyType]:
     try:
-        lookup_field = django_context.resolve_lookup_into_field(model_cls, lookup)
+        lookup_field, model_cls = django_context.resolve_lookup_into_field(model_cls, lookup)
     except FieldError as exc:
         if not silent_on_error:
             ctx.api.fail(exc.args[0], ctx.context)

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -325,7 +325,7 @@
 -   case: handles_field_with_same_name_on_other_model
     main: |
         from myapp.models import A
-        reveal_type(A.objects.values_list("b__name").get())  # N: Revealed type is "Tuple[builtins.str]"
+        reveal_type(A.objects.values_list("name", "b__name").get())  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
     installed_apps:
         - myapp
     files:
@@ -339,4 +339,4 @@
 
                 class A(models.Model):
                     b = models.ForeignKey(B, on_delete=models.CASCADE)
-                    name = models.CharField(null=True)
+                    name = models.IntegerField()

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -322,3 +322,21 @@
                 class Blog(models.Model):
                     num_posts = models.IntegerField()
                     text = models.CharField(max_length=100, blank=True)
+-   case: handles_field_with_same_name_on_other_model
+    main: |
+        from myapp.models import A
+        reveal_type(A.objects.values_list("b__name").get())  # N: Revealed type is "Tuple[builtins.str]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class B(models.Model):
+                    name = models.CharField()
+
+                class A(models.Model):
+                    b = models.ForeignKey(B, on_delete=models.CASCADE)
+                    name = models.CharField(null=True)


### PR DESCRIPTION
# Fix .values_list bug that returns incorrect type for field with same name when selected from related model

`get_field_type_from_lookup` will now check the correct related_model to get a field's type. Previously, it was only ever checking the original model.

## Related issues
- Closes https://github.com/typeddjango/django-stubs/issues/2336