### PR TITLE
Update for Model.[a]save() signature change

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, TypeVar, overload
+from typing import Any, ClassVar, Final, Never, TypeVar, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -71,6 +71,7 @@ class Model(metaclass=ModelBase):
     def get_constraints(self) -> list[tuple[type[Model], Sequence[BaseConstraint]]]: ...
     def save(
         self,
+        *args: Never,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,
@@ -78,6 +79,7 @@ class Model(metaclass=ModelBase):
     ) -> None: ...
     async def asave(
         self,
+        *args: Never,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, Never, TypeVar, overload
+from typing import Any, ClassVar, Final, NoReturn, TypeVar, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -71,7 +71,7 @@ class Model(metaclass=ModelBase):
     def get_constraints(self) -> list[tuple[type[Model], Sequence[BaseConstraint]]]: ...
     def save(
         self,
-        *args: Never,
+        *args: NoReturn,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,
@@ -79,7 +79,7 @@ class Model(metaclass=ModelBase):
     ) -> None: ...
     async def asave(
         self,
-        *args: Never,
+        *args: NoReturn,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,16 @@ select = [
     "PGH004",   # Equivalent to flake8-noqa NQA104
     "PGH003",   # Disallowed blanket `type: ignore` annotations.
 ]
-ignore = ["PYI021", "PYI024", "PYI041", "PYI043"]
+ignore = [
+    "PYI021",
+    "PYI024",
+    "PYI041",
+    "PYI043",
+    # no-return-argument-annotation-in-stub
+    # Prefers typing.Never to typing.NoReturn, but Never only available on
+    # Python 3.11+
+    "PYI050",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "*.pyi" = [

--- a/scripts/stubtest/allowlist_todo_django51.txt
+++ b/scripts/stubtest/allowlist_todo_django51.txt
@@ -29,8 +29,6 @@ django.contrib.gis.db.models.Field.slice_expression
 django.contrib.gis.db.models.ForeignObjectRel.accessor_name
 django.contrib.gis.db.models.ForeignObjectRel.cache_name
 django.contrib.gis.db.models.ForeignObjectRel.is_hidden
-django.contrib.gis.db.models.Model.asave
-django.contrib.gis.db.models.Model.save
 django.contrib.gis.db.models.OrderBy.constraint_validation_compatible
 django.contrib.gis.db.models.TextField.slice_expression
 django.contrib.gis.db.models.WindowFrame.__init__
@@ -122,15 +120,11 @@ django.db.models.Field.slice_expression
 django.db.models.ForeignObjectRel.accessor_name
 django.db.models.ForeignObjectRel.cache_name
 django.db.models.ForeignObjectRel.is_hidden
-django.db.models.Model.asave
-django.db.models.Model.save
 django.db.models.OrderBy.constraint_validation_compatible
 django.db.models.TextField.slice_expression
 django.db.models.WindowFrame.__init__
 django.db.models.WindowFrame.get_exclusion
 django.db.models.WindowFrameExclusion
-django.db.models.base.Model.asave
-django.db.models.base.Model.save
 django.db.models.constraints.CheckConstraint.__init__
 django.db.models.expressions.BaseExpression.constraint_validation_compatible
 django.db.models.expressions.BaseExpression.get_expression_for_validation


### PR DESCRIPTION
# I have made things!

Update for this upstream change deprecating keyword arguments for the `save()` and `asave()` methods: https://github.com/django/django/commit/3915d4c70d0d7673abe675525b58117a5099afd3

## Related issues

...
