### PR TITLE
Improve `settings.TEMPLATE` types

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -7,7 +7,7 @@ from typing import Any, Literal, Protocol, TypeAlias, TypedDict, type_check_only
 
 from typing_extensions import NotRequired
 
-from django_stubs_ext.settings import _TemplatesSetting
+from django_stubs_ext.settings import TemplatesSetting
 
 _Admins: TypeAlias = list[tuple[str, str]]
 
@@ -116,7 +116,7 @@ EMAIL_TIMEOUT: int | None
 # List of strings representing installed apps.
 INSTALLED_APPS: list[str]
 
-TEMPLATES: list[_TemplatesSetting]
+TEMPLATES: list[TemplatesSetting]
 
 # Default form rendering class.
 FORM_RENDERER: str

--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -7,6 +7,8 @@ from typing import Any, Literal, Protocol, TypeAlias, TypedDict, type_check_only
 
 from typing_extensions import NotRequired
 
+from django_stubs_ext.settings import _TemplatesSetting
+
 _Admins: TypeAlias = list[tuple[str, str]]
 
 ####################
@@ -114,7 +116,7 @@ EMAIL_TIMEOUT: int | None
 # List of strings representing installed apps.
 INSTALLED_APPS: list[str]
 
-TEMPLATES: list[dict[str, Any]]
+TEMPLATES: list[_TemplatesSetting]
 
 # Default form rendering class.
 FORM_RENDERER: str

--- a/ext/django_stubs_ext/settings.py
+++ b/ext/django_stubs_ext/settings.py
@@ -5,7 +5,7 @@ from typing_extensions import NotRequired
 
 
 @type_check_only
-class _TemplatesSetting(TypedDict):
+class TemplatesSetting(TypedDict):
     BACKEND: str
     NAME: NotRequired[str]
     DIRS: NotRequired[list[str | Path]]
@@ -13,4 +13,4 @@ class _TemplatesSetting(TypedDict):
     OPTIONS: NotRequired[dict[str, Any]]
 
 
-__all__ = ["_TemplatesSetting"]
+__all__ = ["TemplatesSetting"]

--- a/ext/django_stubs_ext/settings.py
+++ b/ext/django_stubs_ext/settings.py
@@ -7,6 +7,7 @@ from typing_extensions import NotRequired
 @type_check_only
 class TemplatesSetting(TypedDict):
     """Typing helper if you want to type `TEMPLATE` setting."""
+
     BACKEND: str
     NAME: NotRequired[str]
     DIRS: NotRequired[list[str | Path]]

--- a/ext/django_stubs_ext/settings.py
+++ b/ext/django_stubs_ext/settings.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Any, TypedDict, type_check_only
+
+from typing_extensions import NotRequired
+
+
+@type_check_only
+class _TemplatesSetting(TypedDict):
+    BACKEND: str
+    NAME: NotRequired[str]
+    DIRS: NotRequired[list[str | Path]]
+    APP_DIRS: NotRequired[bool]
+    OPTIONS: NotRequired[dict[str, Any]]
+
+
+__all__ = ["_TemplatesSetting"]

--- a/ext/django_stubs_ext/settings.py
+++ b/ext/django_stubs_ext/settings.py
@@ -6,6 +6,7 @@ from typing_extensions import NotRequired
 
 @type_check_only
 class TemplatesSetting(TypedDict):
+    """Typing helper if you want to type `TEMPLATE` setting."""
     BACKEND: str
     NAME: NotRequired[str]
     DIRS: NotRequired[list[str | Path]]

--- a/tests/assert_type/conf/settings.py
+++ b/tests/assert_type/conf/settings.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
-from django_stubs_ext.settings import _TemplatesSetting
+from django_stubs_ext.settings import TemplatesSetting
 
 BASE_DIR = Path(__file__).resolve().parent
 
 # Example taken from various doc pages
 # https://docs.djangoproject.com/en/5.2/ref/settings/#templates
-TEMPLATES: list[_TemplatesSetting] = [
+TEMPLATES: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
@@ -14,7 +14,7 @@ TEMPLATES: list[_TemplatesSetting] = [
 ]
 
 # https://docs.djangoproject.com/en/5.2/ref/templates/api/#the-dirs-option
-TEMPLATES_2: list[_TemplatesSetting] = [
+TEMPLATES_2: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
@@ -25,13 +25,13 @@ TEMPLATES_2: list[_TemplatesSetting] = [
 ]
 
 # https://docs.djangoproject.com/en/5.2/ref/templates/api/#template-loaders
-TEMPLATES_3: list[_TemplatesSetting] = [
+TEMPLATES_3: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [BASE_DIR / "templates"],
     }
 ]
-TEMPLATES_4: list[_TemplatesSetting] = [
+TEMPLATES_4: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "OPTIONS": {
@@ -45,7 +45,7 @@ TEMPLATES_4: list[_TemplatesSetting] = [
     }
 ]
 # https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
-TEMPLATES_5: list[_TemplatesSetting] = [
+TEMPLATES_5: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [BASE_DIR / "templates"],
@@ -64,7 +64,7 @@ TEMPLATES_5: list[_TemplatesSetting] = [
     }
 ]
 # https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
-TEMPLATES_6: list[_TemplatesSetting] = [
+TEMPLATES_6: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "OPTIONS": {
@@ -80,7 +80,7 @@ TEMPLATES_6: list[_TemplatesSetting] = [
     }
 ]
 # https://docs.djangoproject.com/en/5.2/topics/templates/#configuration
-TEMPLATES_7: list[_TemplatesSetting] = [
+TEMPLATES_7: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [],
@@ -91,7 +91,7 @@ TEMPLATES_7: list[_TemplatesSetting] = [
     },
 ]
 # https://docs.djangoproject.com/en/5.2/topics/templates/#django.template.backends.base.Template.render
-TEMPLATES_8: list[_TemplatesSetting] = [
+TEMPLATES_8: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
@@ -108,7 +108,7 @@ TEMPLATES_8: list[_TemplatesSetting] = [
 ]
 
 # Custom jinja backend
-TEMPLATES_9: list[_TemplatesSetting] = [
+TEMPLATES_9: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [BASE_DIR / "templates" / "django"],

--- a/tests/assert_type/conf/settings.py
+++ b/tests/assert_type/conf/settings.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+from django_stubs_ext.settings import _TemplatesSetting
+
+BASE_DIR = Path(__file__).resolve().parent
+
+# Example taken from various doc pages
+# https://docs.djangoproject.com/en/5.2/ref/settings/#templates
+TEMPLATES: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    },
+]
+
+# https://docs.djangoproject.com/en/5.2/ref/templates/api/#the-dirs-option
+TEMPLATES_2: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            "/home/html/templates/lawrence.com",
+            "/home/html/templates/default",
+        ],
+    },
+]
+
+# https://docs.djangoproject.com/en/5.2/ref/templates/api/#template-loaders
+TEMPLATES_3: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+    }
+]
+TEMPLATES_4: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "loaders": [
+                (
+                    "django.template.loaders.filesystem.Loader",
+                    [BASE_DIR / "templates"],
+                ),
+            ],
+        },
+    }
+]
+# https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
+TEMPLATES_5: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "OPTIONS": {
+            "loaders": [
+                (
+                    "django.template.loaders.cached.Loader",
+                    [
+                        "django.template.loaders.filesystem.Loader",
+                        "django.template.loaders.app_directories.Loader",
+                        "path.to.custom.Loader",
+                    ],
+                ),
+            ],
+        },
+    }
+]
+# https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
+TEMPLATES_6: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "loaders": [
+                (
+                    "django.template.loaders.locmem.Loader",
+                    {
+                        "index.html": "content here",
+                    },
+                ),
+            ],
+        },
+    }
+]
+# https://docs.djangoproject.com/en/5.2/topics/templates/#configuration
+TEMPLATES_7: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            # ... some options here ...
+        },
+    },
+]
+# https://docs.djangoproject.com/en/5.2/topics/templates/#django.template.backends.base.Template.render
+TEMPLATES_8: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            "/home/html/example.com",
+            "/home/html/default",
+        ],
+    },
+    {
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "DIRS": [
+            "/home/html/jinja2",
+        ],
+    },
+]
+
+# Custom jinja backend
+TEMPLATES_9: list[_TemplatesSetting] = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates" / "django"],
+        "APP_DIRS": True,
+    },
+    {
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "DIRS": [BASE_DIR / "templates" / "jinja"],
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+            "environment": "example.jinja.environment",
+            "extensions": [
+                "jinja2.ext.do",
+                "jinja2.ext.i18n",
+                "jinja2.ext.loopcontrols",
+            ],
+        },
+    },
+]


### PR DESCRIPTION
# I have made things!

Narrow the types slightly for `settings.TEMPLATE` with a `TypedDict`

We could maybe improve for the `OPTIONS` key too but the possible values differ depending on the backend. 
And people could have custom backend adding custom keys there so I'm not sure it's worth pursuing.

## Related issues

Fixes #2731
