### PR TITLE
Stronger type for `settings.AUTH_PASSWORD_VALIDATORS`

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -404,11 +404,11 @@ PASSWORD_RESET_TIMEOUT: int
 PASSWORD_HASHERS: list[str]
 
 @type_check_only
-class AuthPasswordValidatorsDict(TypedDict):
+class _AuthPasswordValidatorsDict(TypedDict):
     NAME: str
     OPTIONS: NotRequired[dict[str, Any]]
 
-AUTH_PASSWORD_VALIDATORS: list[AuthPasswordValidatorsDict]
+AUTH_PASSWORD_VALIDATORS: list[_AuthPasswordValidatorsDict]
 
 ###########
 # SIGNING #

--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -3,7 +3,9 @@ from re import Pattern
 
 # This is defined here as a do-nothing function because we can't import
 # django.utils.translation -- that module depends on the settings.
-from typing import Any, Literal, Protocol, TypeAlias, type_check_only
+from typing import Any, Literal, Protocol, TypeAlias, TypedDict, type_check_only
+
+from typing_extensions import NotRequired
 
 _Admins: TypeAlias = list[tuple[str, str]]
 
@@ -401,7 +403,12 @@ PASSWORD_RESET_TIMEOUT: int
 # upon login
 PASSWORD_HASHERS: list[str]
 
-AUTH_PASSWORD_VALIDATORS: list[dict[str, str]]
+@type_check_only
+class AuthPasswordValidatorsDict(TypedDict):
+    NAME: str
+    OPTIONS: NotRequired[dict[str, Any]]
+
+AUTH_PASSWORD_VALIDATORS: list[AuthPasswordValidatorsDict]
 
 ###########
 # SIGNING #


### PR DESCRIPTION
# I have made things!

This expect a list of dict with required `NAME` key and optional `OPTION` key.
See usage [in django](https://github.com/django/django/blob/9d93e35c207a001de1aa9ca9165bdec824da9021/django/contrib/auth/password_validation.py#L25-L38)

## Related issues

Closes #215
