### PR TITLE
Fix `reveal_type` to return its argument

### DIFF
--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -135,5 +135,5 @@ def monkeypatch(extra_classes: Iterable[type] | None = None, include_builtins: b
 
     # Add `reveal_type` and `reveal_locals` helpers if needed:
     if include_builtins:
-        builtins.reveal_type = lambda _: None
+        builtins.reveal_type = lambda obj, /: obj
         builtins.reveal_locals = lambda: None


### PR DESCRIPTION
`reveal_type` can be used in the middle of an expression, as in `func(reveal_type(obj))`, so it needs to return its argument at runtime.

By the way, [`typing.reveal_type`](https://docs.python.org/3/library/typing.html#typing.reveal_type) was added to the runtime library in Python 3.11, and also as [`typing_extensions.reveal_type`](https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.reveal_type) for all Python versions in typing-extensions 4.1.0, so this monkey-patch is not really needed anymore—maybe we should turn it off by default.