### PR TITLE
Add missing instance variable declarations for `RawQuerySet`

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -203,7 +203,7 @@ class RawQuerySet(Iterable[_Model], Sized):
     def __init__(
         self,
         raw_query: RawQuery | str,
-        model: type[Model] | None = None,
+        model: type[_Model] | None = None,
         query: Query | None = None,
         params: tuple[Any, ...] = (),
         translations: dict[str, str] | None = None,

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -194,7 +194,12 @@ class QuerySet(Generic[_Model, _Row], Iterable[_Row], Sized):
     def __getitem__(self, s: slice) -> Self: ...
 
 class RawQuerySet(Iterable[_Model], Sized):
+    raw_query: RawQuery | str
+    model: type[_Model] | None
     query: RawQuery
+    params: tuple[Any, ...] | None
+    translations: dict[str, str]
+
     def __init__(
         self,
         raw_query: RawQuery | str,


### PR DESCRIPTION
Adding a few missing instance variable types