### PR TITLE
Update _AsSqlType to allow tuple[str, tuple]

### DIFF
--- a/django-stubs/db/models/sql/compiler.pyi
+++ b/django-stubs/db/models/sql/compiler.pyi
@@ -10,11 +10,12 @@ from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression, Expression, Ref
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import AggregateQuery, DeleteQuery, InsertQuery, UpdateQuery
+from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import cached_property
 
 _ParamT: TypeAlias = str | int
 
-_ParamsT: TypeAlias = list[_ParamT]
+_ParamsT: TypeAlias = _ListOrTuple[_ParamT]
 _AsSqlType: TypeAlias = tuple[str, _ParamsT]
 
 class PositionRef(Ref):


### PR DESCRIPTION
### I have made things!

### Description
The Django ORM uses both tuples and lists for the params portion of the `as_sql()` return. This can cause problems ([ticket](https://code.djangoproject.com/ticket/35972)/[forum](https://forum.djangoproject.com/t/advanced-postgresql-functions-like-json-to-recordset-json-jsonb-to-recordset-jsonb/35542/5)/[PR](https://github.com/django/django/pull/19057)), but until the type is eventually narrowed to just `tuple[str, tuple]`  as described on the Django ticket, the stub should allow `tuple[str, tuple]` in addition to `tuple[str, list]` to reflect the current state of play.