### PR TITLE
Add full signatures to CheckConstraint.__init__ overloads

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -52,6 +52,7 @@ class CheckConstraint(BaseConstraint):
         self,
         *,
         name: str,
+        condition: None = None,
         check: Q | BaseExpression,
         violation_error_code: str | None = None,
         violation_error_message: _StrOrPromise | None = None,
@@ -62,6 +63,7 @@ class CheckConstraint(BaseConstraint):
         *,
         name: str,
         condition: Q | BaseExpression,
+        check: None = None,
         violation_error_code: str | None = None,
         violation_error_message: _StrOrPromise | None = None,
     ) -> None: ...

--- a/scripts/stubtest/allowlist_todo_django51.txt
+++ b/scripts/stubtest/allowlist_todo_django51.txt
@@ -17,7 +17,6 @@ django.contrib.contenttypes.fields.GenericForeignKey.cache_name
 django.contrib.contenttypes.fields.GenericForeignKey.get_attname_column
 django.contrib.contenttypes.models.ContentType.get_object_for_this_type
 django.contrib.gis.db.backends.mysql.operations.MySQLOperations.collect
-django.contrib.gis.db.models.CheckConstraint.__init__
 django.contrib.gis.db.models.ForeignObjectRel.accessor_name
 django.contrib.gis.db.models.ForeignObjectRel.cache_name
 django.contrib.gis.db.models.OrderBy.constraint_validation_compatible
@@ -94,14 +93,12 @@ django.db.backends.sqlite3.features.DatabaseFeatures.supports_frame_exclusion
 django.db.backends.sqlite3.operations.DatabaseOperations.force_group_by
 django.db.migrations.autodetector.MigrationAutodetector.generate_altered_index_together
 django.db.migrations.autodetector.OperationDependency
-django.db.models.CheckConstraint.__init__
 django.db.models.ForeignObjectRel.accessor_name
 django.db.models.ForeignObjectRel.cache_name
 django.db.models.OrderBy.constraint_validation_compatible
 django.db.models.WindowFrame.__init__
 django.db.models.WindowFrame.get_exclusion
 django.db.models.WindowFrameExclusion
-django.db.models.constraints.CheckConstraint.__init__
 django.db.models.expressions.BaseExpression.constraint_validation_compatible
 django.db.models.expressions.BaseExpression.get_expression_for_validation
 django.db.models.expressions.OrderBy.constraint_validation_compatible


### PR DESCRIPTION
# I have made things!

Following #2331 from @q0w which added the overloads to cover the upstream deprecation, add the missing args on each overload to stop stubtest errors that the signatures don't match.

## Related issues

n/a