### PR TITLE
Restrict setuptools to <79.0.0 for SETUPTOOLS_ENABLE_FEATURES=legacy-editable to work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run mypy on plugin code
@@ -63,7 +63,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       # Must match `shard` definition in the test matrix:
@@ -91,7 +91,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run stubtest
@@ -112,7 +112,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
       - name: Run pyright on the stubs
         uses: jakebailey/pyright-action@v2
@@ -146,7 +146,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
           pip install "Django==${{ matrix.django-version }}"
           pip check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ known-first-party = ["django_stubs_ext", "mypy_django_plugin"]
 split-on-trailing-comma = false
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<79.0.0", "wheel"]


### PR DESCRIPTION
`setuptools==79.0.0` released on April 20 2025 removed support for "legacy-editable", thus breaking CI.
(thanks @UnknownPlatypus for finding the problem reason)
https://setuptools.pypa.io/en/stable/history.html#v79-0-0

On another PR, @sobolevn suggested explicitly using the older `setuptools` version.
https://github.com/typeddjango/django-stubs/pull/2615#issuecomment-2819618591