### PR TITLE
Update `Meta.permissions` type

### DIFF
--- a/ext/django_stubs_ext/db/models/__init__.py
+++ b/ext/django_stubs_ext/db/models/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         managed: ClassVar[bool]  # default: True
         order_with_respect_to: ClassVar[str]
         ordering: ClassVar[Sequence[str | OrderBy]]
-        permissions: ClassVar[_ListOrTuple[tuple[str, str]]]
+        permissions: ClassVar[_ListOrTuple[tuple[str, StrOrPromise]]]
         default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
         proxy: ClassVar[bool]  # default: False
         required_db_features: ClassVar[_ListOrTuple[str]]


### PR DESCRIPTION
# I have made things!

This is rather usual to have translation for the `human_readable_permission_name`.

```python
from django.utils.translation import gettext_lazy as _
class MyModel(models.Model):
    ...
    class Meta:
        permissions = [
             ("export_data", _("Can export data from the admin")) 
        ]
```

Ref: https://docs.djangoproject.com/en/5.2/ref/models/options/#django.db.models.Options.permissions