### PR TITLE
Use mypy `Instance.copy_modified`

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -187,10 +187,6 @@ def lookup_class_typeinfo(api: TypeChecker, klass: type | None) -> TypeInfo | No
     return field_info
 
 
-def reparametrize_instance(instance: Instance, new_args: list[MypyType]) -> Instance:
-    return Instance(instance.type, args=new_args, line=instance.line, column=instance.column)
-
-
 def get_class_fullname(klass: type) -> str:
     return klass.__module__ + "." + klass.__qualname__
 
@@ -393,7 +389,7 @@ def convert_any_to_type(typ: MypyType, referred_to_type: MypyType) -> MypyType:
                 args.append(referred_to_type)
             else:
                 args.append(default_arg)
-        return reparametrize_instance(proper_type, args)
+        return proper_type.copy_modified(args=args)
 
     if isinstance(proper_type, AnyType):
         return referred_to_type

--- a/mypy_django_plugin/transformers/choices.py
+++ b/mypy_django_plugin/transformers/choices.py
@@ -16,7 +16,7 @@ from mypy.types import (
 )
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.lib import fullnames, helpers
+from mypy_django_plugin.lib import fullnames
 
 
 # TODO: [mypy 1.14+] Remove this backport of `TypeInfo.enum_members`.
@@ -232,7 +232,7 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
             new_value_arg = _try_replace_value(value_arg, base_type, has_empty_label)
             if new_label_arg is not label_arg or new_value_arg is not value_arg:
                 new_choice_arg = choice_arg.copy_modified(items=[new_value_arg, new_label_arg])
-                return helpers.reparametrize_instance(default_attr_type, [new_choice_arg])
+                return default_attr_type.copy_modified(args=[new_choice_arg])
 
     elif (
         name == "labels"
@@ -243,7 +243,7 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
         label_arg = get_proper_type(default_attr_type.args[0])
         new_label_arg = _try_replace_label(label_arg, has_lazy_label)
         if new_label_arg is not label_arg:
-            return helpers.reparametrize_instance(default_attr_type, [new_label_arg])
+            return default_attr_type.copy_modified(args=[new_label_arg])
 
     elif (
         name == "values"
@@ -254,7 +254,7 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
         value_arg = get_proper_type(default_attr_type.args[0])
         new_value_arg = _try_replace_value(value_arg, base_type, has_empty_label)
         if new_value_arg is not value_arg:
-            return helpers.reparametrize_instance(default_attr_type, [new_value_arg])
+            return default_attr_type.copy_modified(args=[new_value_arg])
 
     elif name in ("__empty__", "label"):
         return _try_replace_label(default_attr_type, has_lazy_label)

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -53,7 +53,7 @@ def reparametrize_related_field_type(related_field_type: Instance, set_type: Myp
         helpers.convert_any_to_type(related_field_type.args[0], set_type),
         helpers.convert_any_to_type(related_field_type.args[1], get_type),
     ]
-    return helpers.reparametrize_instance(related_field_type, new_args=args)
+    return related_field_type.copy_modified(args=args)
 
 
 def fill_descriptor_types_for_related_field(ctx: FunctionContext, django_context: DjangoContext) -> MypyType:
@@ -177,7 +177,7 @@ def set_descriptor_types_for_field(
                 ctx.context,
             )
 
-    return helpers.reparametrize_instance(default_return_type, [set_type, get_type])
+    return default_return_type.copy_modified(args=[set_type, get_type])
 
 
 def determine_type_of_array_field(ctx: FunctionContext, django_context: DjangoContext) -> MypyType:
@@ -229,7 +229,7 @@ def determine_type_of_array_field(ctx: FunctionContext, django_context: DjangoCo
 
         args.append(helpers.convert_any_to_type(default_arg, new_type))
 
-    return helpers.reparametrize_instance(default_return_type, args)
+    return default_return_type.copy_modified(args=args)
 
 
 def transform_into_proper_return_type(ctx: FunctionContext, django_context: DjangoContext) -> MypyType:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -50,7 +50,7 @@ def determine_proper_manager_type(ctx: FunctionContext) -> MypyType:
     ):
         return default_return_type
 
-    return helpers.reparametrize_instance(default_return_type, [outer_model_info.self_type])
+    return default_return_type.copy_modified(args=[outer_model_info.self_type])
 
 
 def get_field_type_from_lookup(
@@ -198,7 +198,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
 
     if flat and named:
         ctx.api.fail("'flat' and 'named' can't be used together", ctx.context)
-        return helpers.reparametrize_instance(default_return_type, [model_type, AnyType(TypeOfAny.from_error)])
+        return default_return_type.copy_modified(args=[model_type, AnyType(TypeOfAny.from_error)])
 
     # account for possible None
     flat = flat or False
@@ -207,7 +207,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
     row_type = get_values_list_row_type(
         ctx, django_context, model_cls, is_annotated=is_annotated, flat=flat, named=named
     )
-    return helpers.reparametrize_instance(default_return_type, [model_type, row_type])
+    return default_return_type.copy_modified(args=[model_type, row_type])
 
 
 def gather_kwargs(ctx: MethodContext) -> dict[str, MypyType] | None:
@@ -311,7 +311,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
             row_type = annotated_type
     else:
         row_type = annotated_type
-    return helpers.reparametrize_instance(default_return_type, [annotated_type, row_type])
+    return default_return_type.copy_modified(args=[annotated_type, row_type])
 
 
 def resolve_field_lookups(lookup_exprs: Sequence[Expression], django_context: DjangoContext) -> list[str] | None:
@@ -362,7 +362,7 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
             ctx, django_context, model_cls, lookup=field_lookup, method="values"
         )
         if field_lookup_type is None:
-            return helpers.reparametrize_instance(default_return_type, [model_type, AnyType(TypeOfAny.from_error)])
+            return default_return_type.copy_modified(args=[model_type, AnyType(TypeOfAny.from_error)])
 
         column_types[field_lookup] = field_lookup_type
 
@@ -372,4 +372,4 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
         column_types.update(expression_types)
 
     row_type = helpers.make_typeddict(ctx.api, column_types, set(column_types.keys()), set())
-    return helpers.reparametrize_instance(default_return_type, [model_type, row_type])
+    return default_return_type.copy_modified(args=[model_type, row_type])


### PR DESCRIPTION
# I have made things!

Noticed mypy provides `Instance.copy_modified` which is a more accurate version of our `helpers.reparametrize_instance` so I've updated the usages.

The method has been around for at least 8 years in mypy (and initially looked exactly like our version) so I think it's should be safe to change given our mypy version support policy. 
