### PR TITLE
Fix ` generic get type parameter is not optional` false positive

### DIFF
--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -49,6 +49,27 @@
                     text_nullable = models.CharField(max_length=100, null=True)
                     text = models.CharField(max_length=100)
 
+-   case: nullable_field_with_strict_optional_false
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel().text_nullable)  # N: Revealed type is "builtins.str | None"
+    installed_apps:
+        - myapp
+    mypy_config: |
+      [mypy]
+      strict_optional = True
+
+      [mypy-myapp.*]
+      strict_optional = False
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    text_nullable = models.CharField(max_length=100, null=True)
+
+
 -   case: nullable_array_field
     main: |
         from myapp.models import MyModel


### PR DESCRIPTION
# I have made things!

(not ready for review)
Just a failing test for now. Apparently, we were bailing most of the time previously due to this check;

```
# bail if either mapped_set_type or mapped_get_type have type Never
if not (isinstance(mapped_set_type, UninhabitedType) or isinstance(mapped_get_type, UninhabitedType)):
```

which is not the case anymore after mypy 1.16

# Relate issue

Fixes #2724