### PR TITLE
Allow `MutableMapping` for `Form.Initial`

### DIFF
--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, MutableMapping
 from typing import Any, ClassVar
 
 from django.core.exceptions import ValidationError
@@ -19,7 +19,7 @@ class BaseForm(RenderableFormMixin):
     data: _DataT
     files: _FilesT
     auto_id: bool | str
-    initial: Mapping[str, Any]
+    initial: MutableMapping[str, Any]
     error_class: type[ErrorList]
     prefix: str | None
     label_suffix: str
@@ -38,7 +38,7 @@ class BaseForm(RenderableFormMixin):
         files: _FilesT | None = None,
         auto_id: bool | str = "id_%s",
         prefix: str | None = None,
-        initial: Mapping[str, Any] | None = None,
+        initial: MutableMapping[str, Any] | None = None,
         error_class: type[ErrorList] = ...,
         label_suffix: str | None = None,
         empty_permitted: bool = False,

--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Collection, Container, Iterator, Mapping, Sequence
+from collections.abc import Callable, Collection, Container, Iterator, Mapping, MutableMapping, Sequence
 from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
 from uuid import UUID
 
@@ -76,7 +76,7 @@ class BaseModelForm(Generic[_M], BaseForm):
         files: _FilesT | None = None,
         auto_id: bool | str = "id_%s",
         prefix: str | None = None,
-        initial: Mapping[str, Any] | None = None,
+        initial: MutableMapping[str, Any] | None = None,
         error_class: type[ErrorList] = ...,
         label_suffix: str | None = None,
         empty_permitted: bool = False,


### PR DESCRIPTION
# I have made things!

This allows modifying the `initial` dict of a `Form` / `ModelForm`. 
[This is a regular dict at runtime](https://github.com/django/django/blob/main/django/forms/forms.py#L94) so I think it make more sense to use `MutableMapping` here.

I was stuck with this error for a use case where I infer the initial value of a `ModelForm` field based on a field on the instance.
Something like that:

```python
def __init__(self, *args: Any, **kwargs: Any) -> None:
    super().__init__(*args, **kwargs)

    if self.instance.pk and self.instance.billing_address:
        self.initial["use_specific_billing_address"] = (
            self.instance.billing_address != self.instance.address
        )
    else:
         self.initial["use_specific_billing_address"] = False
```


## Related issues
None