### PR TITLE
Add type-checking to Manager.acreate

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -172,6 +172,7 @@ class NewSemanalDjangoPlugin(Plugin):
             "alias": partial(querysets.extract_proper_type_queryset_annotate, django_context=self.django_context),
             "annotate": partial(querysets.extract_proper_type_queryset_annotate, django_context=self.django_context),
             "create": partial(init_create.redefine_and_typecheck_model_create, django_context=self.django_context),
+            "acreate": partial(init_create.redefine_and_typecheck_model_acreate, django_context=self.django_context),
             "filter": typecheck_filtering_method,
             "get": typecheck_filtering_method,
             "exclude": typecheck_filtering_method,

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -76,3 +76,23 @@ def redefine_and_typecheck_model_create(ctx: MethodContext, django_context: Djan
         return ctx.default_return_type
 
     return typecheck_model_method(ctx, django_context, model_cls, "create")
+
+
+def redefine_and_typecheck_model_acreate(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
+    default_return_type = get_proper_type(ctx.default_return_type)
+
+    if not isinstance(default_return_type, Instance):
+        # only work with ctx.default_return_type = model Instance
+        return ctx.default_return_type
+
+    # default_return_type at this point should be of type Coroutine[Any, Any, <Model>]
+    model = default_return_type.args[-1]
+    if not isinstance(model, Instance):
+        return ctx.default_return_type
+
+    model_fullname = model.type.fullname
+    model_cls = django_context.get_model_class_by_fullname(model_fullname)
+    if model_cls is None:
+        return ctx.default_return_type
+
+    return typecheck_model_method(ctx, django_context, model_cls, "acreate")

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -86,7 +86,7 @@ def redefine_and_typecheck_model_acreate(ctx: MethodContext, django_context: Dja
         return ctx.default_return_type
 
     # default_return_type at this point should be of type Coroutine[Any, Any, <Model>]
-    model = default_return_type.args[-1]
+    model = get_proper_type(default_return_type.args[-1])
     if not isinstance(model, Instance):
         return ctx.default_return_type
 

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -161,7 +161,7 @@
         import asyncio
         from myapp.models import User
         async def amain() -> None:
-            await User.objects.acreate(pk=1, name='Max', age=10)
+            reveal_type(await User.objects.acreate(pk=1, name='Max', age=10))  # N: Revealed type is "myapp.models.User"
             await User.objects.acreate(age=[])  # E: Incompatible type for "age" of "User" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
     installed_apps:
         - myapp

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -155,3 +155,21 @@
                     id = models.IntegerField(primary_key=True)
                 class MyModel3(models.Model):
                     default = models.IntegerField(default=return_int)
+
+-   case: default_manager_acreate_is_typechecked
+    main: |
+        import asyncio
+        from myapp.models import User
+        async def amain() -> None:
+            await User.objects.acreate(pk=1, name='Max', age=10)
+            await User.objects.acreate(age=[])  # E: Incompatible type for "age" of "User" (got "List[Any]", expected "Union[float, int, str, Combinable]")  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class User(models.Model):
+                    name = models.CharField(max_length=100)
+                    age = models.IntegerField()


### PR DESCRIPTION
This PR adds type-checking to kwargs for the `.acreate()` method. Currently `.create()` is type-checked but `.acreate()` is not.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

Closes #2090 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
This is my first time diving into this codebase so let me know if I missed anything. I used the test case from #2093.