### PR TITLE
Fix signature of `LogEntryManager.log_actions`

### DIFF
--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal, overload
 from uuid import UUID
 
 from django.db import models
@@ -22,6 +22,7 @@ class LogEntryManager(models.Manager[LogEntry]):
         action_flag: int,
         change_message: Any = ...,
     ) -> LogEntry: ...
+    @overload
     def log_actions(
         self,
         user_id: int | str | UUID,
@@ -29,8 +30,18 @@ class LogEntryManager(models.Manager[LogEntry]):
         action_flag: int,
         change_message: str | list[Any] = "",
         *,
-        single_object: bool = False,
-    ) -> list[LogEntry] | LogEntry: ...
+        single_object: Literal[True] = ...,
+    ) -> LogEntry: ...
+    @overload
+    def log_actions(
+        self,
+        user_id: int | str | UUID,
+        queryset: Iterable[Model],
+        action_flag: int,
+        change_message: str | list[Any] = "",
+        *,
+        single_object: Literal[False] = ...,
+    ) -> list[LogEntry]: ...
 
 class LogEntry(models.Model):
     action_time: models.DateTimeField

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -25,7 +25,7 @@ class LogEntryManager(models.Manager[LogEntry]):
     def log_actions(
         self,
         user_id: int | str | UUID,
-        queryset: QuerySet[Model],
+        queryset: Iterable[Model],
         action_flag: int,
         change_message: str | list[Any] = "",
         *,

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any, ClassVar
 from uuid import UUID
 

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -2,7 +2,6 @@ from typing import Any, ClassVar
 from uuid import UUID
 
 from django.db import models
-from django.db.models import QuerySet
 from django.db.models.base import Model
 from typing_extensions import deprecated
 


### PR DESCRIPTION
`LogEntryManager.log_actions` can take any `Iterable[T]` for the `queryset` param, not necessarily a `QuerySet[T]`. Indeed, Django itself invokes it with a `list[T]` in `ModelAdmin.log_addition`: https://github.com/django/django/blob/091f66e51aa900f7d7650529621bdc8e4b0dee68/django/contrib/admin/options.py#L945

