### PR TITLE
Enable a few more ruff rules

### DIFF
--- a/django-stubs/db/backends/base/introspection.pyi
+++ b/django-stubs/db/backends/base/introspection.pyi
@@ -1,17 +1,24 @@
-from collections import namedtuple
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.utils import CursorWrapper
 from django.db.models.base import Model
 
-TableInfo = namedtuple("TableInfo", ["name", "type"])
+class TableInfo(NamedTuple):
+    name: str
+    type: str
 
-FieldInfo = namedtuple(
-    "FieldInfo",
-    ["name", "type_code", "display_size", "internal_size", "precision", "scale", "null_ok", "default", "collation"],
-)
+class FieldInfo(NamedTuple):
+    name: str
+    type_code: int
+    display_size: int
+    internal_size: int
+    precision: int
+    scale: int
+    null_ok: bool
+    default: str
+    collation: str
 
 class BaseDatabaseIntrospection:
     data_types_reverse: Any

--- a/django-stubs/db/backends/mysql/introspection.pyi
+++ b/django-stubs/db/backends/mysql/introspection.pyi
@@ -1,24 +1,20 @@
-from collections import namedtuple
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.db.backends.base.introspection import BaseDatabaseIntrospection
 from django.db.backends.mysql.base import DatabaseWrapper
 
 FieldInfo: Any
-InfoLine = namedtuple(
-    "InfoLine",
-    [
-        "col_name",
-        "data_type",
-        "max_len",
-        "num_prec",
-        "num_scale",
-        "extra",
-        "column_default",
-        "collation",
-        "is_unsigned",
-    ],
-)
+
+class InfoLine(NamedTuple):
+    col_name: str
+    data_type: str
+    max_len: int
+    num_prec: int
+    num_scale: int
+    extra: str
+    column_default: str
+    collation: str | None
+    is_unsigned: bool
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     connection: DatabaseWrapper

--- a/django-stubs/db/migrations/operations/utils.pyi
+++ b/django-stubs/db/migrations/operations/utils.pyi
@@ -1,6 +1,5 @@
-from collections import namedtuple
 from collections.abc import Iterator
-from typing import Literal
+from typing import Any, Literal, NamedTuple
 
 from django.db.migrations.state import ModelState, ProjectState
 from django.db.models import Field, Model
@@ -9,7 +8,9 @@ def resolve_relation(
     model: str | type[Model], app_label: str | None = ..., model_name: str | None = ...
 ) -> tuple[str, str]: ...
 
-FieldReference = namedtuple("FieldReference", ["to", "through"])
+class FieldReference(NamedTuple):
+    to: Any
+    through: Any
 
 def field_references(
     model_tuple: tuple[str, str],

--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -1,6 +1,5 @@
-from collections import namedtuple
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, ClassVar, Literal, TypeVar
+from typing import Any, ClassVar, Literal, NamedTuple, TypeVar
 
 from _typeshed import Incomplete
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -9,15 +8,21 @@ from django.db.models.expressions import BaseExpression
 from django.db.models.fields import Field
 from django.db.models.fields.mixins import FieldCacheMixin
 from django.db.models.lookups import Lookup, Transform
+from django.db.models.options import Options
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from django.db.models.sql.query import Query
 from django.db.models.sql.where import WhereNode
 from django.utils import tree
 from django.utils.functional import cached_property
 
-PathInfo = namedtuple(
-    "PathInfo", ["from_opts", "to_opts", "target_fields", "join_field", "m2m", "direct", "filtered_relation"]
-)
+class PathInfo(NamedTuple):
+    from_opts: Options
+    to_opts: Options
+    target_fields: tuple[Field, ...]
+    join_field: Field
+    m2m: bool
+    direct: bool
+    filtered_relation: FilteredRelation | None
 
 def subclasses(cls: type[RegisterLookupMixin]) -> Iterator[type[RegisterLookupMixin]]: ...
 

--- a/django-stubs/db/models/sql/query.pyi
+++ b/django-stubs/db/models/sql/query.pyi
@@ -1,7 +1,6 @@
 import collections
-from collections import namedtuple
-from collections.abc import Iterable, Iterator, Sequence
-from typing import Any, Literal
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import Any, Literal, NamedTuple
 
 from django.db.backends.utils import CursorWrapper
 from django.db.models import Field, FilteredRelation, Model, Q
@@ -13,7 +12,13 @@ from django.db.models.sql.datastructures import BaseTable, Join
 from django.db.models.sql.where import WhereNode
 from django.utils.functional import cached_property
 
-JoinInfo = namedtuple("JoinInfo", ("final_field", "targets", "opts", "joins", "path", "transform_function"))
+class JoinInfo(NamedTuple):
+    final_field: Field
+    targets: tuple[Any, ...]
+    opts: Any
+    joins: list[str]
+    path: list[Any]
+    transform_function: Callable[[Field, str], Expression]
 
 class RawQuery:
     high_mark: int | None

--- a/django-stubs/template/defaulttags.pyi
+++ b/django-stubs/template/defaulttags.pyi
@@ -1,7 +1,6 @@
-from collections import namedtuple
 from collections.abc import Iterator, Sequence
 from datetime import date as real_date
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.http.request import QueryDict
 from django.template.base import FilterExpression, Parser, Token
@@ -78,7 +77,9 @@ class LoremNode(Node):
     method: str
     def __init__(self, count: FilterExpression, method: str, common: bool) -> None: ...
 
-GroupedResult = namedtuple("GroupedResult", ["grouper", "list"])
+class GroupedResult(NamedTuple):
+    grouper: Any
+    list: list[Any]
 
 class RegroupNode(Node):
     expression: FilterExpression

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,6 @@ ignore = [
     "PYI024",
     "PYI041",
     "PYI043",
-    # no-return-argument-annotation-in-stub
-    # Prefers typing.Never to typing.NoReturn, but Never only available on
-    # Python 3.11+
-    "PYI050",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ select = [
 ignore = [
     "PYI021",
     "PYI024",
-    "PYI041",
+    "PYI041", # This might not be obvious that `float | int` is mostly equivalent to `float` typing wise | int | str
     "PYI043",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ select = [
     "PGH003",   # Disallowed blanket `type: ignore` annotations.
 ]
 ignore = [
-    "PYI021",
+    "PYI021", # We have a few meaningful docstrings for stubs only constructs/utilities.
     "PYI041", # This might not be obvious that `float | int` is mostly equivalent to `float` typing wise | int | str
     "PYI043",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "_typeshed.Self".msg = "Use typing_extensions.Self (PEP 673) instead."
+"typing.assert_type".msg = "Use typing_extensions.assert_type instead."
 
 [tool.ruff.lint.isort]
 known-first-party = ["django_stubs_ext", "mypy_django_plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ select = [
 ]
 ignore = [
     "PYI021",
-    "PYI024",
     "PYI041", # This might not be obvious that `float | int` is mostly equivalent to `float` typing wise | int | str
     "PYI043",
 ]


### PR DESCRIPTION
# I have made things! 

This does a few `ruff` related upgrades:
- ensure `assert_type` is imported from `typing_extension` (otherwise ci fails when testing with python 3.10).
- remove `PYI050` ignore -- ruff already knows it cannot run this rule since we declare `target-version 310`.
- document `PYI041`and `PYI021` ignores.
- remove `PYI024` ignore and fix existing violations.

I would also like to remove the `PYI043` ignore, I think it's valuable because `TypeAlias` and `TypeVar` are easily confused right now. See https://docs.astral.sh/ruff/rules/t-suffixed-type-alias/.
Let me know what you think, I can send a followup PR or document why we keep the ignore.

