### PR TITLE
Run tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,6 @@ jobs:
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
         run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests --durations=0
-        env:
-          PYTEST_XDIST_AUTO_NUM_WORKERS: 4
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run pytest tests
         run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
         env:
-          PYTEST_XDIST_AUTO_NUM_WORKERS: 2
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 3
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
-        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests --durations=0
+        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
         run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
+        env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 2
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,9 @@ jobs:
 
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
-        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
+        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests --durations=0
         env:
-          PYTEST_XDIST_AUTO_NUM_WORKERS: 3
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 4
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
-        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} tests
+        run: PYTHONPATH='.' pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
       - name: Run mypy on the test cases
         run: mypy --strict tests/assert_type
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ You can also run pre-commit per file or for a specific path, simply replace "--a
 To execute the unit tests, simply run:
 
 ```bash
-pytest
+pytest -n auto
 ```
 
 If you get some unexpected results or want to be sure that tests run is not affected by previous one, remove `mypy` cache:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Regular configuration file (can be used as base in other projects, runs in CI)
 
 [mypy]
-# Modified in `tests_extension_hook.py`
+# Modified in `tests.yml`
 incremental = true
 
 # Strictness:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Regular configuration file (can be used as base in other projects, runs in CI)
 
 [mypy]
-# Modified in `tests.yml`
+# Modified in `tests_extension_hook.py`
 incremental = true
 
 # Strictness:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pre-commit==4.2.0
 pytest==8.3.5
 pytest-mypy-plugins==3.2.0
 pytest-shard==0.1.2
+pytest-xdist==3.6.1
 
 # Django deps:
 psycopg2-binary

--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -32,3 +32,8 @@ def django_plugin_hook(test_item: YamlTestItem) -> None:
 
     mysettings_file = File(path="mysettings.py", content=custom_settings)
     test_item.files.append(mysettings_file)
+
+    if hasattr(test_item.config, "workerinput"):
+        # Append worker ID to cache directory to prevent race conditions during parallel mypy testing
+        # Avoids potential file corruption when multiple processes access/write cached files simultaneously
+        test_item.incremental_cache_dir += test_item.config.workerinput["workerid"]

--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -31,7 +31,7 @@ def django_plugin_hook(test_item: YamlTestItem) -> None:
             test_item.additional_mypy_config += django_settings_section
 
     # Disable caching in tests to allow parallel execution
-    test_item.disable_cache = True
+    test_item.disable_cache = False
 
     mysettings_file = File(path="mysettings.py", content=custom_settings)
     test_item.files.append(mysettings_file)

--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -30,8 +30,5 @@ def django_plugin_hook(test_item: YamlTestItem) -> None:
         if "[mypy.plugins.django-stubs]" not in test_item.additional_mypy_config:
             test_item.additional_mypy_config += django_settings_section
 
-    # Disable caching in tests to allow parallel execution
-    test_item.disable_cache = False
-
     mysettings_file = File(path="mysettings.py", content=custom_settings)
     test_item.files.append(mysettings_file)

--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -30,5 +30,8 @@ def django_plugin_hook(test_item: YamlTestItem) -> None:
         if "[mypy.plugins.django-stubs]" not in test_item.additional_mypy_config:
             test_item.additional_mypy_config += django_settings_section
 
+    # Disable caching in tests to allow parallel execution
+    test_item.disable_cache = True
+
     mysettings_file = File(path="mysettings.py", content=custom_settings)
     test_item.files.append(mysettings_file)

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -44,7 +44,6 @@
                     some_decimal = models.DecimalField(max_digits=10, decimal_places=5)
 
 -   case: test_add_id_field_if_no_primary_key_defined
-    disable_cache: true
     main: |
         from myapp.models import User
         reveal_type(User().id)  # N: Revealed type is "builtins.int"
@@ -59,7 +58,6 @@
                     pass
 
 -   case: test_do_not_add_id_if_field_with_primary_key_True_defined
-    disable_cache: true
     main: |
         from myapp.models import User
         reveal_type(User().my_pk)  # N: Revealed type is "builtins.int"

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -453,7 +453,6 @@
                 NewManager = models.Manager.from_queryset(ModelQuerySet)
 
 -   case: from_queryset_with_inherited_manager_and_typing_no_return
-    disable_cache: true
     main: |
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -684,7 +683,6 @@
 # For details see: https://github.com/typeddjango/django-stubs/issues/1022
 -   case: from_queryset_custom_auth_user_model
     # Cache needs to be disabled to consistently reproduce the bug
-    disable_cache: true
     main: |
         from users.models import User
     custom_settings: |

--- a/tests/typecheck/models/test_extra_methods.yml
+++ b/tests/typecheck/models/test_extra_methods.yml
@@ -20,7 +20,6 @@
                     gender = models.CharField(max_length=100, choices=GENDER_CHOICES)
 
 -   case: date_datetime_fields_have_get_next_by_get_previous_by
-    disable_cache: true
     parametrized:
         - allow_any: "true"
         - allow_any: "false"

--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -1,5 +1,4 @@
 -   case: settings_loaded_from_different_files
-    disable_cache: true
     main: |
         from django.conf import settings
         # standard settings
@@ -61,7 +60,6 @@
 
 
 -   case: settings_loaded_from_runtime_magic
-    disable_cache: true
     main: |
         from django.conf import settings
 
@@ -81,7 +79,6 @@
 
 
 -   case: settings_loaded_from_runtime_magic_strict_default
-    disable_cache: true
     main: |
         from django.conf import settings
 


### PR DESCRIPTION
# I have made things!

This speed up the `django-stubs` test suite by using multiprocessing with [`pytest-xdist`](https://github.com/pytest-dev/pytest-xdist).

- Locally, I went from **~5min to ~25s** for the whole test suite.
- In CI, it went from **[~3min](https://github.com/typeddjango/django-stubs/actions/runs/14017953849/job/39246069086) to [~1min20s](https://github.com/typeddjango/django-stubs/actions/runs/14070003527/job/39401764007?pr=2580)** per shard
