### PR TITLE
Fix `Func.function`

### DIFF
--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -11,6 +11,7 @@ from django.utils.functional import cached_property
 NUMERIC_TYPES: Any
 
 class GeoFuncMixin:
+    function: str | None = None
     geom_param_pos: Any
     @property
     def geo_field(self) -> Any: ...

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -181,7 +181,7 @@ class OuterRef(F):
     def relabeled_clone(self, relabels: Any) -> Self: ...
 
 class Func(SQLiteNumericMixin, Expression):
-    function: str
+    function: str | None
     name: str
     template: str
     arg_joiner: str

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -181,7 +181,7 @@ class OuterRef(F):
     def relabeled_clone(self, relabels: Any) -> Self: ...
 
 class Func(SQLiteNumericMixin, Expression):
-    function: str | None
+    function: str | None = None
     name: str
     template: str
     arg_joiner: str

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -293,7 +293,6 @@ django.contrib.gis.db.models.ForeignObjectRel.empty_strings_allowed
 django.contrib.gis.db.models.ForeignObjectRel.get_extra_restriction
 django.contrib.gis.db.models.ForeignObjectRel.identity
 django.contrib.gis.db.models.ForeignObjectRel.path_infos
-django.contrib.gis.db.models.Func.function
 django.contrib.gis.db.models.Func.allowed_default
 django.contrib.gis.db.models.GenericIPAddressField.formfield
 django.contrib.gis.db.models.GeoAggregate
@@ -360,13 +359,11 @@ django.contrib.gis.db.models.Window.as_sqlite
 django.contrib.gis.db.models.aggregates.Extent.is_extent
 django.contrib.gis.db.models.aggregates.Extent3D.is_extent
 django.contrib.gis.db.models.aggregates.GeoAggregate.as_sql
-django.contrib.gis.db.models.aggregates.GeoAggregate.function
 django.contrib.gis.db.models.fields.GeometryField.contribute_to_class
 django.contrib.gis.db.models.fields.RasterField.contribute_to_class
 django.contrib.gis.db.models.functions.Area.as_sql
 django.contrib.gis.db.models.functions.GeoFuncMixin.__init__
 django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql
-django.contrib.gis.db.models.functions.GeoFuncMixin.function
 django.contrib.gis.db.models.functions.GeoFuncMixin.name
 django.contrib.gis.db.models.functions.GeoFuncMixin.resolve_expression
 django.contrib.gis.db.models.functions.Length.as_sql
@@ -694,7 +691,6 @@ django.db.models.ForeignObjectRel.empty_strings_allowed
 django.db.models.ForeignObjectRel.get_extra_restriction
 django.db.models.ForeignObjectRel.identity
 django.db.models.ForeignObjectRel.path_infos
-django.db.models.Func.function
 django.db.models.Func.allowed_default
 django.db.models.GenericIPAddressField.formfield
 django.db.models.ImageField.__get__
@@ -790,7 +786,6 @@ django.db.models.expressions.When.allowed_default
 django.db.models.expressions.Col.relabeled_clone
 django.db.models.expressions.Exists.empty_result_set_value
 django.db.models.expressions.Expression.identity
-django.db.models.expressions.Func.function
 django.db.models.expressions.OrderBy.as_oracle
 django.db.models.expressions.OrderBy.as_sql
 django.db.models.expressions.Ref.get_refs
@@ -955,7 +950,6 @@ django.db.models.functions.Coalesce.as_oracle
 django.db.models.functions.Coalesce.empty_result_set_value
 django.db.models.functions.Collate.as_sql
 django.db.models.functions.Collate.collation_re
-django.db.models.functions.Concat.function
 django.db.models.functions.ConcatPair.as_postgresql
 django.db.models.functions.Cot.as_oracle
 django.db.models.functions.Degrees.as_oracle
@@ -998,7 +992,6 @@ django.db.models.functions.math.Random.as_oracle
 django.db.models.functions.mixins.FixDecimalInputMixin.as_postgresql
 django.db.models.functions.mixins.FixDurationInputMixin.as_mysql
 django.db.models.functions.mixins.FixDurationInputMixin.as_oracle
-django.db.models.functions.text.Concat.function
 django.db.models.functions.text.ConcatPair.as_postgresql
 django.db.models.indexes.IndexExpression.wrapper_classes
 django.db.models.lookups.FieldGetDbPrepValueIterableMixin.batch_process_rhs


### PR DESCRIPTION
# I have made things!

This attribute is allowed to be `None`, per [the source](https://github.com/django/django/blob/ae2736ca3bf4c6a27e23ee95530ad965b550d4cc/django/db/models/expressions.py#L1051). Allowing that ripples through to subclasses. I also fixed [`GeoFuncMixin`](https://github.com/django/django/blob/ae2736ca3bf4c6a27e23ee95530ad965b550d4cc/django/db/models/expressions.py#L1051), a mixin for `Func` subclasses.

## Related issues

N/A