### PR TITLE
Update TestCase classes for Django 5.1

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -63,6 +63,8 @@ class SimpleTestCase(unittest.TestCase):
     async_client: AsyncClient
     # TODO: str -> Literal['__all__']
     databases: set[str] | str
+    @classmethod
+    def ensure_connection_patch_method(cls) -> None: ...
     def __call__(self, result: unittest.TestResult | None = ...) -> None: ...
     def settings(self, **kwargs: Any) -> Any: ...
     def modify_settings(self, **kwargs: Any) -> Any: ...
@@ -105,15 +107,6 @@ class SimpleTestCase(unittest.TestCase):
         errors: list[str] | str,
         msg_prefix: str = ...,
     ) -> None: ...
-    # assertFormsetError (lowercase "set") deprecated in Django 4.2
-    def assertFormsetError(
-        self,
-        formset: BaseFormSet,
-        form_index: int | None,
-        field: str | None,
-        errors: list[str] | str,
-        msg_prefix: str = ...,
-    ) -> None: ...
     def assertFormSetError(
         self,
         formset: BaseFormSet,
@@ -150,6 +143,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertHTMLEqual(self, html1: str, html2: str, msg: str | None = ...) -> None: ...
     def assertHTMLNotEqual(self, html1: str, html2: str, msg: str | None = ...) -> None: ...
     def assertInHTML(self, needle: str, haystack: str, count: int | None = ..., msg_prefix: str = ...) -> None: ...
+    def assertNotInHTML(self, needle: str, haystack: str, msg_prefix: str = ...) -> None: ...
     def assertJSONEqual(
         self,
         raw: str | bytes | bytearray,
@@ -171,15 +165,6 @@ class TransactionTestCase(SimpleTestCase):
     fixtures: Any
     multi_db: bool
     serialized_rollback: bool
-    # assertQuerysetEqual (lowercase "set") deprecated in Django 4.2
-    def assertQuerysetEqual(
-        self,
-        qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
-        values: Collection[Any],
-        transform: Callable[[Model], Any] | type[str] = ...,
-        ordered: bool = ...,
-        msg: str | None = ...,
-    ) -> None: ...
     def assertQuerySetEqual(
         self,
         qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,

--- a/scripts/stubtest/allowlist_todo_django51.txt
+++ b/scripts/stubtest/allowlist_todo_django51.txt
@@ -195,10 +195,6 @@ django.test.RequestFactory.patch
 django.test.RequestFactory.post
 django.test.RequestFactory.put
 django.test.RequestFactory.trace
-django.test.SimpleTestCase.assertFormsetError
-django.test.SimpleTestCase.assertNotInHTML
-django.test.SimpleTestCase.ensure_connection_patch_method
-django.test.TransactionTestCase.assertQuerysetEqual
 django.test.client.AsyncClient.__init__
 django.test.client.AsyncClient.delete
 django.test.client.AsyncClient.get
@@ -241,10 +237,6 @@ django.test.selenium.SeleniumTestCase.take_screenshot
 django.test.selenium.screenshot_cases
 django.test.signals.file_storage_changed
 django.test.signals.form_renderer_changed
-django.test.testcases.SimpleTestCase.assertFormsetError
-django.test.testcases.SimpleTestCase.assertNotInHTML
-django.test.testcases.SimpleTestCase.ensure_connection_patch_method
-django.test.testcases.TransactionTestCase.assertQuerysetEqual
 django.test.utils.garbage_collect
 django.urls.converters.get_converter
 django.urls.resolvers.LocaleRegexRouteDescriptor


### PR DESCRIPTION
# I have made things!

1. `SimpleTestCase.assertNotInHTML` added in https://github.com/django/django/commit/2bf46c3825ad4ec170324791d6f3a329316ae2d4
2. `SimpleTestCase.ensure_connection_patch_method()` added in https://github.com/django/django/commit/8fb0be3500cc7519a56985b1b6f415d75ac6fedb
3. `SimpleTestCase.assertFormsetError` removed in https://github.com/django/django/commit/c35fd9e2750a3e49a57d9fef964b9ef3e7cb49cb
4. `TransactionTestCase.assertQuerysetEqual` removed in https://github.com/django/django/commit/69af3bea9987044c944b5bc83e32c35f0a73c6dd

## Related issues

n/a