### PR TITLE
Remove `OrderedDict` usage, this is the default since py 3.6

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -357,7 +356,7 @@ def get_current_module(api: TypeChecker) -> MypyFile:
 
 
 def make_oneoff_named_tuple(
-    api: TypeChecker, name: str, fields: "OrderedDict[str, MypyType]", extra_bases: list[Instance] | None = None
+    api: TypeChecker, name: str, fields: "dict[str, MypyType]", extra_bases: list[Instance] | None = None
 ) -> TupleType:
     current_module = get_current_module(api)
     if extra_bases is None:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Sequence
 
 from django.core.exceptions import FieldError
@@ -109,7 +108,7 @@ def get_values_list_row_type(
             assert lookup_type is not None
             return lookup_type
         elif named:
-            column_types: OrderedDict[str, MypyType] = OrderedDict()
+            column_types: dict[str, MypyType] = {}
             for field in django_context.get_model_fields(model_cls):
                 column_type = django_context.get_field_get_type(
                     typechecker_api, model_info, field, method="values_list"
@@ -137,7 +136,7 @@ def get_values_list_row_type(
         typechecker_api.fail("'flat' is not valid when 'values_list' is called with more than one field", ctx.context)
         return AnyType(TypeOfAny.from_error)
 
-    column_types = OrderedDict()
+    column_types = {}
     for field_lookup in field_lookups:
         lookup_field_type = get_field_type_from_lookup(
             ctx, django_context, model_cls, lookup=field_lookup, method="values_list", silent_on_error=is_annotated
@@ -354,7 +353,7 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
         for field in django_context.get_model_fields(model_cls):
             field_lookups.append(field.attname)
 
-    column_types: OrderedDict[str, MypyType] = OrderedDict()
+    column_types: dict[str, MypyType] = {}
 
     # Collect `*fields` types -- `.values("id", "name")`
     for field_lookup in field_lookups:


### PR DESCRIPTION
Followup after discussion in https://github.com/typeddjango/django-stubs/pull/2779#discussion_r2295460703
