### PR TITLE
Improve admin decorators

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -13,11 +13,13 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 @overload
 def action(
     function: _F,
+    *,
     permissions: Sequence[str] | None = ...,
     description: _StrOrPromise | None = ...,
 ) -> _F: ...
 @overload
 def action(
+    function: None = None,
     *,
     permissions: Sequence[str] | None = ...,
     description: _StrOrPromise | None = ...,
@@ -25,6 +27,7 @@ def action(
 @overload
 def display(
     function: _F,
+    *,
     boolean: bool | None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,
     description: _StrOrPromise | None = ...,
@@ -32,6 +35,7 @@ def display(
 ) -> _F: ...
 @overload
 def display(
+    function: None = None,
     *,
     boolean: bool | None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,

--- a/django-stubs/contrib/gis/admin/__init__.pyi
+++ b/django-stubs/contrib/gis/admin/__init__.pyi
@@ -6,6 +6,7 @@ from django.contrib.admin import StackedInline as StackedInline
 from django.contrib.admin import TabularInline as TabularInline
 from django.contrib.admin import action as action
 from django.contrib.admin import autodiscover as autodiscover
+from django.contrib.admin import display as display
 from django.contrib.admin import register as register
 from django.contrib.admin import site as site
 from django.contrib.gis.admin.options import GISModelAdmin as GISModelAdmin

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -7,10 +7,6 @@ django.contrib.admin.FieldListFilter.title
 django.contrib.admin.ModelAdmin
 django.contrib.admin.StackedInline
 django.contrib.admin.TabularInline
-django.contrib.admin.action
-django.contrib.admin.decorators.action
-django.contrib.admin.decorators.display
-django.contrib.admin.display
 django.contrib.admin.filters.FieldListFilter.title
 django.contrib.admin.helpers.AdminForm.fields
 django.contrib.admin.helpers.AdminForm.is_bound
@@ -171,8 +167,6 @@ django.contrib.gis.admin.GISModelAdmin.gis_widget
 django.contrib.gis.admin.ModelAdmin
 django.contrib.gis.admin.StackedInline
 django.contrib.gis.admin.TabularInline
-django.contrib.gis.admin.action
-django.contrib.gis.admin.display
 django.contrib.gis.admin.options.GISModelAdmin
 django.contrib.gis.admin.options.GISModelAdmin.gis_widget
 django.contrib.gis.admin.options.GeoModelAdminMixin


### PR DESCRIPTION
# I have made things!

Following previous improvements (#1267, #1292), improve them some more, so we can drop the stubtest exception. The key is to still have the `function` argument but show that in the second case, it must be left with the default `None` to return a decorator.

## Related issues

n/a