### PR TITLE
Tidy `django.conf.urls`

### DIFF
--- a/django-stubs/conf/urls/__init__.pyi
+++ b/django-stubs/conf/urls/__init__.pyi
@@ -1,31 +1,9 @@
-from collections.abc import Callable, Sequence
-from typing import Any, overload
-
-from django.http.response import HttpResponse, HttpResponseBase
-from django.urls import URLPattern, URLResolver
 from django.urls import include as include
-from typing_extensions import TypeAlias
+from django.views import defaults
 
-handler400: str | Callable[..., HttpResponse]
-handler403: str | Callable[..., HttpResponse]
-handler404: str | Callable[..., HttpResponse]
-handler500: str | Callable[..., HttpResponse]
+__all__ = ["handler400", "handler403", "handler404", "handler500", "include"]
 
-_IncludedURLConf: TypeAlias = tuple[Sequence[URLResolver | URLPattern], str | None, str | None]
-
-# Deprecated
-@overload
-def url(
-    regex: str, view: Callable[..., HttpResponseBase], kwargs: dict[str, Any] | None = ..., name: str | None = ...
-) -> URLPattern: ...
-@overload
-def url(
-    regex: str, view: _IncludedURLConf, kwargs: dict[str, Any] | None = ..., name: str | None = ...
-) -> URLResolver: ...
-@overload
-def url(
-    regex: str,
-    view: Sequence[URLResolver | str],
-    kwargs: dict[str, Any] | None = ...,
-    name: str | None = ...,
-) -> URLResolver: ...
+handler400 = defaults.bad_request
+handler403 = defaults.permission_denied
+handler404 = defaults.page_not_found
+handler500 = defaults.server_error

--- a/django-stubs/urls/conf.pyi
+++ b/django-stubs/urls/conf.pyi
@@ -6,10 +6,10 @@ from django.urls import URLPattern, URLResolver, _AnyURL
 from django.utils.functional import _StrOrPromise
 from typing_extensions import TypeAlias
 
-from ..conf.urls import _IncludedURLConf
 from ..http.response import HttpResponseBase
 
 _URLConf: TypeAlias = str | ModuleType | Sequence[_AnyURL]
+_IncludedURLConf: TypeAlias = tuple[Sequence[URLResolver | URLPattern], str | None, str | None]
 
 def include(arg: _URLConf | tuple[_URLConf, str], namespace: str | None = ...) -> _IncludedURLConf: ...
 

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -3,7 +3,6 @@
 
 django.__main__
 django.conf.global_settings.gettext_noop
-django.conf.urls.url
 django.contrib.admin.FieldListFilter.title
 django.contrib.admin.ModelAdmin
 django.contrib.admin.StackedInline
@@ -1293,7 +1292,6 @@ django.db.backends.postgresql.base.Cursor
 
 # mypy 1.14.0 new issues:
 django.apps.__all__
-django.conf.urls.__all__
 django.contrib.admin.__all__
 django.contrib.gis.admin.__all__
 django.contrib.gis.db.models.__all__


### PR DESCRIPTION
# I have made things!

1. Remove `url()`, [removed in Django 4.0](https://github.com/django/django/commit/98ae3925e57c3f054814b847971194f7cd8d98d1).
2. Import the default views rather than redefining their types.
3. Move `_IncludedURLConf` to `urls/conf.pyi`.
4. Copy `__all__` from [source](https://github.com/django/django/blob/main/django/conf/urls/__init__.py).

## Related issues

N/A