### PR TITLE
Handle `.prefetch_related(..., to_attr="foo")` conflict with `.annotate(foo=...)`

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -426,7 +426,11 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
             [elem_model if elem_model is not None else AnyType(TypeOfAny.special_form)],
         )
 
-        fields[to_attr_value] = value_type
+        if not (model_type.extra_attrs and to_attr_value in model_type.extra_attrs.attrs):
+            # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
+            # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
+            # So only add the annotation here if it doesn't exist yet.
+            fields[to_attr_value] = value_type
 
     if not fields:
         return ctx.default_return_type

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -163,13 +163,15 @@
             User.objects
             .annotate(foo=F("username"))
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
-            .get().foo
+            .get()
         )
-        reveal_type(annotate_into_prefetch)  # N: Revealed type is "Any"
+        reveal_type(annotate_into_prefetch)  # N: Revealed type is "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
         prefetch_into_annotate = (
             User.objects
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
             .annotate(foo=F("username"))
-            .get().foo
+            .get()
         )
-        reveal_type(prefetch_into_annotate)  # N: Revealed type is "Any"
+        reveal_type(prefetch_into_annotate)  # N: Revealed type is "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
+    installed_apps:
+        - django.contrib.auth

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -151,3 +151,25 @@
 
     installed_apps:
         - django.contrib.auth
+
+-   case: prefetch_related_conflict_with_annotate
+    main: |
+        from django.db.models import Prefetch, F
+        from django.contrib.auth.models import User, Group
+
+        # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
+        # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
+        annotate_into_prefetch = (
+            User.objects
+            .annotate(foo=F("username"))
+            .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
+            .get().foo
+        )
+        reveal_type(annotate_into_prefetch)  # N: Revealed type is "Any"
+        prefetch_into_annotate = (
+            User.objects
+            .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
+            .annotate(foo=F("username"))
+            .get().foo
+        )
+        reveal_type(prefetch_into_annotate)  # N: Revealed type is "Any"


### PR DESCRIPTION
# I have made things!

Fixes one of the issue identified in the initial implementation (#2779).

The current fix does not correctly handle chained `prefetch_related` mapping to the same `to_attr` ie:

```python
reveal_type(
    Article.objects # N: Revealed type is "builtins.list[myapp.models.Group]"  <--- incorrect, should be `list[Article]`
     .prefetch_related(Prefetch("tags", Group.objects.all(), to_attr="foo"))
     .prefetch_related(Prefetch("related_articles", Article.objects.all(), to_attr="foo"))
     .get().foo
)
```

This should be possible to handle but require expanding the hacky usage of [`ExtraAttrs`](https://github.com/typeddjango/django-stubs/blob/cbe9bd63da1264ada0f3ae1ec1f1f52fc3c798b2/mypy_django_plugin/transformers/models.py#L1132-L1150) to record if the annotation come from a `.annotate()` or a `.prefetch_related()` call.

I'm not sure it's worth the complexity given the unlikeliness of this happening. Let me know what you think
