### PR TITLE
change assertFormError form arg type to BaseForm

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -12,7 +12,7 @@ from django.db import connections as connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.base import Model
 from django.db.models.query import QuerySet, RawQuerySet
-from django.forms import BaseFormSet, Form
+from django.forms import BaseForm, BaseFormSet
 from django.forms.fields import EmailField
 from django.http import HttpRequest
 from django.http.response import FileResponse, HttpResponseBase
@@ -101,7 +101,7 @@ class SimpleTestCase(unittest.TestCase):
     ) -> None: ...
     def assertFormError(
         self,
-        form: Form,
+        form: BaseForm,
         field: str | None,
         errors: list[str] | str,
         msg_prefix: str = ...,


### PR DESCRIPTION
# I have made things!

Changes the form arg type for `django.test.SimpleTestCase.assertFormError` from `django.forms.Form` to `django.forms.BaseForm`. Allows instances of other form classes that are not subclasses of `Form` to be used without raising type errors, e.g. `ModelForm`. This also better aligns with the type used for `assertFormSetError` which types the formset arg as `BaseFormSet`, not `FormSet`.