### PR TITLE
Allow tuples for some `TypedModelMeta` fields

### DIFF
--- a/ext/django_stubs_ext/db/models/__init__.py
+++ b/ext/django_stubs_ext/db/models/__init__.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     from typing import ClassVar, Literal, Union
 
     from django.db.models import BaseConstraint, Index, OrderBy
+    from django.utils.datastructures import _ListOrTuple
 
     from django_stubs_ext import StrOrPromise
 
@@ -28,16 +29,16 @@ if TYPE_CHECKING:
         managed: ClassVar[bool]  # default: True
         order_with_respect_to: ClassVar[str]
         ordering: ClassVar[Sequence[Union[str, OrderBy]]]
-        permissions: ClassVar[list[tuple[str, str]]]
+        permissions: ClassVar[_ListOrTuple[tuple[str, str]]]
         default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
         proxy: ClassVar[bool]  # default: False
-        required_db_features: ClassVar[list[str]]
+        required_db_features: ClassVar[_ListOrTuple[str]]
         required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
         select_on_save: ClassVar[bool]  # default: False
-        indexes: ClassVar[list[Index]]
+        indexes: ClassVar[_ListOrTuple[Index]]
         unique_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]
         index_together: ClassVar[Union[Sequence[Sequence[str]], Sequence[str]]]  # Deprecated in Django 4.2
-        constraints: ClassVar[list[BaseConstraint]]
+        constraints: ClassVar[_ListOrTuple[BaseConstraint]]
         verbose_name: ClassVar[StrOrPromise]
         verbose_name_plural: ClassVar[StrOrPromise]
 


### PR DESCRIPTION
# I have made things!

Django supports both `list` and `tuple` in many places, including here.

## Related issues

N/A