### PR TITLE
Allow passing None to migrations.AlterOrderWithRespectTo

### DIFF
--- a/django-stubs/db/migrations/operations/models.pyi
+++ b/django-stubs/db/migrations/operations/models.pyi
@@ -96,8 +96,8 @@ class AlterIndexTogether(AlterTogetherOptionOperation):
 
 class AlterOrderWithRespectTo(ModelOptionOperation):
     option_name: str
-    order_with_respect_to: str
-    def __init__(self, name: str, order_with_respect_to: str) -> None: ...
+    order_with_respect_to: str | None
+    def __init__(self, name: str, order_with_respect_to: str | None) -> None: ...
 
 class AlterModelOptions(ModelOptionOperation):
     ALTER_OPTION_KEYS: list[str]


### PR DESCRIPTION
Consider the following models:
```python
from django.db import models


class Question(models.Model):
    text = models.TextField()


class Answer(models.Model):
    question = models.ForeignKey(Question, on_delete=models.CASCADE)

    class Meta:
        order_with_respect_to = "question"
```

If I now completely remove the `Answer.Meta` class and run `./manage.py makemigrations`, I get the following migration:
```python
# Generated by Django 5.2.4 on 2025-07-29 16:59

from django.db import migrations


class Migration(migrations.Migration):

    dependencies = [
        ('polls', '0001_initial'),
    ]

    operations = [
        migrations.AlterOrderWithRespectTo(
            name='answer',
            order_with_respect_to=None,
        ),
    ]
```

Thus, the type hints should allow passing `order_with_respect_to=None` to `AlterOrderWithRespectTo`.