### PR TITLE
Fix type annotations for 3rd party models

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -526,6 +526,10 @@ def is_model_type(info: TypeInfo) -> bool:
     return info.metaclass_type is not None and info.metaclass_type.type.has_base(fullnames.MODEL_METACLASS_FULLNAME)
 
 
+def is_registered_model_type(info: TypeInfo, django_context: "DjangoContext") -> bool:
+    return info.fullname in {get_class_fullname(cls) for cls in django_context.all_registered_model_classes}
+
+
 def get_model_from_expression(
     expr: Expression,
     *,

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -237,7 +237,10 @@ def transform_into_proper_return_type(ctx: FunctionContext, django_context: Djan
     assert isinstance(default_return_type, Instance)
 
     outer_model_info = helpers.get_typechecker_api(ctx).scope.active_class()
-    if outer_model_info is None or not helpers.is_model_type(outer_model_info):
+    if outer_model_info is None or (
+        not helpers.is_model_type(outer_model_info)
+        and not helpers.is_registered_model_type(outer_model_info, django_context)
+    ):
         return ctx.default_return_type
 
     assert isinstance(outer_model_info, TypeInfo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ Django==5.1.3; python_version >= '3.10'
 -e ./ext
 -e .[redis,compatible-mypy,oracle]
 
+# 3rd Party Library for Testing
+django-extensions==3.2.3
+
 # Overrides:
 mypy==1.13.0
 pyright==1.1.388

--- a/tests/typecheck/models/test_3rd_party_models.yml
+++ b/tests/typecheck/models/test_3rd_party_models.yml
@@ -1,8 +1,15 @@
 -   case: handles_type_annotations_on_3rd_party_models
+    installed_apps:
+        - django_extensions
+        - myapp
     main: |
-        from django.db import models
-        from django_extensions.db.models import TimeStampedModel # type: ignore [import-untyped]
+        from myapp.models import A
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django_extensions.db.models import TimeStampedModel # type: ignore[import-untyped]
 
-        class A(TimeStampedModel):
-            name = models.CharField()
-            count = models.IntegerField()
+                class A(TimeStampedModel):
+                    name = models.CharField()

--- a/tests/typecheck/models/test_3rd_party_models.yml
+++ b/tests/typecheck/models/test_3rd_party_models.yml
@@ -1,0 +1,8 @@
+-   case: handles_type_annotations_on_3rd_party_models
+    main: |
+        from django.db import models
+        from django_extensions.db.models import TimeStampedModel # type: ignore [import-untyped]
+
+        class A(TimeStampedModel):
+            name = models.CharField()
+            count = models.IntegerField()


### PR DESCRIPTION
# Fix type annotations for 3rd party models

The clean-up in [PR #2263](https://github.com/typeddjango/django-stubs/pull/2263) that got released in v5.0.3 ended up breaking type annotations for models that are subclasses of models imported from 3rd party libraries.

I restored the logic that checks a model's fullname in the list of registered django apps. We still need to do this because Django models imported from untyped 3rd party libraries will have no `metaclass_type`, so `helpers.is_model_type` will always fail for them.

## Related issues
- Closes: [#2341](https://github.com/typeddjango/django-stubs/issues/2341)
- Related to: [PR #2263](https://github.com/typeddjango/django-stubs/pull/2263)

