### PR TITLE
Narrow `RegexValidator.regex` instance level type to `Pattern[str]`

### DIFF
--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Collection, Sequence, Sized
 from decimal import Decimal
 from re import Pattern, RegexFlag
-from typing import Any, Generic, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, TypeAlias
 
 from django.core.files.base import File
 from django.utils.deconstruct import _Deconstructible
@@ -13,19 +13,8 @@ _Regex: TypeAlias = str | Pattern[str]
 
 _ValidatorCallable: TypeAlias = Callable[[Any], None]  # noqa: PYI047
 
-_ClassT = TypeVar("_ClassT")
-_InstanceT = TypeVar("_InstanceT")
-
-@type_check_only
-class _ClassOrInstanceAttribute(Generic[_ClassT, _InstanceT]):
-    @overload
-    def __get__(self, instance: None, owner: type[object]) -> _ClassT: ...
-    @overload
-    def __get__(self, instance: object, owner: type[object]) -> _InstanceT: ...
-    def __set__(self, instance: object, value: _InstanceT) -> None: ...
-
 class RegexValidator(_Deconstructible):
-    regex: _ClassOrInstanceAttribute[_Regex, Pattern[str]]
+    regex: Pattern[str]
     message: _StrOrPromise
     code: str
     inverse_match: bool

--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -14,7 +14,7 @@ _Regex: TypeAlias = str | Pattern[str]
 _ValidatorCallable: TypeAlias = Callable[[Any], None]  # noqa: PYI047
 
 class RegexValidator(_Deconstructible):
-    regex: _Regex  # Pattern[str] on instance, but may be str on class definition
+    regex: Pattern[str]
     message: _StrOrPromise
     code: str
     inverse_match: bool

--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -17,15 +17,15 @@ _ClassT = TypeVar("_ClassT")
 _InstanceT = TypeVar("_InstanceT")
 
 @type_check_only
-class ClassOrInstanceAttribute(Generic[_ClassT, _InstanceT]):
+class _ClassOrInstanceAttribute(Generic[_ClassT, _InstanceT]):
     @overload
-    def __get__(self, obj: None, owner: type[object]) -> _ClassT: ...
+    def __get__(self, instance: None, owner: type[object]) -> _ClassT: ...
     @overload
-    def __get__(self, obj: object, owner: type[object]) -> _InstanceT: ...
-    def __set__(self, obj: object, value: _InstanceT) -> None: ...
+    def __get__(self, instance: object, owner: type[object]) -> _InstanceT: ...
+    def __set__(self, instance: object, value: _InstanceT) -> None: ...
 
 class RegexValidator(_Deconstructible):
-    regex: ClassOrInstanceAttribute[_Regex, Pattern[str]]
+    regex: _ClassOrInstanceAttribute[_Regex, Pattern[str]]
     message: _StrOrPromise
     code: str
     inverse_match: bool

--- a/django-stubs/core/validators.pyi
+++ b/django-stubs/core/validators.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Collection, Sequence, Sized
 from decimal import Decimal
 from re import Pattern, RegexFlag
-from typing import Any, TypeAlias
+from typing import Any, Generic, TypeAlias, TypeVar, overload, type_check_only
 
 from django.core.files.base import File
 from django.utils.deconstruct import _Deconstructible
@@ -13,8 +13,19 @@ _Regex: TypeAlias = str | Pattern[str]
 
 _ValidatorCallable: TypeAlias = Callable[[Any], None]  # noqa: PYI047
 
+_ClassT = TypeVar("_ClassT")
+_InstanceT = TypeVar("_InstanceT")
+
+@type_check_only
+class ClassOrInstanceAttribute(Generic[_ClassT, _InstanceT]):
+    @overload
+    def __get__(self, obj: None, owner: type[object]) -> _ClassT: ...
+    @overload
+    def __get__(self, obj: object, owner: type[object]) -> _InstanceT: ...
+    def __set__(self, obj: object, value: _InstanceT) -> None: ...
+
 class RegexValidator(_Deconstructible):
-    regex: Pattern[str]
+    regex: ClassOrInstanceAttribute[_Regex, Pattern[str]]
     message: _StrOrPromise
     code: str
     inverse_match: bool

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -550,3 +550,9 @@ django.contrib.gis.forms.BaseModelFormSet.save_m2m
 
 # Dynamically generated in https://github.com/django/django/blob/0ee06c04e0256094270db3ffe8b5dafa6a8457a3/django/core/mail/backends/locmem.py#L24
 django.core.mail.outbox
+
+# We use a trick using a descriptor class to represent an attribute with different type at the class and instance level.
+# Here to narrow `str | Pattern[str]` at the class level to `Pattern[str]` at the instance level.
+django.core.validators.RegexValidator.regex
+django.contrib.auth.validators.ASCIIUsernameValidator.regex
+django.contrib.auth.validators.UnicodeUsernameValidator.regex

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -551,8 +551,9 @@ django.contrib.gis.forms.BaseModelFormSet.save_m2m
 # Dynamically generated in https://github.com/django/django/blob/0ee06c04e0256094270db3ffe8b5dafa6a8457a3/django/core/mail/backends/locmem.py#L24
 django.core.mail.outbox
 
-# We use a trick using a descriptor class to represent an attribute with different type at the class and instance level.
-# Here to narrow `str | Pattern[str]` at the class level to `Pattern[str]` at the instance level.
+# The type system does not allow to represent an attribute with different type at the class level (`str | Pattern[str]`)
+# and instance (`Pattern[str]`) level. But in order to have more precise type at the instance level, we restrict the types
+# allowed at the class level to a subset. In an ideal world, these should probably have different attribute names.
 django.core.validators.RegexValidator.regex
 django.contrib.auth.validators.ASCIIUsernameValidator.regex
 django.contrib.auth.validators.UnicodeUsernameValidator.regex

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -29,4 +29,4 @@ UnicodeUsernameValidator.regex = ""  # type: ignore[assignment] # pyright: ignor
 
 
 class StrSubtype(RegexValidator):
-    regex = "abc"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+    regex = "abc"  # type: ignore[assignment] # pyright: ignore[reportAssignmentType]

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -1,3 +1,4 @@
+import re
 from re import Pattern
 from typing import assert_type
 
@@ -6,6 +7,12 @@ from django.core.validators import RegexValidator
 
 assert_type(RegexValidator.regex, str | Pattern[str])
 assert_type(RegexValidator().regex, Pattern[str])
+RegexValidator().regex = re.compile("")
+RegexValidator().regex = ""  # type: ignore[assignment] # expect "Pattern[str]"
+RegexValidator.regex = "anything fails here"  # type: ignore[assignment] # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
 
 assert_type(UnicodeUsernameValidator.regex, str | Pattern[str])
 assert_type(UnicodeUsernameValidator().regex, Pattern[str])
+UnicodeUsernameValidator().regex = re.compile("")
+UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # expect "Pattern[str]"
+UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment] # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -1,0 +1,11 @@
+from re import Pattern
+from typing import assert_type
+
+from django.contrib.auth.validators import UnicodeUsernameValidator
+from django.core.validators import RegexValidator
+
+assert_type(RegexValidator.regex, str | Pattern[str])
+assert_type(RegexValidator().regex, Pattern[str])
+
+assert_type(UnicodeUsernameValidator.regex, str | Pattern[str])
+assert_type(UnicodeUsernameValidator().regex, Pattern[str])

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -13,6 +13,7 @@ assert_type(UnicodeUsernameValidator.regex, str | Pattern[str])
 assert_type(UnicodeUsernameValidator().regex, Pattern[str])
 UnicodeUsernameValidator().regex = re.compile("")
 
+
 # expect "Pattern[str]"
 RegexValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
 UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
@@ -20,3 +21,11 @@ UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # pyright: ign
 # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
 RegexValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
 UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+
+
+class RegexSubtype(RegexValidator):
+    regex = re.compile("abc")
+
+
+class StrSubtype(RegexValidator):
+    regex = "abc"

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -1,18 +1,22 @@
 import re
 from re import Pattern
-from typing import assert_type
 
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.validators import RegexValidator
+from typing_extensions import assert_type
 
 assert_type(RegexValidator.regex, str | Pattern[str])
 assert_type(RegexValidator().regex, Pattern[str])
 RegexValidator().regex = re.compile("")
-RegexValidator().regex = ""  # type: ignore[assignment] # expect "Pattern[str]"
-RegexValidator.regex = "anything fails here"  # type: ignore[assignment] # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
 
 assert_type(UnicodeUsernameValidator.regex, str | Pattern[str])
 assert_type(UnicodeUsernameValidator().regex, Pattern[str])
 UnicodeUsernameValidator().regex = re.compile("")
-UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # expect "Pattern[str]"
-UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment] # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
+
+# expect "Pattern[str]"
+RegexValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+
+# expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
+RegexValidator.regex = "anything fails here"  # type: ignore[assignment]
+UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment]

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -18,5 +18,5 @@ RegexValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[report
 UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
 
 # expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
-RegexValidator.regex = "anything fails here"  # type: ignore[assignment]
-UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment]
+RegexValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/assert_type/core/test_validators.py
+++ b/tests/assert_type/core/test_validators.py
@@ -5,27 +5,28 @@ from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.validators import RegexValidator
 from typing_extensions import assert_type
 
-assert_type(RegexValidator.regex, str | Pattern[str])
 assert_type(RegexValidator().regex, Pattern[str])
 RegexValidator().regex = re.compile("")
 
-assert_type(UnicodeUsernameValidator.regex, str | Pattern[str])
 assert_type(UnicodeUsernameValidator().regex, Pattern[str])
 UnicodeUsernameValidator().regex = re.compile("")
-
 
 # expect "Pattern[str]"
 RegexValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
 UnicodeUsernameValidator().regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
-
-# expect "_ClassOrInstanceAttribute[Union[str, Pattern[str]], Pattern[str]]"
-RegexValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
-UnicodeUsernameValidator.regex = "anything fails here"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
 
 
 class RegexSubtype(RegexValidator):
     regex = re.compile("abc")
 
 
+# We would like to improve on these, it should allow "str | Pattern[str]":
+assert_type(RegexValidator.regex, Pattern[str])
+assert_type(UnicodeUsernameValidator.regex, Pattern[str])
+
+RegexValidator.regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+UnicodeUsernameValidator.regex = ""  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]
+
+
 class StrSubtype(RegexValidator):
-    regex = "abc"
+    regex = "abc"  # type: ignore[assignment] # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
# I have made things!

This is cast to a lazy Pattern in the [`__init__`](https://github.com/django/django/blob/9d93e35c207a001de1aa9ca9165bdec824da9021/django/core/validators.py#L45) so I think it makes sens to narrow here. 

This fixes an issue I had at work when trying to access the regex pattern

```python
validate_not_gmail = RegexValidator(
    regex=r".+@(?!gmail).+\..+",
    message="The email address cannot contain gmail",
)
...
class MyForm(forms.Form):
    email = EmailField(
        label="Mail",
        required=True,
        widget=Input(
            input_type="email",
            attrs={
                "pattern": validate_not_gmail.regex.pattern, # error: Item "str" of "str | Pattern[str]" has no attribute "pattern"
                "title": validate_not_gmail.message,
            },
        ),
        validators=[validate_email_required, validate_not_gmail],
    )
```

This makes the type of `regex` on the class slightly off but I think it's better than having it slightly off for instances which people are usually working with.