### PR TITLE
Make Model.[a]save() keyword-only

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, NoReturn, TypeVar, overload
+from typing import Any, ClassVar, Final, TypeVar, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -71,7 +71,7 @@ class Model(metaclass=ModelBase):
     def get_constraints(self) -> list[tuple[type[Model], Sequence[BaseConstraint]]]: ...
     def save(
         self,
-        *args: NoReturn,
+        *,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,
@@ -79,7 +79,7 @@ class Model(metaclass=ModelBase):
     ) -> None: ...
     async def asave(
         self,
-        *args: NoReturn,
+        *,
         force_insert: bool | tuple[ModelBase, ...] = False,
         force_update: bool = False,
         using: str | None = None,

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -488,3 +488,14 @@ django.contrib.sessions.backends.base.SessionBase.setdefault
 
 # Limited stubtest support for enums (https://github.com/python/mypy/issues/16806)
 django.db.migrations.operations.base.OperationCategory.__new__
+
+# Ignore: ...Model.[a]save is inconsistent, stub does not have *args argument "args"
+# Positional arguments were deprecated in Django 5.1, we have adopted keyword-only arguments early.
+django.contrib.auth.base_user.AbstractBaseUser.save
+django.contrib.auth.models.AbstractBaseUser.save
+django.contrib.gis.db.models.Model.asave
+django.contrib.gis.db.models.Model.save
+django.db.models.Model.asave
+django.db.models.Model.save
+django.db.models.base.Model.asave
+django.db.models.base.Model.save


### PR DESCRIPTION
# I have made things!

Follow-up to https://github.com/typeddjango/django-stubs/pull/2535#discussion_r1992996956 .

## Related issues

n/a