### PR TITLE
add null keyword argument to ManyToManyField init

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -272,6 +272,7 @@ class ManyToManyField(RelatedField[Any, Any], Generic[_To, _Through]):
         max_length: int | None = ...,
         unique: bool = ...,
         blank: bool = ...,
+        null: bool = ...,
         db_index: bool = ...,
         default: Any = ...,
         editable: bool = ...,

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1597,3 +1597,12 @@
                     featured = models.BooleanField()
                     authors = models.ManyToManyField(Author)
                     objects = OtherManager()
+
+-   case: test_many_to_many_field_null
+    main: |
+        from django.db import models
+        class Person(models.Model):
+            friends = models.ManyToManyField("self", null=True, blank=True)
+
+        p: Person
+        reveal_type(p.friends)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[main.Person, main.Person_friends]"


### PR DESCRIPTION
# I have made things!

Resolves #2505, added the `null` keyword argument to `ManyToManyField`'s `__init__`
