### PR TITLE
fix: Add `context_data` attribute to _MonkeyPatchedW/ASGIResponse.

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -189,7 +189,15 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     request: dict[str, Any]
     client: Client
     templates: list[Template]
+
+    # `context` and `context_data` are populated based on whether you use the standard template
+    # backend or a custom one respectively.
+    # `context_data` only exists if the response was successful too as the return type changes.
+    # `HTTPResponse` when API failed and `TemplateResponse` when successful.
+    # https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.Response.context
     context: ContextList | dict[str, Any]
+    context_data: ContextList | dict[str, Any]
+
     content: bytes
     resolver_match: ResolverMatch
     redirect_chain: list[tuple[str, int]]
@@ -200,7 +208,15 @@ class _MonkeyPatchedASGIResponse(_ASGIResponse):
     request: dict[str, Any]
     client: AsyncClient
     templates: list[Template]
+
+    # `context` and `context_data` are populated based on whether you use the standard template
+    # backend or a custom one respectively.
+    # `context_data` only exists if the response was successful too as the return type changes.
+    # `HTTPResponse` when API failed and `TemplateResponse` when successful.
+    # https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.Response.context
     context: ContextList | dict[str, Any]
+    context_data: ContextList | dict[str, Any]
+
     content: bytes
     resolver_match: ResolverMatch
     redirect_chain: list[tuple[str, int]]

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -8,6 +8,7 @@
       reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
+      reveal_type(response.context_data)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
       reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
       response.json()
@@ -22,6 +23,7 @@
         reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
         reveal_type(response.client)  # N: Revealed type is "django.test.client.AsyncClient"
         reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
+        reveal_type(response.context_data)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
         reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
         reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
         response.json()


### PR DESCRIPTION
As detailed in Django's documentation [0], when a non-standard template backend is used, the `context_data` attribute is populated instead of `context` when the test API call is successful. I've seen this to be a populated attribute regardless of the backend template engine being used. Regardless, this near-hidden attribute is missing and should be included to help improve unit testing when validating that the response data contains the expected data.

[0] https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.Response.context

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues
None.

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
