### PR TITLE
Update `django.core.validators` for Django 5.2

### DIFF
--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -33,6 +33,7 @@ class DomainNameValidator(RegexValidator):
     ul: str
     hostname_re: str
     domain_re: str
+    tld_no_fqdn_re: str
     tld_re: str
     ascii_only_hostname_re: str
     ascii_only_domain_re: str
@@ -65,6 +66,9 @@ def validate_integer(value: float | str | None) -> None: ...
 class EmailValidator(_Deconstructible):
     message: _StrOrPromise
     code: str
+    domain_re: str
+    hostname_re: str
+    tld_no_fqdn_re: str
     user_regex: Pattern[str]
     domain_regex: Pattern[str]
     literal_regex: Pattern[str]

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -146,10 +146,6 @@ django.core.serializers.json.Deserializer
 django.core.serializers.jsonl.Deserializer
 django.core.serializers.python.Deserializer
 django.core.serializers.pyyaml.Deserializer
-django.core.validators.DomainNameValidator.tld_no_fqdn_re
-django.core.validators.EmailValidator.domain_re
-django.core.validators.EmailValidator.hostname_re
-django.core.validators.EmailValidator.tld_no_fqdn_re
 django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint


### PR DESCRIPTION
# I have made things!
- added
    - `django.core.validators.DomainNameValidator.tld_no_fqdn_re`
    - `django.core.validators.EmailValidator.domain_re`
    - `django.core.validators.EmailValidator.hostname_re`
    - `django.core.validators.EmailValidator.tld_no_fqdn_re`
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues
[django PR 18950](https://github.com/django/django/pull/18950)

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
