### PR TITLE
Auto inherit from `TypedModelMeta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ https://github.com/typeddjango/django-stubs/discussions/2101#discussioncomment-9
 
 ### Type checking of Model Meta attributes
 
+> [!NOTE]
+> If you are using the mypy plugin and have `django_stub_ext` installed, your model `Meta` classes
+> will be automatically type-checked without further changes.
+
 By inheriting from the `TypedModelMeta` class, you can ensure you're using correct types for
 attributes:
 

--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -56,7 +56,7 @@ COMBINABLE_EXPRESSION_FULLNAME = "django.db.models.expressions.Combinable"
 F_EXPRESSION_FULLNAME = "django.db.models.expressions.F"
 
 ANY_ATTR_ALLOWED_CLASS_FULLNAME = "django_stubs_ext.AnyAttrAllowed"
-
+TYPED_MODEL_META_FULLNAME = "django_stubs_ext.db.models.TypedModelMeta"
 STR_PROMISE_FULLNAME = "django.utils.functional._StrPromise"
 
 OBJECT_DOES_NOT_EXIST = "django.core.exceptions.ObjectDoesNotExist"

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -125,9 +125,11 @@ class NewSemanalDjangoPlugin(Plugin):
                     deps.add(self._new_dependency(related_model_module))
 
         return list(deps) + [
-            # for QuerySet.annotate
+            # For `QuerySet.annotate`
             self._new_dependency("django_stubs_ext"),
-            # For Manager.from_queryset
+            # For `TypedModelMeta` lookup in model transformers
+            self._new_dependency("django_stubs_ext.db.models"),
+            # For `Manager.from_queryset`
             self._new_dependency("django.db.models.query"),
         ]
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -64,9 +64,9 @@ class NewSemanalDjangoPlugin(Plugin):
         self.django_context = DjangoContext(self.plugin_config.django_settings_module)
 
     def _get_current_form_bases(self) -> dict[str, int]:
-        model_sym = self.lookup_fully_qualified(fullnames.BASEFORM_CLASS_FULLNAME)
-        if model_sym is not None and isinstance(model_sym.node, TypeInfo):
-            bases = helpers.get_django_metadata_bases(model_sym.node, "baseform_bases")
+        model_info = self._get_typeinfo_or_none(fullnames.BASEFORM_CLASS_FULLNAME)
+        if model_info:
+            bases = helpers.get_django_metadata_bases(model_info, "baseform_bases")
             bases[fullnames.BASEFORM_CLASS_FULLNAME] = 1
             bases[fullnames.FORM_CLASS_FULLNAME] = 1
             bases[fullnames.MODELFORM_CLASS_FULLNAME] = 1
@@ -201,12 +201,8 @@ class NewSemanalDjangoPlugin(Plugin):
         return None
 
     def get_customize_class_mro_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
-        sym = self.lookup_fully_qualified(fullname)
-        if (
-            sym is not None
-            and isinstance(sym.node, TypeInfo)
-            and sym.node.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
-        ):
+        info = self._get_typeinfo_or_none(fullname)
+        if info and info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME):
             return reparametrize_any_manager_hook
         else:
             return None
@@ -218,8 +214,8 @@ class NewSemanalDjangoPlugin(Plugin):
 
     def get_base_class_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
         # Base class is a Model class definition
-        sym = self.lookup_fully_qualified(fullname)
-        if sym is not None and isinstance(sym.node, TypeInfo) and helpers.is_model_type(sym.node):
+        info = self._get_typeinfo_or_none(fullname)
+        if info and helpers.is_model_type(info):
             return partial(process_model_class, django_context=self.django_context)
 
         # Base class is a Form class definition
@@ -227,7 +223,7 @@ class NewSemanalDjangoPlugin(Plugin):
             return forms.transform_form_class
 
         # Base class is a QuerySet class definition
-        if sym is not None and isinstance(sym.node, TypeInfo) and sym.node.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
+        if info and info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
             return add_as_manager_to_queryset_class
         return None
 

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -145,7 +145,7 @@
     -   path: myapp/models.py
         content: |
             from django.db import models
-            from typing import Literal
+            from typing import Literal, ClassVar
 
             class Abstract(models.Model):
                 field = models.CharField()
@@ -158,7 +158,7 @@
 
             class LiteralAbstract(models.Model):
                 class Meta:
-                    abstract: Literal[True]
+                    abstract: ClassVar[Literal[True]]
 
 
 - case: test_use_abstract_model

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -76,6 +76,58 @@
                 unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Sequence[Sequence[str]]")  [assignment]
                 unknown_attr = True  # can't check this
 
+        class MyModelMultipleBaseMeta(models.Model):
+          class Meta(MyModel.Meta, TypedModelMeta):
+              abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+
+-   case: auto_base_model_meta_incompatible_types
+    main: |
+        from myapp.models import MyModelWithAutoTypedMeta
+    installed_apps:
+      - myapp
+    files:
+      - path: myapp/__init__.py
+      - path: myapp/models.py
+        content: |
+            from django.db import models
+
+            class MyModelWithAutoTypedMeta(models.Model):
+                example = models.CharField(max_length=100)
+                class Meta:
+                    abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+                    verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "list[str]", base class "TypedModelMeta" defined the type as "str | _StrPromise")  [assignment]
+                    unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Sequence[Sequence[str]]")  [assignment]
+
+            class DefinitelyNotAModel:
+                class Meta:
+                    abstract = 7
+                    verbose_name = ['test']
+                    unique_together = {1: 2}
+                    unknown_attr = True
+
+-   case: auto_base_model_meta_incompatible_types_multiple_inheritance
+    main: |
+        from myapp.models import MyModel, MyModel2, MyModel3
+    installed_apps:
+      - myapp
+    files:
+      - path: myapp/__init__.py
+      - path: myapp/models.py
+        content: |
+            from django.db import models
+
+            class MyModel(models.Model):
+                class Meta:
+                    abstract = 5  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+
+            class MyModel2(models.Model):
+                class Meta:
+                    abstract = 5  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+
+            class MyModel3(models.Model):
+                class Meta(MyModel.Meta, MyModel2.Meta):
+                    verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "list[str]", base class "TypedModelMeta" defined the type as "str | _StrPromise")  [assignment]
+                    unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Sequence[Sequence[str]]")  [assignment]
 
 -   case: instantiate_abstract_model
     main: |

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -94,7 +94,7 @@
             class MyModelWithAutoTypedMeta(models.Model):
                 example = models.CharField(max_length=100)
                 class Meta:
-                    abstract = 7  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
+                    abstract = 0  # E: Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")  [assignment]
                     verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "list[str]", base class "TypedModelMeta" defined the type as "str | _StrPromise")  [assignment]
                     unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Sequence[Sequence[str]]")  [assignment]
 
@@ -126,6 +126,7 @@
 
             class MyModel3(models.Model):
                 class Meta(MyModel.Meta, MyModel2.Meta):
+                    abstract = 0 # OK because both base classes currently define this as int
                     verbose_name = ['test']  # E: Incompatible types in assignment (expression has type "list[str]", base class "TypedModelMeta" defined the type as "str | _StrPromise")  [assignment]
                     unique_together = {1: 2}  # E: Incompatible types in assignment (expression has type "dict[int, int]", base class "TypedModelMeta" defined the type as "Sequence[Sequence[str]]")  [assignment]
 


### PR DESCRIPTION
# I have made things!
(Review per commit advised, the first one is a minor cleanup)

Implement the suggestion in https://github.com/typeddjango/django-stubs/pull/1375#issuecomment-1440572037 providing automatic type-checking of Django models `Meta` class by artificially inserting `TypedModelMeta` in the mro.

The error message might be slightly confusing since the user did not add an explicit base class but I think is comprehensible enough and that the value outweigh the slightly weird message. For ex:

> Incompatible types in assignment (expression has type "int", base class "TypedModelMeta" defined the type as "bool")

I've also tested this change on a rather large Django codebase (1M python LoC) adding errors that were all caught properly.