### PR TITLE
Add ModelForm.declared_fields

### DIFF
--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -91,6 +91,7 @@ class BaseModelForm(Generic[_M], BaseForm):
 
 class ModelForm(BaseModelForm[_M], metaclass=ModelFormMetaclass):
     base_fields: ClassVar[dict[str, Field]]
+    declared_fields: ClassVar[dict[str, Field]]
 
 def modelform_factory(
     model: type[_M],

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -67,10 +67,6 @@ django.contrib.auth.backends.RemoteUserBackend.authenticate
 django.contrib.auth.base_user.AbstractBaseUser.last_login
 django.contrib.auth.base_user.AbstractBaseUser.password
 django.contrib.auth.decorators.login_required
-django.contrib.auth.forms.AdminUserCreationForm.declared_fields
-django.contrib.auth.forms.BaseUserCreationForm.declared_fields
-django.contrib.auth.forms.UserChangeForm.declared_fields
-django.contrib.auth.forms.UserCreationForm.declared_fields
 django.contrib.auth.hashers.Argon2PasswordHasher.params
 django.contrib.auth.hashers.ScryptPasswordHasher
 django.contrib.auth.hashers.must_update_salt
@@ -154,7 +150,6 @@ django.contrib.contenttypes.models.ContentType.model
 django.contrib.contenttypes.models.ContentTypeManager.__init__
 django.contrib.contenttypes.models.ContentTypeManager.__slotnames__
 django.contrib.flatpages.admin.FlatPageAdmin
-django.contrib.flatpages.forms.FlatpageForm.declared_fields
 django.contrib.flatpages.models.FlatPage.content
 django.contrib.flatpages.models.FlatPage.enable_comments
 django.contrib.flatpages.models.FlatPage.id
@@ -382,7 +377,6 @@ django.contrib.gis.forms.Input
 django.contrib.gis.forms.Media.__html__
 django.contrib.gis.forms.ModelChoiceField.__deepcopy__
 django.contrib.gis.forms.ModelChoiceIterator
-django.contrib.gis.forms.ModelForm.declared_fields
 django.contrib.gis.forms.ModelFormMetaclass
 django.contrib.gis.forms.ModelFormOptions
 django.contrib.gis.forms.ModelMultipleChoiceField.hidden_widget
@@ -1132,7 +1126,6 @@ django.forms.Input
 django.forms.Media.__html__
 django.forms.ModelChoiceField.__deepcopy__
 django.forms.ModelChoiceIterator
-django.forms.ModelForm.declared_fields
 django.forms.ModelFormMetaclass
 django.forms.ModelFormOptions
 django.forms.ModelMultipleChoiceField.hidden_widget
@@ -1169,7 +1162,6 @@ django.forms.models.BaseModelForm.save_m2m
 django.forms.models.BaseModelFormSet.model
 django.forms.models.BaseModelFormSet.save_m2m
 django.forms.models.ModelChoiceField.__deepcopy__
-django.forms.models.ModelForm.declared_fields
 django.forms.models.ModelFormMetaclass.__new__
 django.forms.models.ModelMultipleChoiceField.hidden_widget
 django.forms.models.inlineformset_factory


### PR DESCRIPTION
# I have made things!

I noticed whilst working on #2555 that `ModelForm.declared_fields` was missing.

This field is added by `DeclarativeFieldsMetaclass`:

https://github.com/django/django/blob/main/django/forms/forms.py#L26-L32

We declared it for `Form`:

https://github.com/typeddjango/django-stubs/blob/6c4333db1b541c2e09a4976b0ade2d990ea28242/django-stubs/forms/forms.pyi#L74-L76

It was just missed for `ModelForm` before.

## Related issues

n/a