### PR TITLE
Detect more incompatible `to_attr` targets

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -437,13 +437,12 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
                     continue
 
                 if lookup_value := helpers.resolve_string_attribute_value(lookup_expr, django_context):
-                    if qs_model := helpers.get_model_info_from_qs_ctx(ctx, django_context):
-                        try:
-                            observed_model_cls = django_context.resolve_lookup_into_field(qs_model.cls, lookup_value)[1]
-                            if model_info := helpers.lookup_class_typeinfo(api, observed_model_cls):
-                                elem_model = Instance(model_info, [])
-                        except (FieldError, LookupsAreUnsupported):
-                            pass
+                    try:
+                        observed_model_cls = django_context.resolve_lookup_into_field(qs_model.cls, lookup_value)[1]
+                        if model_info := helpers.lookup_class_typeinfo(api, observed_model_cls):
+                            elem_model = Instance(model_info, [])
+                    except (FieldError, LookupsAreUnsupported):
+                        pass
 
         value_type = api.named_generic_type(
             "builtins.list",

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -358,14 +358,15 @@ def gather_flat_args(ctx: MethodContext) -> list[tuple[Expression | None, Proper
     arguments when their type is a TupleType with statically known items.
     """
     lookups: list[tuple[Expression | None, ProperType]] = []
+    arg_start_idx = 0
     for expr, typ, kind in zip(ctx.args[0], ctx.arg_types[0], ctx.arg_kinds[0], strict=False):
         ptyp = get_proper_type(typ)
         if kind == ARG_STAR:
             # Expand starred tuple items if statically known
             if isinstance(ptyp, TupleType):
-                for item_typ in ptyp.items:
-                    lookups.append((None, get_proper_type(item_typ)))
+                lookups.append((None, get_proper_type(ptyp.items[arg_start_idx])))
             # If not a TupleType (e.g. list/Iterable), we cannot expand statically
+            arg_start_idx += 1
             continue
         lookups.append((expr, ptyp))
     return lookups

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -401,7 +401,7 @@ def check_conflicting_attr_value(
     )
     if is_conflicting_attr_value:
         ctx.api.fail(
-            f'Attribute "{attr_name}" already defined on "{model.typ.type.name}"',
+            f'Attribute "{attr_name}" already defined on "{model.typ}"',
             ctx.context,
             code=NO_REDEF,
         )

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -13,6 +13,7 @@ from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
 from mypy_django_plugin.lib import fullnames, helpers
+from mypy_django_plugin.lib.helpers import DjangoModel
 from mypy_django_plugin.transformers.models import get_annotated_type
 
 
@@ -181,10 +182,10 @@ def gather_kwargs(ctx: MethodContext) -> dict[str, MypyType] | None:
     return kwargs
 
 
-def gather_expression_types(ctx: MethodContext) -> dict[str, MypyType] | None:
+def gather_expression_types(ctx: MethodContext) -> dict[str, MypyType]:
     kwargs = gather_kwargs(ctx)
     if not kwargs:
-        return None
+        return {}
 
     # For now, we don't try to resolve the output_field of the field would be, but use Any.
     # NOTE: It's important that we use 'special_form' for 'Any' as otherwise we can
@@ -226,21 +227,21 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
         return ctx.default_return_type
 
     api = helpers.get_typechecker_api(ctx)
-    expression_types = gather_expression_types(ctx)
+    expression_types = {
+        attr_name: typ
+        for attr_name, typ in gather_expression_types(ctx).items()
+        if not check_conflicting_attr_value(ctx, django_model, attr_name)
+    }
 
-    fields_dict = None
-    if expression_types is not None:
+    annotated_type: ProperType = django_model.typ
+    if expression_types:
         fields_dict = helpers.make_typeddict(
             api,
             fields=expression_types,
             required_keys=set(expression_types.keys()),
             readonly_keys=set(),
         )
-
-    if fields_dict is not None:
         annotated_type = get_annotated_type(api, django_model.typ, fields_dict=fields_dict)
-    else:
-        annotated_type = django_model.typ
 
     row_type: MypyType
     if len(default_return_type.args) > 1:
@@ -311,10 +312,7 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
         column_types[field_lookup] = field_lookup_type
 
     # Collect `**expressions` types -- `.values(lower_name=Lower("name"), foo=F("name"))`
-    expression_types = gather_expression_types(ctx)
-    if expression_types is not None:
-        column_types.update(expression_types)
-
+    column_types.update(gather_expression_types(ctx))
     row_type = helpers.make_typeddict(ctx.api, column_types, set(column_types.keys()), set())
     return default_return_type.copy_modified(args=[django_model.typ, row_type])
 
@@ -372,6 +370,44 @@ def gather_flat_args(ctx: MethodContext) -> list[tuple[Expression | None, Proper
     return lookups
 
 
+def check_conflicting_attr_value(
+    ctx: MethodContext, model: DjangoModel, attr_name: str, new_attrs: dict[str, MypyType] | None = None
+) -> bool:
+    """
+    Check if adding `attr_name` would conflict with existing symbols on `model`.
+
+    Args:
+        - model: The Django model being analyzed
+        - attr_name: The name of the attribute to be added
+        - fields: A mapping of field names to types currently being added to the model
+    """
+    is_conflicting_attr_value = bool(
+        # 1. Conflict with another symbol on the model.
+        # Ex:
+        #     User.objects.prefetch_related(Prefetch(..., to_attr="id"))
+        model.typ.type.get(attr_name)
+        # 2. Conflict with a previous annotation.
+        # Ex:
+        #     User.objects.annotate(foo=...).prefetch_related(Prefetch(...,to_attr="foo"))
+        #     User.objects.prefetch_related(Prefetch(...,to_attr="foo")).prefetch_related(Prefetch(...,to_attr="foo"))
+        or (model.typ.extra_attrs and attr_name in model.typ.extra_attrs.attrs)
+        # 3. Conflict with another symbol added in the current processing.
+        # Ex:
+        #     User.objects.prefetch_related(
+        #        Prefetch("groups", Group.objects.filter(name="test"), to_attr="new_attr"),
+        #        Prefetch("groups", Group.objects.all(), to_attr="new_attr"), # E: Not OK!
+        #     )
+        or (new_attrs is not None and attr_name in new_attrs)
+    )
+    if is_conflicting_attr_value:
+        ctx.api.fail(
+            f'Attribute "{attr_name}" already defined on "{model.typ.type.name}"',
+            ctx.context,
+            code=NO_REDEF,
+        )
+    return is_conflicting_attr_value
+
+
 def extract_prefetch_related_annotations(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     """
     Extract annotated attributes via `prefetch_related(Prefetch(..., to_attr=...))`
@@ -392,7 +428,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     ):
         return ctx.default_return_type
 
-    fields: dict[str, MypyType] = {}
+    new_attrs: dict[str, MypyType] = {}
 
     for expr, typ in gather_flat_args(ctx):
         if not (isinstance(typ, Instance) and typ.type.has_base(fullnames.PREFETCH_CLASS_FULLNAME)):
@@ -450,23 +486,16 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
             [elem_model if elem_model is not None else AnyType(TypeOfAny.special_form)],
         )
 
-        if qs_model.typ.type.get(to_attr_value):
-            ctx.api.fail(
-                f'Attribute "{to_attr_value}" already defined on "{qs_model.typ.type.name}"', ctx.context, code=NO_REDEF
-            )
-        elif not (qs_model.typ.extra_attrs and to_attr_value in qs_model.typ.extra_attrs.attrs):
-            # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
-            # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
-            # So only add the annotation here if it doesn't exist yet.
-            fields[to_attr_value] = value_type
+        if not check_conflicting_attr_value(ctx, qs_model, to_attr_value, new_attrs):
+            new_attrs[to_attr_value] = value_type
 
-    if not fields:
+    if not new_attrs:
         return ctx.default_return_type
 
     fields_dict = helpers.make_typeddict(
         api,
-        fields=fields,
-        required_keys=set(fields.keys()),
+        fields=new_attrs,
+        required_keys=set(new_attrs.keys()),
         readonly_keys=set(),
     )
 

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -185,13 +185,13 @@
         # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
         # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
         annotate_into_prefetch = (
-            User.objects # E: Attribute "foo" already defined on "User@AnnotatedWith"  [no-redef]
+            User.objects # E: Attribute "foo" already defined on "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"  [no-redef]
             .annotate(foo=F("username"))
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
             .get()
         )
         prefetch_into_annotate = (
-            User.objects  # E: Attribute "foo" already defined on "User@AnnotatedWith"  [no-redef]
+            User.objects  # E: Attribute "foo" already defined on "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': builtins.list[django.contrib.auth.models.Group]})]"  [no-redef]
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
             .annotate(foo=F("username"))
             .get()
@@ -205,15 +205,15 @@
         from django.db.models import Prefetch, F
         from myapp.models import Article, Tag
 
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="pk"))  # E: Attribute "pk" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="id"))  # E: Attribute "id" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="tags"))  # E: Attribute "tags" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_property"))  # E: Attribute "my_property" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_method"))  # E: Attribute "my_method" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_classmethod"))  # E: Attribute "my_classmethod" already defined on "Article"  [no-redef]
-        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_staticmethod"))  # E: Attribute "my_staticmethod" already defined on "Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="pk"))  # E: Attribute "pk" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="id"))  # E: Attribute "id" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="tags"))  # E: Attribute "tags" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_property"))  # E: Attribute "my_property" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_method"))  # E: Attribute "my_method" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_classmethod"))  # E: Attribute "my_classmethod" already defined on "myapp.models.Article"  [no-redef]
+        Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_staticmethod"))  # E: Attribute "my_staticmethod" already defined on "myapp.models.Article"  [no-redef]
 
-        Tag.objects.prefetch_related(Prefetch("articles", Article.objects.all(), to_attr="articles"))  # E: Attribute "articles" already defined on "Tag"  [no-redef]
+        Tag.objects.prefetch_related(Prefetch("articles", Article.objects.all(), to_attr="articles"))  # E: Attribute "articles" already defined on "myapp.models.Tag"  [no-redef]
 
     files:
         -   path: myapp/__init__.py
@@ -264,11 +264,11 @@
         from django.db.models import Prefetch
         from django.contrib.auth.models import User, Group
 
-        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "User"  [no-redef]
+        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "django.contrib.auth.models.User"  [no-redef]
            Prefetch("groups", Group.objects.filter(name="test"), to_attr="new_attr"),
            Prefetch("groups", Group.objects.all(), to_attr="new_attr"),
         )
-        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "User@AnnotatedWith"  [no-redef]
+        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'new_attr': builtins.list[django.contrib.auth.models.Group]})]"  [no-redef]
            Prefetch("groups", Group.objects.all(), to_attr="new_attr"),
         ).prefetch_related(
            Prefetch("groups", Group.objects.all(), to_attr="new_attr"),

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -213,6 +213,9 @@
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_method"))  # E: Attribute "my_method" already defined on "Article"  [no-redef]
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_classmethod"))  # E: Attribute "my_classmethod" already defined on "Article"  [no-redef]
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_staticmethod"))  # E: Attribute "my_staticmethod" already defined on "Article"  [no-redef]
+
+        Tag.objects.prefetch_related(Prefetch("articles", Article.objects.all(), to_attr="articles"))  # E: Attribute "articles" already defined on "Tag"  [no-redef]
+
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -130,12 +130,13 @@
         first_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags")
         second_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags2")
         third_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags3")
+        fourth_prefetch = Prefetch("tags", Tag.objects.all(), to_attr="every_tags4")
         prefetch_objs = (first_prefetch, second_prefetch)
 
         reveal_type(Article.objects.prefetch_related(*prefetch_objs).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})]]"
         reveal_type(Article.objects.prefetch_related(third_prefetch, *prefetch_objs).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags3': builtins.list[myapp.models.Tag], 'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags3': builtins.list[myapp.models.Tag], 'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})]]"
         reveal_type(Article.objects.prefetch_related(*prefetch_objs, third_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})]]"
-        reveal_type(Article.objects.prefetch_related(first_prefetch, *prefetch_objs, third_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})]]"
+        reveal_type(Article.objects.prefetch_related(fourth_prefetch, *prefetch_objs, third_prefetch).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags4': builtins.list[myapp.models.Tag], 'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags4': builtins.list[myapp.models.Tag], 'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag], 'every_tags3': builtins.list[myapp.models.Tag]})]]"
 
         # *args prefetch from helper function
         def _get_prefetches() -> tuple[
@@ -184,19 +185,17 @@
         # When mixing `.annotate(foo=...)` and `prefetch_related(Prefetch(...,to_attr=foo))`
         # The last annotate in the chain takes precedence (even if it is prior to the prefetch_related)
         annotate_into_prefetch = (
-            User.objects
+            User.objects # E: Attribute "foo" already defined on "User@AnnotatedWith"  [no-redef]
             .annotate(foo=F("username"))
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
             .get()
         )
-        reveal_type(annotate_into_prefetch)  # N: Revealed type is "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
         prefetch_into_annotate = (
-            User.objects
+            User.objects  # E: Attribute "foo" already defined on "User@AnnotatedWith"  [no-redef]
             .prefetch_related(Prefetch("groups", Group.objects.all(), to_attr="foo"))
             .annotate(foo=F("username"))
             .get()
         )
-        reveal_type(prefetch_into_annotate)  # N: Revealed type is "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
 
 
 -   case: prefetch_related_to_attr_conflict_with_model_attr
@@ -257,3 +256,23 @@
                 class Person(models.Model): ...
                 class Book(models.Model):
                     author = models.ForeignKey(Person, on_delete=models.CASCADE)
+
+-   case: prefetch_related_conflicting_prefetches_on_same_attr
+    installed_apps:
+        - django.contrib.auth
+    main: |
+        from django.db.models import Prefetch
+        from django.contrib.auth.models import User, Group
+
+        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "User"  [no-redef]
+           Prefetch("groups", Group.objects.filter(name="test"), to_attr="new_attr"),
+           Prefetch("groups", Group.objects.all(), to_attr="new_attr"),
+        )
+        User.objects.prefetch_related( # E: Attribute "new_attr" already defined on "User@AnnotatedWith"  [no-redef]
+           Prefetch("groups", Group.objects.all(), to_attr="new_attr"),
+        ).prefetch_related(
+           Prefetch("groups", Group.objects.all(), to_attr="new_attr"),
+        )
+        User.objects.prefetch_related("groups", Prefetch("groups")) # Ok
+        User.objects.prefetch_related("groups", Prefetch("groups", Group.objects.filter(name="test"))) # TODO: Should be Not OK!
+        User.objects.prefetch_related(Prefetch("groups", Group.objects.filter(name="test")), "groups") # TODO: Should be Not OK! (but OK at runtime :/)

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -1,4 +1,6 @@
 -   case: prefetch_related_to_attr
+    installed_apps:
+        - myapp
     main: |
         from myapp.models import Article, Tag
         from django.db.models import Prefetch, F, QuerySet
@@ -143,8 +145,7 @@
             return prefetch_objs
 
         reveal_type(Article.objects.prefetch_related(*_get_prefetches()).all()) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})], myapp.models.Article@AnnotatedWith[TypedDict({'every_tags': builtins.list[myapp.models.Tag], 'every_tags2': builtins.list[myapp.models.Tag]})]]"
-    installed_apps:
-        - myapp
+
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
@@ -156,6 +157,8 @@
                     tags = models.ManyToManyField(to=Tag, related_name="articles", blank=True)
 
 -   case: prefetch_related_and_annotate
+    installed_apps:
+        - django.contrib.auth
     main: |
         from django.db.models import Prefetch, F
         from django.contrib.auth.models import User, Group
@@ -169,10 +172,11 @@
         reveal_type(user.annotated_user) # N: Revealed type is "Any"
         reveal_type(user.to_attr_groups) # N: Revealed type is "builtins.list[django.contrib.auth.models.Group]"
 
-    installed_apps:
-        - django.contrib.auth
+
 
 -   case: prefetch_related_to_attr_conflict_with_annotate
+    installed_apps:
+        - django.contrib.auth
     main: |
         from django.db.models import Prefetch, F
         from django.contrib.auth.models import User, Group
@@ -193,10 +197,11 @@
             .get()
         )
         reveal_type(prefetch_into_annotate)  # N: Revealed type is "django.contrib.auth.models.User@AnnotatedWith[TypedDict({'foo': Any})]"
-    installed_apps:
-        - django.contrib.auth
+
 
 -   case: prefetch_related_to_attr_conflict_with_model_attr
+    installed_apps:
+        - myapp
     main: |
         from django.db.models import Prefetch, F
         from myapp.models import Article, Tag
@@ -208,9 +213,6 @@
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_method"))  # E: Attribute "my_method" already defined on "Article"  [no-redef]
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_classmethod"))  # E: Attribute "my_classmethod" already defined on "Article"  [no-redef]
         Article.objects.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="my_staticmethod"))  # E: Attribute "my_staticmethod" already defined on "Article"  [no-redef]
-
-    installed_apps:
-        - myapp
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py


### PR DESCRIPTION
# I have made things!

Initial work to address https://github.com/typeddjango/django-stubs/pull/2794#discussion_r2318888629 and detect more incompatible `to_attr` targets.

The main changes in behavior are:
- We detect duplicate `to_attr` used in a single `prefetch_related`
- We detect duplicate `to_attr` from chained `prefetch_related`
- `.annotate` now also detect conflict with existing fields

The logic is now shared with the annotate hook, which means we now detect runtime annotate errors like [ValueError: The annotation 'username' conflicts with a field on the model.](https://github.com/django/django/blob/686a8a62ae7faba9c3b17080c3532b821e8cb1f3/django/db/models/query.py#L1734-L1737)

We still don't detect suttle errors like `User.objects.prefetch_related("groups", Prefetch("groups", Group.objects.filter(name="test")))` which is invalid because the queryset changed. 
I'm working on another PR to detect these and more but it's a bit more complicated because we need to track the `lookup` value to do so correctly