### PR TITLE
Fix aliasing of choices in a class in choices plugin

### DIFF
--- a/mypy_django_plugin/transformers/choices.py
+++ b/mypy_django_plugin/transformers/choices.py
@@ -5,6 +5,7 @@ from mypy.types import (
     AnyType,
     Instance,
     LiteralType,
+    Overloaded,
     ProperType,
     TupleType,
     TypeOfAny,
@@ -184,6 +185,8 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
             _node_type = get_proper_type(_node_type.upper_bound)
         if isinstance(_node_type, Instance):
             node = _node_type.type
+        if isinstance(_node_type, Overloaded) and _node_type.is_type_obj():
+            node = _node_type.type_object()
 
     if node is None:
         if isinstance(_node_type, UnionType):

--- a/tests/assert_type/db/models/test_enums.py
+++ b/tests/assert_type/db/models/test_enums.py
@@ -1,7 +1,7 @@
 import enum
 from typing import Any, Literal, TypeVar
 
-from django.db.models import Choices, IntegerChoices, TextChoices
+from django.db.models import Choices, IntegerChoices, Model, TextChoices
 from django.utils.functional import _StrOrPromise
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import assert_type
@@ -121,6 +121,18 @@ class ShoutyTextChoices(TextChoices):
     @property
     def label(self) -> str:
         return super().label.upper()
+
+
+class DeckModel(Model):
+    # Alias with the same name.
+    Suit = Suit
+
+    # Alias with a different name.
+    House = Suit
+
+    class Joker(TextChoices):
+        BLACK = "B"
+        RED = "R"
 
 
 # Assertions for an integer choices type that uses a lazy translatable string for all labels.
@@ -276,3 +288,9 @@ assert_type([member.value for choices in x for member in choices], list[int | st
 x = (Constants, Separator)
 assert_type([member.label for choices in x for member in choices], list[_StrOrPromise])
 assert_type([member.value for choices in x for member in choices], list[Any])
+
+
+# Assertions for choices objects defined and aliased in a model.
+assert_type(DeckModel.Suit.choices, list[tuple[int, _StrOrPromise]])
+assert_type(DeckModel.House.choices, list[tuple[int, _StrOrPromise]])
+assert_type(DeckModel.Joker.choices, list[tuple[str, str]])  # pyright: ignore[reportAssertTypeFailure]


### PR DESCRIPTION
Fixes another small case that was missed in the choices plugin implementation.

Another fix for a3f2a558fc6c5544b3b46a6e53e6f266272236f7 (#2582)
Follow up to c37850b62a7217129e75f9985da37c2870b6b069 (#2646)

Fixes #2665