### PR TITLE
Fix test `HttpResponse.context_data`

### DIFF
--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -223,7 +223,8 @@ class _MonkeyPatchedWSGIResponse(_WSGIResponse):
     # `HTTPResponse` when API failed and `TemplateResponse` when successful.
     # https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.Response.context
     context: ContextList | dict[str, Any]
-    context_data: ContextList | dict[str, Any]
+    # Must match `django.template.response.SimpleTemplateResponse.context_data`
+    context_data: dict[str, Any] | None
 
     content: bytes
     resolver_match: ResolverMatch
@@ -244,7 +245,8 @@ class _MonkeyPatchedASGIResponse(_ASGIResponse):
     # `HTTPResponse` when API failed and `TemplateResponse` when successful.
     # https://docs.djangoproject.com/en/stable/topics/testing/tools/#django.test.Response.context
     context: ContextList | dict[str, Any]
-    context_data: ContextList | dict[str, Any]
+    # Must match `django.template.response.SimpleTemplateResponse.context_data`
+    context_data: dict[str, Any] | None
 
     content: bytes
     resolver_match: ResolverMatch

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -8,7 +8,7 @@
       reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
       reveal_type(response.client)  # N: Revealed type is "django.test.client.Client"
       reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
-      reveal_type(response.context_data)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
+      reveal_type(response.context_data)  # N: Revealed type is "Union[builtins.dict[builtins.str, Any], None]"
       reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
       reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
       reveal_type(response.text)  # N: Revealed type is "builtins.str"
@@ -24,7 +24,7 @@
         reveal_type(response.templates)  # N: Revealed type is "builtins.list[django.template.base.Template]"
         reveal_type(response.client)  # N: Revealed type is "django.test.client.AsyncClient"
         reveal_type(response.context)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
-        reveal_type(response.context_data)  # N: Revealed type is "Union[django.test.utils.ContextList, builtins.dict[builtins.str, Any]]"
+        reveal_type(response.context_data)  # N: Revealed type is "Union[builtins.dict[builtins.str, Any], None]"
         reveal_type(response.content)  # N: Revealed type is "builtins.bytes"
         reveal_type(response.redirect_chain)  # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.int]]"
         response.json()


### PR DESCRIPTION
Fixes #2683 partially (the initial issue only)

From the [django docs](https://docs.djangoproject.com/en/5.2/topics/testing/tools/#django.test.Response.context), the type of `context_data` is coming from [`django.template.response.SimpleTemplateResponse.context_data`](https://docs.djangoproject.com/en/5.2/ref/template-response/#django.template.response.SimpleTemplateResponse.context_data)

I've updated the stubs to match that
