### PR TITLE
base.pyi: use base class HttpResponseBase

### DIFF
--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
-from django.http.response import HttpResponse
 from django.urls.resolvers import ResolverMatch
 
 def resolve(path: str, urlconf: str | None = ...) -> ResolverMatch: ...

--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -6,7 +6,7 @@ from django.urls.resolvers import ResolverMatch
 
 def resolve(path: str, urlconf: str | None = ...) -> ResolverMatch: ...
 def reverse(
-    viewname: Callable[..., HttpResponse] | str | None,
+    viewname: Callable[..., HttpResponseBase] | str | None,
     urlconf: str | None = ...,
     args: Sequence[Any] | None = ...,
     kwargs: dict[str, Any] | None = ...,

--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
+from django.http.response import HttpResponseBase
 from django.urls.resolvers import ResolverMatch
 
 def resolve(path: str, urlconf: str | None = ...) -> ResolverMatch: ...


### PR DESCRIPTION
Previously, this was only a `Callable` but 125f31a81116f5f149c3e868d950608571e9a5e8 restricted the last parameter to `HttpResponse` which is unnecessarily strict, as it does not cover things like `StreamingHttpResponse` and its descendant `FileResponse` among others – while _view_ functions can return these as well. They have a common base class `HttpResponseBase` – I guess this would be a better choice here.