### PR TITLE
content_type_extra contains bytes, not str.

### DIFF
--- a/django-stubs/core/files/uploadedfile.pyi
+++ b/django-stubs/core/files/uploadedfile.pyi
@@ -6,7 +6,7 @@ from typing_extensions import Self
 class UploadedFile(File):
     content_type: str | None
     charset: str | None
-    content_type_extra: dict[str, str] | None
+    content_type_extra: dict[str, bytes] | None
     size: int | None  # type: ignore[assignment]
     name: str | None
     def __init__(
@@ -16,7 +16,7 @@ class UploadedFile(File):
         content_type: str | None = None,
         size: int | None = None,
         charset: str | None = None,
-        content_type_extra: dict[str, str] | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
     ) -> None: ...
 
 class TemporaryUploadedFile(UploadedFile):
@@ -26,7 +26,7 @@ class TemporaryUploadedFile(UploadedFile):
         content_type: str | None,
         size: int | None,
         charset: str | None,
-        content_type_extra: dict[str, str] | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
     ) -> None: ...
     def temporary_file_path(self) -> str: ...
 
@@ -40,7 +40,7 @@ class InMemoryUploadedFile(UploadedFile):
         content_type: str | None,
         size: int | None,
         charset: str | None,
-        content_type_extra: dict[str, str] | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
     ) -> None: ...
     def open(self, mode: str | None = None) -> Self: ...  # type: ignore[override]
 

--- a/django-stubs/core/files/uploadhandler.pyi
+++ b/django-stubs/core/files/uploadhandler.pyi
@@ -19,7 +19,7 @@ class FileUploadHandler:
     content_type: str | None
     content_length: int | None
     charset: str | None
-    content_type_extra: dict[str, str] | None
+    content_type_extra: dict[str, bytes] | None
     request: HttpRequest | None
     field_name: str
     def __init__(self, request: HttpRequest | None = None) -> None: ...
@@ -38,7 +38,7 @@ class FileUploadHandler:
         content_type: str,
         content_length: int | None,
         charset: str | None = None,
-        content_type_extra: dict[str, str] | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
     ) -> None: ...
     def receive_data_chunk(self, raw_data: bytes, start: int) -> bytes | None: ...
     def file_complete(self, file_size: int) -> UploadedFile | None: ...
@@ -54,7 +54,7 @@ class TemporaryFileUploadHandler(FileUploadHandler):
         content_type: str,
         content_length: int | None,
         charset: str | None = ...,
-        content_type_extra: dict[str, str] | None = ...,
+        content_type_extra: dict[str, bytes] | None = ...,
     ) -> None: ...
     def receive_data_chunk(self, raw_data: bytes, start: int) -> bytes | None: ...
     def file_complete(self, file_size: int) -> UploadedFile | None: ...
@@ -78,7 +78,7 @@ class MemoryFileUploadHandler(FileUploadHandler):
         content_type: str,
         content_length: int | None,
         charset: str | None = ...,
-        content_type_extra: dict[str, str] | None = ...,
+        content_type_extra: dict[str, bytes] | None = ...,
     ) -> None: ...
     def receive_data_chunk(self, raw_data: bytes, start: int) -> bytes | None: ...
     def file_complete(self, file_size: int) -> UploadedFile | None: ...


### PR DESCRIPTION
Here's my test showing the runtime type:

```
#!/usr/bin/env python3
from django.conf import settings
from django.core.files.uploadedfile import UploadedFile
from django.core.handlers.wsgi import WSGIRequest
from django.test.client import BOUNDARY, MULTIPART_CONTENT, FakePayload

settings.configure(DEBUG=True)

payload = FakePayload(
    "\r\n".join(
        [
            f"--{BOUNDARY}",
            "Content-Type: text/plain; key=value; charset=big5",
            'Content-Disposition: form-data; name="file"; filename="test.txt"',
            "",
            "body",
            f"--{BOUNDARY}--",
        ]
    )
)
request = WSGIRequest(
    {
        "REQUEST_METHOD": "POST",
        "CONTENT_LENGTH": len(payload),
        "CONTENT_TYPE": MULTIPART_CONTENT,
        "wsgi.input": payload,
    }
)

parsed_file = request.FILES["file"]
assert isinstance(parsed_file, UploadedFile)

# {'key': b'value', 'charset': b'big5'}
print(parsed_file.content_type_extra)
```