### PR TITLE
Fix `FormMixin` plugin

### DIFF
--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -8,7 +8,7 @@ from django.utils.datastructures import _ListOrTuple
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
 
-_FormT = TypeVar("_FormT", bound=BaseForm, default=BaseForm)
+_FormT = TypeVar("_FormT", bound=BaseForm)
 _ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm)
 _M = TypeVar("_M", bound=models.Model)
 

--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -8,7 +8,7 @@ from django.utils.datastructures import _ListOrTuple
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
 
-_FormT = TypeVar("_FormT", bound=BaseForm)
+_FormT = TypeVar("_FormT", bound=BaseForm, default=BaseForm)
 _ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm)
 _M = TypeVar("_M", bound=models.Model)
 

--- a/tests/typecheck/test_forms.yml
+++ b/tests/typecheck/test_forms.yml
@@ -36,7 +36,9 @@
             pass
         class MyForm2(forms.ModelForm):
             pass
-        class MyView(FormView):
+
+        # FormView generic param provided
+        class MyView(FormView[MyForm]):
             form_class = MyForm
             def post(self, request: HttpRequest, *args: Any, **kwds: Any) -> HttpResponse:
                 form_class = self.get_form_class()
@@ -44,7 +46,19 @@
                 reveal_type(self.get_form(None))  # N: Revealed type is "main.MyForm"
                 reveal_type(self.get_form())  # N: Revealed type is "main.MyForm"
                 reveal_type(self.get_form(form_class))  # N: Revealed type is "main.MyForm"
-                reveal_type(self.get_form(MyForm2))  # N: Revealed type is "main.MyForm2"
+                reveal_type(self.get_form(MyForm2))  # N: Revealed type is "main.MyForm" # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "type[MyForm2]"; expected "type[MyForm] | None"  [arg-type]
+                return HttpResponse()
+
+        # FormView generic param omitted -- fallback to TypeVar default
+        class MyView2(FormView):
+            form_class = MyForm
+            def post(self, request: HttpRequest, *args: Any, **kwds: Any) -> HttpResponse:
+                form_class = self.get_form_class()
+                reveal_type(form_class)  # N: Revealed type is "type[django.forms.forms.BaseForm]"
+                reveal_type(self.get_form(None))  # N: Revealed type is "django.forms.forms.BaseForm"
+                reveal_type(self.get_form())  # N: Revealed type is "django.forms.forms.BaseForm"
+                reveal_type(self.get_form(form_class))  # N: Revealed type is "django.forms.forms.BaseForm"
+                reveal_type(self.get_form(MyForm2))  # N: Revealed type is "django.forms.forms.BaseForm"
                 return HttpResponse()
 
 -   case: updateview_form_valid_has_form_save

--- a/tests/typecheck/test_forms.yml
+++ b/tests/typecheck/test_forms.yml
@@ -54,11 +54,11 @@
             form_class = MyForm
             def post(self, request: HttpRequest, *args: Any, **kwds: Any) -> HttpResponse:
                 form_class = self.get_form_class()
-                reveal_type(form_class)  # N: Revealed type is "type[django.forms.forms.BaseForm]"
-                reveal_type(self.get_form(None))  # N: Revealed type is "django.forms.forms.BaseForm"
-                reveal_type(self.get_form())  # N: Revealed type is "django.forms.forms.BaseForm"
-                reveal_type(self.get_form(form_class))  # N: Revealed type is "django.forms.forms.BaseForm"
-                reveal_type(self.get_form(MyForm2))  # N: Revealed type is "django.forms.forms.BaseForm"
+                reveal_type(form_class)  # N: Revealed type is "type[Any]"
+                reveal_type(self.get_form(None))  # N: Revealed type is "Any"
+                reveal_type(self.get_form())  # N: Revealed type is "Any"
+                reveal_type(self.get_form(form_class))  # N: Revealed type is "Any"
+                reveal_type(self.get_form(MyForm2))  # N: Revealed type is "Any"
                 return HttpResponse()
 
 -   case: formview_form_valid_proper_type
@@ -84,10 +84,6 @@
             def form_valid(self, form: RegistrationForm) -> HttpResponse:
                  form.save()
                  return super().form_valid(form)
-    out: |
-        main:11: error: Argument 1 of "form_valid" is incompatible with supertype "django.views.generic.edit.FormMixin"; supertype defines the argument type as "BaseForm"  [override]
-        main:11: note: This violates the Liskov substitution principle
-        main:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
 
 -   case: updateview_form_valid_has_form_save
     main: |

--- a/tests/typecheck/test_forms.yml
+++ b/tests/typecheck/test_forms.yml
@@ -61,6 +61,34 @@
                 reveal_type(self.get_form(MyForm2))  # N: Revealed type is "django.forms.forms.BaseForm"
                 return HttpResponse()
 
+-   case: formview_form_valid_proper_type
+    main: |
+        from django.http import HttpRequest, HttpResponse
+        from django.forms import models
+        from django.views.generic.edit import FormView
+
+        class RegistrationForm(models.ModelForm): ...
+
+        class RegistrationViewNoGeneric(FormView):
+            form_class = RegistrationForm
+            template_name = 'web_app/registration.html'
+
+            def form_valid(self, form: RegistrationForm) -> HttpResponse:
+                 form.save()
+                 return super().form_valid(form)
+
+        class RegistrationViewWithGeneric(FormView[RegistrationForm]):
+            form_class = RegistrationForm
+            template_name = 'web_app/registration.html'
+
+            def form_valid(self, form: RegistrationForm) -> HttpResponse:
+                 form.save()
+                 return super().form_valid(form)
+    out: |
+        main:11: error: Argument 1 of "form_valid" is incompatible with supertype "django.views.generic.edit.FormMixin"; supertype defines the argument type as "BaseForm"  [override]
+        main:11: note: This violates the Liskov substitution principle
+        main:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+
 -   case: updateview_form_valid_has_form_save
     main: |
         from django import forms

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -82,8 +82,8 @@
         class MyCreateView(CreateView[Article, ArticleModelForm]):
             def some(self) -> None:
                 reveal_type(self.get_form())  # N: Revealed type is "main.ArticleModelForm"
-                reveal_type(self.get_form(SubArticleModelForm))  # N: Revealed type is "main.SubArticleModelForm"
-                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.AnotherArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "type[AnotherArticleModelForm]"; expected "type[ArticleModelForm] | None"  [arg-type]
+                reveal_type(self.get_form(SubArticleModelForm))  # N: Revealed type is "main.ArticleModelForm"
+                reveal_type(self.get_form(AnotherArticleModelForm))  # N: Revealed type is "main.ArticleModelForm"  # E: Argument 1 to "get_form" of "FormMixin" has incompatible type "type[AnotherArticleModelForm]"; expected "type[ArticleModelForm] | None"  [arg-type]
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
# I have made things!


Currently, `FormView` is defined with a generic param, the important bits using it being:

```python
class FormView(Generic[_FormT]):
    form_class: type[_FormT] | None
    def get_form_class(self) -> type[_FormT]: ...
    def get_form(self, form_class: type[_FormT] | None = ...) -> _FormT: ...
    def form_valid(self, form: _FormT) -> HttpResponse: ...
    def form_invalid(self, form: _FormT) -> HttpResponse: ...
```

But we have some custom plugin code that allows that:
```python
class MyForm(forms.ModelForm): ...
class MyForm2(forms.ModelForm): ...

class MyView(FormView[MyForm]):
    def post(self, request: HttpRequest, *args: Any, **kwds: Any) -> HttpResponse:
        self.get_form(MyForm2) # N: Revealed type is "main.MyForm2"
```
However this is not actually type safe, because it breaks assumption made by the other hooks.
cf https://github.com/typeddjango/django-stubs/pull/921#issuecomment-1100928895 that describe this very well.

This pr extend the generic param using [PEP 696 Typevar Defaults](https://peps.python.org/pep-0696/) and removes the plugin code.

## Related issues

Fixes #920
Fixes #261
Supersede #921