### PR TITLE
Add `ClassVar` annotations on `Migration` class attributes

### DIFF
--- a/django-stubs/db/migrations/migration.pyi
+++ b/django-stubs/db/migrations/migration.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import ClassVar
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.operations.base import Operation
@@ -6,12 +7,12 @@ from django.db.migrations.state import ProjectState
 from typing_extensions import Self
 
 class Migration:
-    operations: Sequence[Operation]
-    dependencies: Sequence[tuple[str, str]]
-    run_before: Sequence[tuple[str, str]]
-    replaces: Sequence[tuple[str, str]]
-    initial: bool | None
-    atomic: bool
+    operations: ClassVar[Sequence[Operation]]
+    dependencies: ClassVar[Sequence[tuple[str, str]]]
+    run_before: ClassVar[Sequence[tuple[str, str]]]
+    replaces: ClassVar[Sequence[tuple[str, str]]]
+    initial: ClassVar[bool | None]
+    atomic: ClassVar[bool]
     name: str
     app_label: str
     def __init__(self, name: str, app_label: str) -> None: ...


### PR DESCRIPTION
# I have made things!

The class war goes on! This PR adds `ClassVar` annotations to `Migration` class attributes. 

https://docs.djangoproject.com/en/dev/howto/writing-migrations/

Other classes to consider in the future:

- [x] `ModelAdmin` 
- [x] `Migration`
- [ ] `Model`
- [ ] `Meta`
- [ ] `View`
- [ ] `Form` / `ModelForm`
- [ ] `Media`

## Related issues

- https://github.com/typeddjango/django-stubs/pull/2524
- https://github.com/astral-sh/ruff/issues/5243
