### PR TITLE
Fix types for `TestCase.assertJSON{Not,}Equal`

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -152,13 +152,13 @@ class SimpleTestCase(unittest.TestCase):
     def assertInHTML(self, needle: str, haystack: str, count: int | None = ..., msg_prefix: str = ...) -> None: ...
     def assertJSONEqual(
         self,
-        raw: str,
+        raw: str | bytes | bytearray,
         expected_data: dict[str, Any] | list[Any] | str | int | float | bool | None,
         msg: str | None = ...,
     ) -> None: ...
     def assertJSONNotEqual(
         self,
-        raw: str,
+        raw: str | bytes | bytearray,
         expected_data: dict[str, Any] | list[Any] | str | int | float | bool | None,
         msg: str | None = ...,
     ) -> None: ...


### PR DESCRIPTION
The implementation of this function just passes the `raw` value to `json.loads`, which [is typed as accepting][1] strings, bytes objects, or bytearrays.

Update the signature of `assertJSONEqual` and `assertJSONNotEqual` to match.

[1]: https://github.com/python/typeshed/blob/aac4394eb29d86797628b57d6f01f5e17f5ff83f/stdlib/json/__init__.pyi#L40

Please let me know if I missed important things from the contributor process?