### PR TITLE
Don't try to patch automatically symbols in `django.contrib.auth.forms`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,22 @@ This happens because these Django classes do not support [`__class_getitem__`](h
    You can add extra types to patch with `django_stubs_ext.monkeypatch(extra_classes=[YourDesiredType])`
 
    **If you use generic symbols in `django.contrib.auth.forms`**, you will have to do the monkeypatching
-   again in your first [`AppConfig.ready`](https://docs.djangoproject.com/en/5.2/ref/applications/#django.apps.AppConfig.ready).
+   manually in your first [`AppConfig.ready`](https://docs.djangoproject.com/en/5.2/ref/applications/#django.apps.AppConfig.ready).
    This is currently required because `django.contrib.auth.forms` cannot be imported until django is initialized.
+
+    ```python
+    import django_stubs_ext
+    from django.apps import AppConfig
+
+    class ClientsConfig(AppConfig):
+        name = "clients"
+
+        def ready(self):
+            from django.contrib.auth.forms import SetPasswordMixin, SetUnusablePasswordMixin
+
+            # For Django 5.1+, use `extra_classes=[SetPasswordForm, AdminPasswordChangeForm]` instead.
+            django_stubs_ext.monkeypatch(extra_classes=[SetPasswordMixin, SetUnusablePasswordMixin])
+    ```
 
 
 2. You can use strings instead: `'QuerySet[MyModel]'` and `'Manager[MyModel]'`, this way it will work as a type for `mypy` and as a regular `str` in runtime.

--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ This happens because these Django classes do not support [`__class_getitem__`](h
     class ClientsConfig(AppConfig):
         name = "clients"
 
-        def ready(self):
+        def ready(self) -> None:
             from django.contrib.auth.forms import SetPasswordMixin, SetUnusablePasswordMixin
 
-            # For Django 5.1+, use `extra_classes=[SetPasswordForm, AdminPasswordChangeForm]` instead.
+            # For Django version prior to 5.1, use `extra_classes=[SetPasswordForm, AdminPasswordChangeForm]` instead.
             django_stubs_ext.monkeypatch(extra_classes=[SetPasswordMixin, SetUnusablePasswordMixin])
     ```
 


### PR DESCRIPTION
# I have made things!

Revert the automatic patching of symbols in `django.contrib.auth.forms`. 
It can cause circular imports and was already febrile since we had to work-around django model loading machinery.

I've documented how people can still make this work for them in the related section of the README.
The actual fix would be to submit a pr upstream (which ~I'll probably do~ [I've done](https://github.com/django/django/pull/19638))

## Related issues

Fixes #2715
Fixes #2697