### PR TITLE
Initial support for `to_attr` inference in `Prefetch` calls

### DIFF
--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -16,6 +16,7 @@ QUERYSET_CLASS_FULLNAME = "django.db.models.query.QuerySet"
 BASE_MANAGER_CLASS_FULLNAME = "django.db.models.manager.BaseManager"
 MANAGER_CLASS_FULLNAME = "django.db.models.manager.Manager"
 RELATED_MANAGER_CLASS = "django.db.models.fields.related_descriptors.RelatedManager"
+PREFETCH_CLASS_FULLNAME = "django.db.models.query.Prefetch"
 
 CHOICES_CLASS_FULLNAME = "django.db.models.enums.Choices"
 CHOICES_TYPE_METACLASS_FULLNAME = "django.db.models.enums.ChoicesType"

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -14,12 +14,14 @@ from mypy.nodes import (
     ArgKind,
     AssignmentStmt,
     Block,
+    CallExpr,
     ClassDef,
     Context,
     Expression,
     MemberExpr,
     MypyFile,
     NameExpr,
+    Node,
     RefExpr,
     StrExpr,
     SymbolNode,
@@ -40,6 +42,7 @@ from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import make_optional_type
 from mypy.types import (
     AnyType,
+    CallableType,
     Instance,
     LiteralType,
     NoneTyp,
@@ -197,6 +200,44 @@ def get_min_argument_count(ctx: MethodContext | FunctionContext) -> int:
     Excludes *args and **kwargs since their count is indeterminate.
     """
     return sum(not kind.is_star() for kinds in ctx.arg_kinds for kind in kinds)
+
+
+def _get_class_init_type(call: CallExpr) -> CallableType | None:
+    callee_node: Node | None = call.callee
+
+    if isinstance(callee_node, RefExpr):
+        callee_node = callee_node.node
+
+    if (
+        isinstance(callee_node, TypeInfo)
+        and (init_sym := callee_node.get("__init__"))
+        and isinstance((init_type := get_proper_type(init_sym.type)), CallableType)
+    ):
+        return init_type
+    return None
+
+
+def get_class_init_argument_by_name(call: CallExpr, name: str) -> Expression | None:
+    """Adaptation of `mypy.plugins.common._get_argument` for class initializers"""
+    callee_type = _get_class_init_type(call)
+    if not callee_type:
+        return None
+
+    argument = callee_type.argument_by_name(name)
+    if not argument:
+        return None
+    assert argument.name
+
+    for i, (attr_name, attr_value) in enumerate(
+        zip(call.arg_names, call.args, strict=False),
+        start=1,  # Start at one to skip first `self` arg
+    ):
+        if argument.pos is not None and not attr_name and i == argument.pos:
+            return attr_value
+        if attr_name == argument.name:
+            return attr_value
+
+    return None
 
 
 def get_call_argument_by_name(ctx: FunctionContext | MethodContext, name: str) -> Expression | None:

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -160,6 +160,9 @@ class NewSemanalDjangoPlugin(Plugin):
             "filter": typecheck_filtering_method,
             "get": typecheck_filtering_method,
             "exclude": typecheck_filtering_method,
+            "prefetch_related": partial(
+                querysets.extract_prefetch_related_annotations, django_context=self.django_context
+            ),
         }
 
     def get_method_hook(self, fullname: str) -> Callable[[MethodContext], MypyType] | None:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -442,7 +442,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     ):
         return ctx.default_return_type
 
-    fields: OrderedDict[str, MypyType] = OrderedDict()
+    fields: dict[str, MypyType] = {}
 
     for expr, typ in zip(ctx.args[0], ctx.arg_types[0], strict=False):
         typ = get_proper_type(typ)

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -6,7 +6,7 @@ from django.db.models.base import Model
 from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy.checker import TypeChecker
-from mypy.nodes import ARG_NAMED, ARG_NAMED_OPT, Expression
+from mypy.nodes import ARG_NAMED, ARG_NAMED_OPT, AssignmentStmt, CallExpr, Expression, FuncDef, MypyFile, NameExpr
 from mypy.plugin import FunctionContext, MethodContext
 from mypy.types import AnyType, Instance, TupleType, TypedDictType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
@@ -34,6 +34,42 @@ def _extract_model_type_from_queryset(queryset_type: Instance, api: TypeChecker)
         model = get_proper_type(base_type.args[0])
         if isinstance(model, Instance) and helpers.is_model_type(model.type):
             return model
+    return None
+
+
+def _resolve_prefetch_call_expr(expr: Expression, api: TypeChecker) -> CallExpr | None:
+    """
+    Resolve a Prefetch call expression from either an inline call or a variable assignment.
+
+    Inline call:
+        MyModel.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="every_tags"))
+
+    Variable assignment:
+        tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+        MyModel.objects.prefetch_related(tag_prefetch)
+    """
+    if isinstance(expr, CallExpr):
+        return expr
+
+    if not isinstance(expr, NameExpr):
+        return None
+
+    for scope in reversed(api.scope.stack):
+        if isinstance(scope, FuncDef):
+            statements = scope.body.body
+        elif isinstance(scope, MypyFile):
+            statements = scope.defs
+        else:
+            continue
+
+        for stmt in statements:
+            if (
+                isinstance(stmt, AssignmentStmt)
+                and any(isinstance(lval, NameExpr) and lval.name == expr.name for lval in stmt.lvalues)
+                and isinstance(stmt.rvalue, CallExpr)
+            ):
+                return stmt.rvalue
+
     return None
 
 
@@ -373,3 +409,82 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
 
     row_type = helpers.make_typeddict(ctx.api, column_types, set(column_types.keys()), set())
     return default_return_type.copy_modified(args=[model_type, row_type])
+
+
+def _infer_prefetch_element_model_type(queryset_expr: Expression | None, api: TypeChecker) -> Instance | None:
+    """Infer the model Instance from `Prefetch(queryset=...)`"""
+    if queryset_expr is None:
+        # TODO: Infer the model type from the lookup in `Prefetch(lookup=..., to_attr=...)`
+        return None
+    try:
+        qs_type = get_proper_type(api.expr_checker.accept(queryset_expr))
+    except Exception:
+        return None
+    if isinstance(qs_type, Instance):
+        return _extract_model_type_from_queryset(qs_type, api)
+    return None
+
+
+def extract_prefetch_related_annotations(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
+    """
+    Extract annotated attributes via `prefetch_related(Prefetch(..., to_attr=...))`
+
+    See https://docs.djangoproject.com/en/5.2/ref/models/querysets/#prefetch-objects
+    """
+    if not (
+        isinstance(ctx.type, Instance)
+        and isinstance((default_return_type := get_proper_type(ctx.default_return_type)), Instance)
+        and (api := helpers.get_typechecker_api(ctx))
+        and (model_type := _extract_model_type_from_queryset(ctx.type, api)) is not None
+        and ctx.args
+        and ctx.arg_types
+        and ctx.arg_types[0]
+    ):
+        return ctx.default_return_type
+
+    fields: OrderedDict[str, MypyType] = OrderedDict()
+
+    for expr, typ in zip(ctx.args[0], ctx.arg_types[0], strict=False):
+        typ = get_proper_type(typ)
+        if not (
+            isinstance(typ, Instance)
+            and typ.type.fullname == fullnames.PREFETCH_CLASS_FULLNAME
+            and (prefetch_call := _resolve_prefetch_call_expr(expr, api))
+            and (to_attr_expr := helpers.get_class_init_argument_by_name(prefetch_call, "to_attr"))
+            and (to_attr_value := helpers.resolve_string_attribute_value(to_attr_expr, django_context))
+        ):
+            continue
+
+        # Determine model type from the `queryset` attr
+        queryset_expr = helpers.get_class_init_argument_by_name(prefetch_call, "queryset")
+        elem_model = _infer_prefetch_element_model_type(queryset_expr, api)
+        value_type = api.named_generic_type(
+            "builtins.list",
+            [elem_model if elem_model is not None else AnyType(TypeOfAny.special_form)],
+        )
+
+        fields[to_attr_value] = value_type
+
+    if not fields:
+        return ctx.default_return_type
+
+    fields_dict = helpers.make_typeddict(
+        api,
+        fields=fields,
+        required_keys=set(fields.keys()),
+        readonly_keys=set(),
+    )
+
+    annotated_model = get_annotated_type(api, model_type, fields_dict=fields_dict)
+
+    # Keep row shape; if row is a model instance, update it to annotated
+    # Todo: consolidate with `extract_proper_type_queryset_annotate` row handling above.
+    if len(default_return_type.args) > 1:
+        original_row = get_proper_type(default_return_type.args[1])
+        row_type: MypyType = original_row
+        if isinstance(original_row, Instance) and helpers.is_model_type(original_row.type):
+            row_type = annotated_model
+    else:
+        row_type = annotated_model
+
+    return default_return_type.copy_modified(args=[annotated_model, row_type])

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -30,18 +30,6 @@
             ).get().every_articles
         )
 
-        # Intermediary variable -- function scope
-        def foo() -> None:
-            tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
-            reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
-
-        # Intermediary variable -- module scope
-        tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
-        reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
-
-        article_prefetch = Prefetch("article_set", Article.objects.all(), to_attr="every_articles")
-        reveal_type(Tag.objects.prefetch_related(article_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Tag@AnnotatedWith[TypedDict({'every_articles': builtins.list[myapp.models.Article]})], myapp.models.Tag@AnnotatedWith[TypedDict({'every_articles': builtins.list[myapp.models.Article]})]]"
-
         # Member expr
         reveal_type(
             Article.objects.prefetch_related( # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
@@ -64,13 +52,6 @@
         reveal_type(multi_qs.get().ts) # N: Revealed type is "builtins.list[myapp.models.Tag]"
         reveal_type(multi_qs.get().ts2) # N: Revealed type is "builtins.list[myapp.models.Tag]"
 
-        # Mixed inline `Prefetch` and variable `Prefetch` in one call
-        mixed_qs = Article.objects.prefetch_related(
-            tag_prefetch,
-            Prefetch("article_set", Article.objects.all(), to_attr="arts2"),
-        )
-        reveal_type(mixed_qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'arts2': builtins.list[myapp.models.Article]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'arts2': builtins.list[myapp.models.Article]})]]"
-
         # Mixed inline `Prefetch` and plain lookup string in one call; string should be ignored
         mixed_plain = Article.objects.prefetch_related(
             "article_set",
@@ -78,9 +59,28 @@
         )
         reveal_type(mixed_plain) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'arts3': builtins.list[myapp.models.Article]})], myapp.models.Article@AnnotatedWith[TypedDict({'arts3': builtins.list[myapp.models.Article]})]]"
 
+
+        ## Not Supported
+
         # Prefetch with `to_attr` arg but without the `queryset` arg
         # TODO: We should be able to resolve a more accurate type using existing lookup `resolve_lookup_expected_type` machinery
         reveal_type(Article.objects.prefetch_related(models.Prefetch("tags", to_attr="just_tags")).get().just_tags) # N: Revealed type is "builtins.list[Any]"
+
+        # Intermediary variable -- function scope
+        def foo() -> None:
+            tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+            reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article, myapp.models.Article]"
+
+        # Intermediary variable -- module scope
+        tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+        reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article, myapp.models.Article]"
+
+        # Mixed inline `Prefetch` and variable `Prefetch` in one call
+        mixed_qs = Article.objects.prefetch_related(
+            tag_prefetch,
+            Prefetch("article_set", Article.objects.all(), to_attr="arts2"),
+        )
+        reveal_type(mixed_qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'arts2': builtins.list[myapp.models.Article]})], myapp.models.Article@AnnotatedWith[TypedDict({'arts2': builtins.list[myapp.models.Article]})]]"
 
     installed_apps:
         - myapp

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -1,0 +1,112 @@
+-   case: prefetch_related_to_attr
+    main: |
+        from myapp.models import Article, Tag
+        from django.db.models import Prefetch
+        from django.db import models
+
+        # Noop (to_attr not provided)
+        reveal_type(Article.objects.prefetch_related(Prefetch("tags")).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article, myapp.models.Article]"
+        reveal_type(Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all())).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article, myapp.models.Article]"
+
+        # On the QuerySet
+        article_qs = Article.objects.all().prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="every_tags"))
+        reveal_type(article_qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
+        reveal_type(article_qs.get().every_tags) # N: Revealed type is "builtins.list[myapp.models.Tag]"
+        reveal_type(
+            Tag.objects.all().prefetch_related( # N: Revealed type is "builtins.list[myapp.models.Article]"
+                Prefetch("article_set", Article.objects.all(), to_attr="every_articles")
+            ).get().every_articles
+        )
+
+        # On the Manager
+        reveal_type(
+            Article.objects.prefetch_related( # N: Revealed type is "builtins.list[myapp.models.Tag]"
+                Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+            ).get().every_tags
+        )
+        reveal_type(
+            Tag.objects.prefetch_related( # N: Revealed type is "builtins.list[myapp.models.Article]"
+                Prefetch("article_set", Article.objects.all(), to_attr="every_articles")
+            ).get().every_articles
+        )
+
+        # Intermediary variable -- function scope
+        def foo() -> None:
+            tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+            reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
+
+        # Intermediary variable -- module scope
+        tag_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+        reveal_type(Article.objects.prefetch_related(tag_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
+
+        article_prefetch = Prefetch("article_set", Article.objects.all(), to_attr="every_articles")
+        reveal_type(Tag.objects.prefetch_related(article_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Tag@AnnotatedWith[TypedDict({'every_articles': builtins.list[myapp.models.Article]})], myapp.models.Tag@AnnotatedWith[TypedDict({'every_articles': builtins.list[myapp.models.Article]})]]"
+
+        # Member expr
+        reveal_type(
+            Article.objects.prefetch_related( # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
+                models.Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
+            ).all()
+        )
+        # pos args only
+        reveal_type(
+            Article.objects.prefetch_related( # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag]})]]"
+                models.Prefetch("tags", Tag.objects.all(), "every_tags")
+            ).all()
+        )
+
+        # Multiple Prefetch items: both `to_attr` annotations should be present
+        multi_qs = Article.objects.all().prefetch_related(
+            Prefetch("tags", Tag.objects.all(), to_attr="ts"),
+            Prefetch("tags", Tag.objects.all(), to_attr="ts2"),
+        )
+        reveal_type(multi_qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'ts': builtins.list[myapp.models.Tag], 'ts2': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'ts': builtins.list[myapp.models.Tag], 'ts2': builtins.list[myapp.models.Tag]})]]"
+        reveal_type(multi_qs.get().ts) # N: Revealed type is "builtins.list[myapp.models.Tag]"
+        reveal_type(multi_qs.get().ts2) # N: Revealed type is "builtins.list[myapp.models.Tag]"
+
+        # Mixed inline `Prefetch` and variable `Prefetch` in one call
+        mixed_qs = Article.objects.prefetch_related(
+            tag_prefetch,
+            Prefetch("article_set", Article.objects.all(), to_attr="arts2"),
+        )
+        reveal_type(mixed_qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'arts2': builtins.list[myapp.models.Article]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'arts2': builtins.list[myapp.models.Article]})]]"
+
+        # Mixed inline `Prefetch` and plain lookup string in one call; string should be ignored
+        mixed_plain = Article.objects.prefetch_related(
+            "article_set",
+            Prefetch("article_set", Article.objects.all(), to_attr="arts3"),
+        )
+        reveal_type(mixed_plain) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'arts3': builtins.list[myapp.models.Article]})], myapp.models.Article@AnnotatedWith[TypedDict({'arts3': builtins.list[myapp.models.Article]})]]"
+
+        # Prefetch with `to_attr` arg but without the `queryset` arg
+        # TODO: We should be able to resolve a more accurate type using existing lookup `resolve_lookup_expected_type` machinery
+        reveal_type(Article.objects.prefetch_related(models.Prefetch("tags", to_attr="just_tags")).get().just_tags) # N: Revealed type is "builtins.list[Any]"
+
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Tag(models.Model): ...
+                class Article(models.Model):
+                    tags = models.ManyToManyField(to=Tag, related_name="articles", blank=True)
+
+-   case: prefetch_related_and_annotate
+    main: |
+        from django.db.models import Prefetch, F
+        from django.contrib.auth.models import User, Group
+
+        user = (
+            User.objects
+            .annotate(annotated_user=F("username"))
+            .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="to_attr_groups"))
+            .get()
+        )
+        reveal_type(user.annotated_user) # N: Revealed type is "Any"
+        reveal_type(user.to_attr_groups) # N: Revealed type is "builtins.list[django.contrib.auth.models.Group]"
+
+    installed_apps:
+        - django.contrib.auth


### PR DESCRIPTION
# I have made things!

A bit more involved than I expected. I was close to reuse some mypy plugin utils for the argument inference but they currently do no support class instantiation so I've adapted from it.
The logic is very similar to what is done in the `.annotate()` plugin code.

I left a few todos for improvements in later PR's, this one is already quite big.

<details>
<summary>todos

</summary>

### Correctly handle mixed `annotate`/`prefetch_related` on the same key -- :white_check_mark:  in #2791

Currently it applies the last annotation, in reality, only the annotate matter and the prefetch is ignored + we should probably raise type errors?

```yml
-   case: prefetch_related_conflict_with_annotate
    main: |
        from django.db.models import Prefetch, F
        from django.contrib.auth.models import User, Group

        # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
        # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
        # TODO: Whould be nice to raise errors here
        reveal_type(
            User.objects # N: Revealed type is "builtins.list[django.contrib.auth.models.Group]"  <-- Wrong, runtime type is F("username")
            .annotate(foo=F("username"))
            .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
            .get().foo
        )
        reveal_type(
            User.objects # N: Revealed type is "Any"
            .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
            .annotate(foo=F("username"))
            .get().foo
        )
    installed_apps:
        - django.contrib.auth
```

### Narrow type when no queryset is provided -- :white_check_mark: in #2786
Using the existing lookup_type infrastructure.
- create `get_model_info_from_qs_ctx`
- reuse / merge with `_extract_model_type_from_queryset`

```diff
# Prefetch with `to_attr` arg but without the `queryset` arg
# TODO: We should be able to resolve a more accurate type using existing lookup `resolve_lookup_expected_type` machinery
reveal_type(
    Article.objects.prefetch_related(
-     models.Prefetch("tags", to_attr="tags")).get().tags)  # N: Revealed type is "builtins.list[Any]"
+     models.Prefetch("tags", to_attr="tags")).get().tags)  # N: Revealed type is "builtins.list[myapp.models.Tag]"
    )
)
```



</details>

## Related issues

Fixes #795
