### PR TITLE
Add stub for `get_select2_language` from `django.contrib.admin.widgets`

### DIFF
--- a/django-stubs/contrib/admin/widgets.pyi
+++ b/django-stubs/contrib/admin/widgets.pyi
@@ -133,6 +133,8 @@ class AdminUUIDInputWidget(forms.TextInput):
 
 SELECT2_TRANSLATIONS: dict[str, str]
 
+def get_select2_language() -> str | None: ...
+
 class AutocompleteMixin:
     url_name: str
     field: Any

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -50,7 +50,6 @@ django.contrib.admin.views.autocomplete.AutocompleteJsonView.serialize_result
 django.contrib.admin.views.main.ChangeList.search_form_class
 django.contrib.admin.widgets.AutocompleteMixin.media
 django.contrib.admin.widgets.FilteredSelectMultiple.Media
-django.contrib.admin.widgets.get_select2_language
 django.contrib.admin.widgets.BaseAdminTimeWidget.Media
 django.contrib.admin.widgets.BaseAdminDateWidget.Media
 django.contrib.admindocs.utils.non_capturing_group_matcher


### PR DESCRIPTION
# I have made things!

## Related issues
None.


I am not sure whether it should be specified from which version this stub should be used, as the function was not present in Django 3.2.x. I looked how the rest of the types look like and it seems like they are version independent.
