### PR TITLE
Add `db_table_comment` to model meta

### DIFF
--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -51,6 +51,7 @@ class Options(Generic[_M]):
     verbose_name: _StrOrPromise | None
     verbose_name_plural: _StrOrPromise | None
     db_table: str
+    db_table_comment: str
     ordering: Sequence[str] | None
     indexes: list[Any]
     unique_together: Sequence[tuple[str, ...]]  # Are always normalized


### PR DESCRIPTION
# I have made things!

From https://github.com/django/django/pull/14463/commits/78f163a4fb3937aca2e71786fbdd51a0ef39629e:

* `django.db.models.options.Options.db_table_comment` added

## Related issues

N/A