### PR TITLE
Updated the "LogEntryManager" class' "log_action" and "log_actions" methods

### DIFF
--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -15,7 +15,7 @@ class LogEntryManager(models.Manager[LogEntry]):
     @deprecated("log_action() is deprecated and will be removed in Django 6.0. Use log_action_new() instead.")
     def log_action(
         self,
-        user_id: int,
+        user_id: int | str | UUID,
         content_type_id: int,
         object_id: int | str | UUID,
         object_repr: str,
@@ -24,7 +24,7 @@ class LogEntryManager(models.Manager[LogEntry]):
     ) -> LogEntry: ...
     def log_actions(
         self,
-        user_id: int,
+        user_id: int | str | UUID,
         queryset: QuerySet[Model],
         action_flag: int,
         change_message: str | list[Any] = "",


### PR DESCRIPTION
The `LogEntryManager` class' `log_action` and `log_actions` methods both accept `user_id`. Currently, both methods are set up to expect `user_id` to be an `int` ([source](https://github.com/typeddjango/django-stubs/blob/5.2.0/django-stubs/contrib/admin/models.pyi#L18-L27)). However, the user ID could be something else such as a UUID (it is a UUID in some of my projects). I have updated it to use `int | str | UUID` just like the `log_action` method's `object_id` argument.