### PR TITLE
Marking default_error_messages as a ClassVar

### DIFF
--- a/django-stubs/contrib/postgres/fields/array.pyi
+++ b/django-stubs/contrib/postgres/fields/array.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 from _typeshed import Unused
 from django.core.validators import _ValidatorCallable
@@ -22,7 +22,7 @@ class ArrayField(CheckFieldDefaultMixin, Field[_ST, _GT]):
     _pyi_private_get_type: list[Any]
 
     empty_strings_allowed: bool
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: Field
     size: int | None
     default_validators: Sequence[_ValidatorCallable]

--- a/django-stubs/contrib/postgres/forms/array.pyi
+++ b/django-stubs/contrib/postgres/forms/array.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, ClassVar
 
 from django import forms
 from django.db.models.fields import _ErrorMessagesDict
@@ -10,7 +10,7 @@ from django.forms.widgets import _OptAttrs
 from ..utils import prefix_validation_error as prefix_validation_error
 
 class SimpleArrayField(forms.CharField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: forms.Field
     delimiter: str
     min_length: int | None
@@ -46,7 +46,7 @@ class SplitArrayWidget(forms.Widget):
     def needs_multipart_form(self) -> bool: ...  # type: ignore[override]
 
 class SplitArrayField(forms.Field):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: forms.Field
     size: int
     remove_trailing_nulls: bool

--- a/django-stubs/contrib/postgres/forms/hstore.pyi
+++ b/django-stubs/contrib/postgres/forms/hstore.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from django import forms
 from django.db.models.fields import _ErrorMessagesDict
@@ -6,7 +6,7 @@ from django.forms.fields import _ClassLevelWidgetT
 
 class HStoreField(forms.CharField):
     widget: _ClassLevelWidgetT
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     def prepare_value(self, value: Any) -> Any: ...
     def to_python(self, value: Any) -> dict[str, str | None]: ...  # type: ignore[override]
     def has_changed(self, initial: Any, data: Any) -> bool: ...

--- a/django-stubs/contrib/postgres/forms/ranges.pyi
+++ b/django-stubs/contrib/postgres/forms/ranges.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from django import forms
 from django.db.models.fields import _ErrorMessagesDict
@@ -13,7 +13,7 @@ class HiddenRangeWidget(RangeWidget):
     def __init__(self, attrs: _OptAttrs | None = None) -> None: ...
 
 class BaseRangeField(forms.MultiValueField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: type[forms.Field]
     range_type: type[Range]
     hidden_widget: type[forms.Widget]
@@ -22,21 +22,21 @@ class BaseRangeField(forms.MultiValueField):
     def compress(self, values: tuple[Any | None, Any | None]) -> Range | None: ...
 
 class IntegerRangeField(BaseRangeField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: type[forms.Field]
     range_type: type[Range]
 
 class DecimalRangeField(BaseRangeField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: type[forms.Field]
     range_type: type[Range]
 
 class DateTimeRangeField(BaseRangeField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: type[forms.Field]
     range_type: type[Range]
 
 class DateRangeField(BaseRangeField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     base_field: type[forms.Field]
     range_type: type[Range]

--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -147,7 +147,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
     creation_counter: int
     auto_creation_counter: int
     default_validators: Sequence[validators._ValidatorCallable]
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     hidden: bool
     system_check_removed_details: Any | None
     system_check_deprecated_details: Any | None
@@ -443,7 +443,7 @@ class GenericIPAddressField(Field[_ST, _GT]):
     _pyi_private_set_type: str | int | Callable[..., Any] | Combinable
     _pyi_private_get_type: str
 
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     unpack_ipv4: bool
     protocol: str
     def __init__(

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Collection, Iterator, Sequence
 from decimal import Decimal
 from re import Pattern
-from typing import Any, Protocol, type_check_only
+from typing import Any, ClassVar, Protocol, type_check_only
 from uuid import UUID
 
 from django.core.files import File
@@ -32,7 +32,7 @@ class Field:
     widget: _ClassLevelWidgetT
     hidden_widget: type[Widget]
     default_validators: list[_ValidatorCallable]
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     empty_values: Sequence[Any]
     show_hidden_initial: bool
     help_text: _StrOrPromise
@@ -547,7 +547,7 @@ class InvalidJSONInput(str): ...
 class JSONString(str): ...
 
 class JSONField(CharField):
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     widget: _ClassLevelWidgetT
     encoder: Any
     decoder: Any

--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Mapping, Sequence, Sized
-from typing import Any, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 
 from django.db.models.fields import _ErrorMessagesDict
 from django.forms.forms import BaseForm, Form
@@ -47,7 +47,7 @@ class BaseFormSet(Generic[_F], Sized, RenderableFormMixin):
     error_class: type[ErrorList]
     deletion_widget: MediaDefiningClass
     ordering_widget: MediaDefiningClass
-    default_error_messages: _ErrorMessagesDict
+    default_error_messages: ClassVar[_ErrorMessagesDict]
     template_name_div: str
     template_name_p: str
     template_name_table: str


### PR DESCRIPTION
This is only ever a dictionary defined on the class and not being defined as a ClassVar means in projects using django-stubs it's not possible to comply with https://docs.astral.sh/ruff/rules/mutable-class-default/
