### PR TITLE
Improve `.values()` types when expressions are used

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -219,7 +219,7 @@ def gather_kwargs(ctx: MethodContext) -> dict[str, MypyType] | None:
             continue
         if any(kind not in named for kind in ctx.arg_kinds[i]):
             # Only named arguments supported
-            return None
+            continue
         for j in range(len(ctx.arg_names[i])):
             name = ctx.arg_names[i][j]
             assert name is not None

--- a/tests/typecheck/managers/querysets/test_values.yml
+++ b/tests/typecheck/managers/querysets/test_values.yml
@@ -142,3 +142,32 @@
                 class Blog(models.Model):
                     num_posts = models.IntegerField()
                     text = models.CharField(max_length=100, blank=True)
+
+-   case: queryset_values_with_expressions
+    main: |
+        from django.db.models import F
+        from django.db.models.functions import Lower
+        from myapp.models import Blog
+
+        reveal_type(Blog.objects.values("id"))
+        reveal_type(Blog.objects.values("id", "num_posts", "text"))
+        reveal_type(Blog.objects.values(foo=F("id"))) # WRONG
+        reveal_type(Blog.objects.values("id", foo=F("id"))) # WRONG
+        reveal_type(Blog.objects.values("id", lower_text=Lower("text"))) # WRONG
+    out: |
+      main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
+      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
+      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
+      main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
+      main:9: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Blog(models.Model):
+                    num_posts = models.IntegerField()
+                    text = models.CharField(max_length=100)

--- a/tests/typecheck/managers/querysets/test_values.yml
+++ b/tests/typecheck/managers/querysets/test_values.yml
@@ -151,15 +151,15 @@
 
         reveal_type(Blog.objects.values("id"))
         reveal_type(Blog.objects.values("id", "num_posts", "text"))
-        reveal_type(Blog.objects.values(foo=F("id"))) # WRONG
-        reveal_type(Blog.objects.values("id", foo=F("id"))) # WRONG
-        reveal_type(Blog.objects.values("id", lower_text=Lower("text"))) # WRONG
+        reveal_type(Blog.objects.values(foo=F("id")))
+        reveal_type(Blog.objects.values("id", foo=F("id")))
+        reveal_type(Blog.objects.values("id", lower_text=Lower("text")))
     out: |
       main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
       main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
-      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
-      main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
-      main:9: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
+      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'foo': Any})]"
+      main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'foo': Any})]"
+      main:9: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'lower_text': Any})]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_values.yml
+++ b/tests/typecheck/managers/querysets/test_values.yml
@@ -171,3 +171,31 @@
                 class Blog(models.Model):
                     num_posts = models.IntegerField()
                     text = models.CharField(max_length=100)
+
+-   case: queryset_values_m2m_fk_with_expressions
+    main: |
+        from django.db.models import F
+        from django.db.models.functions import Lower
+        from myapp.models import Book
+
+        reveal_type(Book.objects.values(premium_price=F("premiumbookdetails__price")))
+        reveal_type(Book.objects.values(team_name=F("authors__name")))
+    out: |
+      main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'premium_price': Any})]"
+      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'team_name': Any})]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class Author(models.Model):
+                    name = models.CharField(max_length=100)
+
+                class Book(models.Model):
+                    authors = models.ManyToManyField(Author, related_name='books')
+
+                class PremiumBookDetails(models.Model):
+                    book = models.OneToOneField(Book, on_delete=models.CASCADE)
+                    price = models.DecimalField(max_digits=10, decimal_places=2)


### PR DESCRIPTION
# I have made things!

This fixes the types when using `**expressions` inside `QuerySet.values(...)` calls.

Prior to this change, mypy would return the following wrong types in these cases:
```python
reveal_type(Blog.objects.values(foo=F("id"))) # Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
reveal_type(Blog.objects.values("id", foo=F("id"))) # Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
reveal_type(Blog.objects.values("id", lower_text=Lower("text"))) # Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
```

See 22262d1ae232b6c354bf81f4fb1612d18e3d9bb7 for more context
## Related issues

I did not found an exact issue for this but #1845 is kinda related

Further improvement would be to infer the type for some builtin django combinable such as `F(...)` (`.values("id", id2=F("id"))` should both use the same inference code)