### PR TITLE
Update Django 4.2 LTS version to 4.2.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest-xdist==3.6.1
 
 # Django deps:
 psycopg2-binary
-Django==4.2.16; python_version < '3.10'
+Django==4.2.20; python_version < '3.10'
 Django==5.1.7; python_version >= '3.10'
 -e ./ext
 -e .[redis,compatible-mypy,oracle]


### PR DESCRIPTION
Solves GitHub's Dependabot security alerts. The alerts are created because we still use an older Django version in requirements.txt when testing with older Python versions. There is no security impact, because Django is only used in CI and not exposed as a web service.

## Related issues

- Closes https://github.com/typeddjango/django-stubs/security/dependabot/26
- Previous one: #2369
