### PR TITLE
Fix postgres OrderableAggMixin & BTreeIndex

### DIFF
--- a/django-stubs/contrib/postgres/aggregates/mixins.pyi
+++ b/django-stubs/contrib/postgres/aggregates/mixins.pyi
@@ -9,7 +9,11 @@ from typing_extensions import Self
 class OrderableAggMixin:
     order_by: OrderByList
     def __init__(
-        self, *expressions: BaseExpression | Combinable | str, ordering: Sequence[str] = ..., **extra: Any
+        self,
+        *expressions: BaseExpression | Combinable | str,
+        ordering: Sequence[str] = ...,
+        order_by: Sequence[str] = ...,
+        **extra: Any,
     ) -> None: ...
     def resolve_expression(self, *args: Any, **kwargs: Any) -> Self: ...
     def get_source_expressions(self) -> list[Expression]: ...

--- a/django-stubs/contrib/postgres/indexes.pyi
+++ b/django-stubs/contrib/postgres/indexes.pyi
@@ -51,6 +51,7 @@ class BTreeIndex(PostgresIndex):
         self,
         *expressions: BaseExpression | Combinable | str,
         fillfactor: int | None = None,
+        deduplicate_items: bool | None = None,
         fields: Sequence[str] = ...,
         name: str | None = ...,
         db_tablespace: str | None = ...,

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -35,8 +35,6 @@ django.contrib.gis.management
 django.contrib.gis.management.commands
 django.contrib.gis.management.commands.inspectdb
 django.contrib.gis.management.commands.ogrinspect
-django.contrib.postgres.aggregates.mixins.OrderableAggMixin.__init__
-django.contrib.postgres.indexes.BTreeIndex.__init__
 django.contrib.sessions.backends.base.SessionBase.pop
 django.core.checks.Tags.commands
 django.core.checks.commands


### PR DESCRIPTION
# I have made things!

Fix Django 5.2 support for 
```
django.contrib.postgres.aggregates.mixins.OrderableAggMixin.__init__
django.contrib.postgres.indexes.BTreeIndex.__init__
```

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

Not sure is there is some issue for solving it :)
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
