### PR TITLE
Tidy `stubtest.sh`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run stubtest
-        run: bash ./scripts/stubtest.sh
+        run: ./scripts/stubtest.sh
 
   run-pyright:
     timeout-minutes: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,12 @@ rm -r .mypy_cache
 
 ### Testing stubs with `stubtest`
 
-Run `bash ./scripts/stubtest.sh` to test that stubs and sources are in-line.
+Run `./scripts/stubtest.sh` to test that stubs and sources are in-line.
 
-We have two special files to allow errors:
+We have some special files to allow errors:
 1. `scripts/stubtest/allowlist.txt` where we store things that we really don't care about: hacks, django internal utility modules, things that are handled by our plugin, things that are not representable by type system, etc
-2. `scripts/stubtest/allowlist_todo.txt` where we store all errors there are right now. Basically, this is a TODO list: we need to work through this list and fix things (or move entries to real `allowlist.txt`). In the end, ideally we can remove this file
+2. `scripts/stubtest/allowlist_todo.txt` where we store all errors there are right now. Basically, this is a TODO list: we need to work through this list and fix things (or move entries to real `allowlist.txt`). In the end, ideally we can remove this file.
+3. `scripts/stubtest/allowlist_todo_django51.txt` where we store new errors from the Django 5.0 to 5.1 upgrade. This is an extra TODO list.
 
 You might also want to disable `incremental` mode while working on `stubtest` changes.
 This mode leads to several known problems (stubs do not show up or have strange errors).

--- a/scripts/stubtest.sh
+++ b/scripts/stubtest.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-# Run this script as `bash ./scripts/stubtest.sh`
+# Run this script with `./scripts/stubtest.sh`
 
 set -e
 


### PR DESCRIPTION
# I have made things!

1. Add executable bit so it can be run without explicit `bash`.
2. Mark it as for `sh` to skip Bash on e.g. macOS where Zsh is the default.
3. Mention `allowlist_todo_django51.txt` - missed in #2347.

## Related issues

N/A