### PR TITLE
Update mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,7 @@ enable_error_code =
     possibly-undefined,
     redundant-expr,
     redundant-self,
+    truthy-bool,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,7 @@ enable_error_code =
     deprecated,
     exhaustive-match,
     ignore-without-code,
+    possibly-undefined,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,7 @@ enable_error_code =
     exhaustive-match,
     ignore-without-code,
     possibly-undefined,
+    redundant-expr,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,7 @@ disable_error_code = empty-body
 enable_error_code =
     deprecated,
     exhaustive-match,
+    ignore-without-code,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,14 +6,11 @@ incremental = true
 
 # Strictness:
 allow_redefinition = true
-check_untyped_defs = true
 # TODO: add type args to all generics
 disallow_any_generics = false
 # TODO: fix `Any` subclassing in `typeshed/builtins.pyi`
 disallow_subclassing_any = false
-ignore_missing_imports = false
 strict = true
-strict_bytes = true
 local_partial_types = true
 warn_unreachable = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,6 +24,7 @@ enable_error_code =
     redundant-self,
     truthy-bool,
     truthy-iterable,
+    unimported-reveal,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,7 +15,9 @@ local_partial_types = true
 warn_unreachable = true
 
 disable_error_code = empty-body
-enable_error_code = deprecated
+enable_error_code =
+    deprecated,
+    exhaustive-match,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,11 +23,6 @@ plugins =
     mypy_django_plugin.main,
     mypy.plugins.proper_plugin
 
-# Ignore incomplete hints in 3rd party stubs:
-[mypy-yaml.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
 # Our settings:
 [mypy.plugins.django-stubs]
 django_settings_module = scripts.django_tests_settings

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,6 +23,7 @@ enable_error_code =
     redundant-expr,
     redundant-self,
     truthy-bool,
+    truthy-iterable,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,6 +25,7 @@ enable_error_code =
     truthy-bool,
     truthy-iterable,
     unimported-reveal,
+    unused-awaitable,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,7 @@ enable_error_code =
     ignore-without-code,
     possibly-undefined,
     redundant-expr,
+    redundant-self,
 
 show_traceback = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,6 @@
 incremental = true
 
 # Strictness:
-allow_redefinition = true
 # TODO: add type args to all generics
 disallow_any_generics = false
 # TODO: fix `Any` subclassing in `typeshed/builtins.pyi`

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -200,8 +200,6 @@ class DjangoContext:
 
     def get_expected_types(self, api: TypeChecker, model_cls: type[Model], *, method: str) -> dict[str, MypyType]:
         contenttypes_in_apps = self.apps_registry.is_installed("django.contrib.contenttypes")
-        if contenttypes_in_apps:
-            from django.contrib.contenttypes.fields import GenericForeignKey
 
         expected_types = {}
         # add pk if not abstract=True
@@ -256,17 +254,20 @@ class DjangoContext:
 
                     expected_types[field_name] = model_set_type
 
-            elif contenttypes_in_apps and isinstance(field, GenericForeignKey):
-                # it's generic, so cannot set specific model
-                field_name = field.name
-                gfk_info = helpers.lookup_class_typeinfo(api, field.__class__)
-                if gfk_info is None:
-                    gfk_set_type: MypyType = AnyType(TypeOfAny.unannotated)
-                else:
-                    gfk_set_type = helpers.get_private_descriptor_type(
-                        gfk_info, "_pyi_private_set_type", is_nullable=True
-                    )
-                expected_types[field_name] = gfk_set_type
+            elif contenttypes_in_apps:
+                from django.contrib.contenttypes.fields import GenericForeignKey
+
+                if isinstance(field, GenericForeignKey):
+                    # it's generic, so cannot set specific model
+                    field_name = field.name
+                    gfk_info = helpers.lookup_class_typeinfo(api, field.__class__)
+                    if gfk_info is None:
+                        gfk_set_type: MypyType = AnyType(TypeOfAny.unannotated)
+                    else:
+                        gfk_set_type = helpers.get_private_descriptor_type(
+                            gfk_info, "_pyi_private_set_type", is_nullable=True
+                        )
+                    expected_types[field_name] = gfk_set_type
 
         return expected_types
 

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -511,7 +511,7 @@ class DjangoContext:
         for lookup_base in helpers.iter_bases(lookup_info):
             if lookup_base.args and isinstance((lookup_type := get_proper_type(lookup_base.args[0])), Instance):
                 # if it's Field, consider lookup_type a __get__ of current field
-                if isinstance(lookup_type, Instance) and lookup_type.type.fullname == fullnames.FIELD_FULLNAME:
+                if lookup_type.type.fullname == fullnames.FIELD_FULLNAME:
                     field_info = helpers.lookup_class_typeinfo(helpers.get_typechecker_api(ctx), field.__class__)
                     if field_info is None:
                         return AnyType(TypeOfAny.explicit)

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -317,7 +317,7 @@ class AddPrimaryKeyAlias(AddDefaultPrimaryKey):
     def run_with_model_cls(self, model_cls: type[Model]) -> None:
         # We also need to override existing `pk` definition from `stubs`:
         auto_field = model_cls._meta.pk
-        if auto_field:
+        if auto_field is not None:
             self.create_autofield(
                 auto_field=auto_field,
                 dest_name="pk",

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1147,13 +1147,13 @@ def get_annotated_type(
     """
     if model_type.extra_attrs:
         extra_attrs = ExtraAttrs(
-            attrs={**model_type.extra_attrs.attrs, **(fields_dict.items if fields_dict is not None else {})},
+            attrs={**model_type.extra_attrs.attrs, **fields_dict.items},
             immutable=model_type.extra_attrs.immutable.copy(),
             mod_name=None,
         )
     else:
         extra_attrs = ExtraAttrs(
-            attrs=fields_dict.items if fields_dict is not None else {},
+            attrs=fields_dict.items,
             immutable=None,
             mod_name=None,
         )

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -534,10 +534,11 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
 
     See https://docs.djangoproject.com/en/5.2/ref/models/querysets/#prefetch-objects
     """
+    api = helpers.get_typechecker_api(ctx)
+
     if not (
         isinstance(ctx.type, Instance)
         and isinstance((default_return_type := get_proper_type(ctx.default_return_type)), Instance)
-        and (api := helpers.get_typechecker_api(ctx))
         and (qs_model := helpers.get_model_info_from_qs_ctx(ctx, django_context)) is not None
         and ctx.args
         and ctx.arg_types

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -258,8 +258,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
                 "builtins.dict", [api.named_generic_type("builtins.str", []), AnyType(TypeOfAny.from_omitted_generics)]
             )
         elif isinstance(original_row_type, TupleType):
-            fallback: Instance = original_row_type.partial_fallback
-            if fallback is not None and fallback.type.has_base("typing.NamedTuple"):
+            if original_row_type.partial_fallback.type.has_base("typing.NamedTuple"):
                 # TODO: Use a NamedTuple which contains the known fields, but also
                 #  falls back to allowing any attribute access.
                 row_type = AnyType(TypeOfAny.implementation_artifact)

--- a/tests/assert_type/db/models/test_enums.py
+++ b/tests/assert_type/db/models/test_enums.py
@@ -270,24 +270,24 @@ assert_type(Award.values, list[str])
 assert_type(Award.choices, list[tuple[str, str]])  # pyright: ignore[reportAssertTypeFailure]
 
 # Assertions for mixing multiple choices types with consistent base types - only `IntegerChoices`.
-x = (Suit, Vehicle)
-assert_type([member.label for choices in x for member in choices], list[_StrOrPromise])
-assert_type([member.value for choices in x for member in choices], list[int])
+x0 = (Suit, Vehicle)
+assert_type([member.label for choices in x0 for member in choices], list[_StrOrPromise])
+assert_type([member.value for choices in x0 for member in choices], list[int])
 
 # Assertions for mixing multiple choices types with consistent base types - only `TextChoices`.
-x = (Medal, Gender)
-assert_type([member.label for choices in x for member in choices], list[_StrOrPromise])
-assert_type([member.value for choices in x for member in choices], list[str])
+x1 = (Medal, Gender)
+assert_type([member.label for choices in x1 for member in choices], list[_StrOrPromise])
+assert_type([member.value for choices in x1 for member in choices], list[str])
 
 # Assertions for mixing multiple choices types with different base types - `IntegerChoices` and `TextChoices`.
-x = (Medal, Suit)
-assert_type([member.label for choices in x for member in choices], list[_StrOrPromise])
-assert_type([member.value for choices in x for member in choices], list[int | str])
+x2 = (Medal, Suit)
+assert_type([member.label for choices in x2 for member in choices], list[_StrOrPromise])
+assert_type([member.value for choices in x2 for member in choices], list[int | str])
 
 # Assertions for mixing multiple choices types with consistent base types - custom types.
-x = (Constants, Separator)
-assert_type([member.label for choices in x for member in choices], list[_StrOrPromise])
-assert_type([member.value for choices in x for member in choices], list[Any])
+x3 = (Constants, Separator)
+assert_type([member.label for choices in x3 for member in choices], list[_StrOrPromise])
+assert_type([member.value for choices in x3 for member in choices], list[Any])
 
 
 # Assertions for choices objects defined and aliased in a model.

--- a/tests/typecheck/conf/test_settings.yml
+++ b/tests/typecheck/conf/test_settings.yml
@@ -18,6 +18,7 @@
         -   path: myapp/lib.py
             content: |
                 from typing import TYPE_CHECKING
+                from typing_extensions import reveal_type
                 import django.conf
 
                 settings = django.conf.settings

--- a/tests/typecheck/contrib/admin/test_decorators.yml
+++ b/tests/typecheck/contrib/admin/test_decorators.yml
@@ -1,5 +1,7 @@
 - case: test_admin_decorators_display
   main: |
+    from typing_extensions import reveal_type
+
     from django.db import models
 
     from django.contrib import admin
@@ -56,6 +58,8 @@
 
 - case: test_admin_decorators_action
   main: |
+    from typing_extensions import reveal_type
+
     from django.db import models
 
     from django.contrib import admin

--- a/tests/typecheck/contrib/auth/test_auth.yml
+++ b/tests/typecheck/contrib/auth/test_auth.yml
@@ -1,5 +1,6 @@
 -   case: test_objects_using_auth_user_model_picks_up_configured_type
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth import authenticate, aauthenticate, get_user, get_user_model, login
         from django.contrib.auth.backends import ModelBackend
         from django.contrib.auth.decorators import user_passes_test
@@ -32,6 +33,7 @@
 
 -   case: test_objects_using_auth_user_model_uses_builtin_auth_user_per_default
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth import authenticate, aauthenticate, get_user, get_user_model, login
         from django.contrib.auth.backends import ModelBackend
         from django.contrib.auth.decorators import user_passes_test
@@ -62,6 +64,7 @@
 
 -   case: test_objects_for_auth_user_model_returns_stub_types_when_contrib_auth_is_not_installed
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth import authenticate, aauthenticate, get_user, get_user_model, login
         from django.contrib.auth.backends import ModelBackend
         from django.contrib.auth.base_user import AbstractBaseUser

--- a/tests/typecheck/contrib/auth/test_decorators.yml
+++ b/tests/typecheck/contrib/auth/test_decorators.yml
@@ -1,6 +1,7 @@
 -   case: login_required_bare
     main: |
         from typing import Any
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import login_required
         from django.http import HttpRequest, HttpResponse
         @login_required
@@ -9,6 +10,7 @@
 -   case: login_required_bare_async
     main: |
         from typing import Any
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import login_required
         from django.http import HttpRequest, HttpResponse
         @login_required
@@ -16,6 +18,7 @@
         reveal_type(view_func)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 -   case: login_required_fancy
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import login_required
         from django.core.handlers.wsgi import WSGIRequest
         from django.http import HttpResponse
@@ -24,6 +27,7 @@
         reveal_type(view_func)  # N: Revealed type is "def (request: django.core.handlers.wsgi.WSGIRequest, arg: builtins.str) -> django.http.response.HttpResponse"
 -   case: login_required_fancy_async
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import login_required
         from django.core.handlers.asgi import ASGIRequest
         from django.http import HttpResponse
@@ -32,6 +36,7 @@
         reveal_type(view_func)  # N: Revealed type is "def (request: django.core.handlers.asgi.ASGIRequest, arg: builtins.str) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 -   case: login_required_weird
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import login_required
         from django.http import HttpRequest, HttpResponse
         # This is non-conventional usage, but covered in Django tests, so we allow it.
@@ -46,6 +51,7 @@
         def view_func2(request: Any) -> str: ...
 -   case: user_passes_test
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import user_passes_test
         from django.http import HttpRequest, HttpResponse
         @user_passes_test(lambda u: u.get_username().startswith('super'))
@@ -53,6 +59,7 @@
         reveal_type(view_func)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 -   case: user_passes_test_async
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import user_passes_test
         from django.http import HttpRequest, HttpResponse
         @user_passes_test(lambda u: u.get_username().startswith('super'))
@@ -66,6 +73,7 @@
         def view_func(request: HttpRequest) -> HttpResponse: ...
 -   case: permission_required
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import permission_required
         from django.http import HttpRequest, HttpResponse
         @permission_required('polls.can_vote')
@@ -73,6 +81,7 @@
         reveal_type(view_func)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 -   case: permission_required_async
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.decorators import permission_required
         from django.http import HttpRequest, HttpResponse
         @permission_required('polls.can_vote')

--- a/tests/typecheck/contrib/contenttypes/test_models.yml
+++ b/tests/typecheck/contrib/contenttypes/test_models.yml
@@ -1,5 +1,6 @@
 - case: test_contenttypes_models
   main: |
+    from typing_extensions import reveal_type
     from django.contrib.contenttypes.models import ContentType
 
     c = ContentType.objects.create(app_label='abc', model='abc')

--- a/tests/typecheck/contrib/gis/test_fields.yml
+++ b/tests/typecheck/contrib/gis/test_fields.yml
@@ -1,5 +1,6 @@
 -   case: fields_getter_and_setter
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.gis.geos import Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection
         from myapp.models import MyModel
         model = MyModel()

--- a/tests/typecheck/contrib/staticfiles/test_finders.yml
+++ b/tests/typecheck/contrib/staticfiles/test_finders.yml
@@ -1,5 +1,6 @@
 -   case: test_find_one
     main: |
+      from typing_extensions import reveal_type
       from django.contrib.staticfiles import finders
 
       reveal_type(finders.find("filepath"))  # N: Revealed type is "builtins.str | None"
@@ -13,6 +14,7 @@
 
 -   case: test_find_all
     main: |
+      from typing_extensions import reveal_type
       from django.contrib.staticfiles import finders
 
       reveal_type(finders.find("filepath", find_all=True))  # N: Revealed type is "builtins.list[builtins.str]"
@@ -26,6 +28,7 @@
 
 -   case: test_file_system_finder  # test methods *only* on FileSystemFinder
     main: |
+      from typing_extensions import reveal_type
       from django.contrib.staticfiles.finders import FileSystemFinder
 
       finder = FileSystemFinder()
@@ -33,6 +36,7 @@
 
 -   case: test_app_directories_finder  # test methods *only* on AppDirectoriesFinder
     main: |
+      from typing_extensions import reveal_type
       from django.contrib.staticfiles.finders import AppDirectoriesFinder
 
       finder = AppDirectoriesFinder()

--- a/tests/typecheck/core/test_checks.yml
+++ b/tests/typecheck/core/test_checks.yml
@@ -2,6 +2,7 @@
   main: |
     from collections.abc import Sequence
     from typing import Any
+    from typing_extensions import reveal_type
 
     from django.apps.config import AppConfig
     from django.core.checks import register, Warning, CheckMessage

--- a/tests/typecheck/db/models/test_query.yml
+++ b/tests/typecheck/db/models/test_query.yml
@@ -56,6 +56,7 @@
 
 -   case: QuerySet_type_vars
     main: |
+        from typing_extensions import reveal_type
         from django.db.models.query import QuerySet
         from django.contrib.auth.models import User
         from django_stubs_ext import ValuesQuerySet

--- a/tests/typecheck/db/test_connection.yml
+++ b/tests/typecheck/db/test_connection.yml
@@ -1,5 +1,6 @@
 -   case: raw_default_connection
     main: |
+      from typing_extensions import reveal_type
       from django.db import connection
       with connection.cursor() as cursor:
         reveal_type(cursor)  # N: Revealed type is "django.db.backends.utils.CursorWrapper"
@@ -16,6 +17,7 @@
 
 -   case: raw_connections
     main: |
+      from typing_extensions import reveal_type
       from django.db import connections
       reveal_type(connections["test"])  # N: Revealed type is "django.db.backends.base.base.BaseDatabaseWrapper"
       for connection in connections.all():

--- a/tests/typecheck/db/test_transaction.yml
+++ b/tests/typecheck/db/test_transaction.yml
@@ -1,11 +1,13 @@
 -   case: atomic_bare
     main: |
+      from typing_extensions import reveal_type
       from django.db.transaction import atomic
       @atomic
       def func(x: int) -> list: ...
       reveal_type(func)  # N: Revealed type is "def (x: builtins.int) -> builtins.list[Any]"
 -   case: atomic_args
     main: |
+      from typing_extensions import reveal_type
       from django.db.transaction import atomic
       @atomic(using='bla', savepoint=False)
       def func(x: int) -> list: ...
@@ -13,6 +15,7 @@
 -   case: non_atomic_requests_bare
     main: |
       from typing import Any
+      from typing_extensions import reveal_type
       from django.db.transaction import non_atomic_requests
       from django.http import HttpRequest, HttpResponse
       @non_atomic_requests
@@ -21,6 +24,7 @@
 
 -   case: non_atomic_requests_args
     main: |
+      from typing_extensions import reveal_type
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.db.transaction import non_atomic_requests

--- a/tests/typecheck/fields/test_base.yml
+++ b/tests/typecheck/fields/test_base.yml
@@ -1,5 +1,6 @@
 -   case: test_model_fields_classes_present_as_primitives
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         user = User(small_int=1, name='user', slug='user', text='user')
         reveal_type(user.id)  # N: Revealed type is "builtins.int"
@@ -23,6 +24,7 @@
 
 -   case: test_model_field_classes_from_existing_locations
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Booking
         booking = Booking()
         reveal_type(booking.id)  # N: Revealed type is "builtins.int"
@@ -46,6 +48,7 @@
 -   case: test_add_id_field_if_no_primary_key_defined
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().id)  # N: Revealed type is "builtins.int"
     installed_apps:
@@ -61,6 +64,7 @@
 -   case: test_do_not_add_id_if_field_with_primary_key_True_defined
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().my_pk)  # N: Revealed type is "builtins.int"
         User().id  # E: "User" has no attribute "id"  [attr-defined]
@@ -76,6 +80,7 @@
 
 -   case: blank_and_null_char_field_allows_none
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         MyModel(nulltext="")
         MyModel(nulltext=None)
@@ -93,6 +98,7 @@
 
 -   case: blank_and_not_null_charfield_does_not_allow_none
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         MyModel(notnulltext=None)  # E: Incompatible type for "notnulltext" of "MyModel" (got "None", expected "str | int | Combinable")  [misc]
         MyModel(notnulltext="")
@@ -110,6 +116,7 @@
 
 -   case: if_field_called_on_class_return_field_itself
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser.name.field)  # N: Revealed type is "django.db.models.fields.CharField[builtins.str | builtins.int | django.db.models.expressions.Combinable, builtins.str]"
     installed_apps:
@@ -124,6 +131,7 @@
 
 -   case: fields_on_non_model_classes_resolve_to_field_type
     main: |
+        from typing_extensions import reveal_type
         from django.db import models
         class MyClass:
             myfield: models.IntegerField[int, int]
@@ -133,6 +141,7 @@
 
 -   case: fields_inside_mixins_used_in_model_subclasses_resolved_as_primitives
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, AuthMixin
         reveal_type(MyModel().username)  # N: Revealed type is "builtins.str"
     installed_apps:
@@ -152,6 +161,7 @@
 -   case: can_narrow_field_type
     main: |
         from typing import cast, NewType
+        from typing_extensions import reveal_type
         from django.db import models
         Year = NewType("Year", int)
         class Book(models.Model):
@@ -166,6 +176,7 @@
 
 -  case: test_binary_field_return_types
    main: |
+        from typing_extensions import reveal_type
         from django.db import models
         class EncodedMessage(models.Model):
             message = models.BinaryField()
@@ -175,6 +186,7 @@
 
 -  case: test_small_auto_field_class_presents_as_int
    main: |
+        from typing_extensions import reveal_type
         from django.db import models
         class MyModel(models.Model):
             small = models.SmallAutoField(primary_key=True)
@@ -187,6 +199,7 @@
         # Ref: https://github.com/typeddjango/django-stubs/issues/1261
         # Django modifies the model so it doesn't have 'modelname', but we don't follow
         # along. But the 'name=' argument to a field isn't a documented feature.
+        from typing_extensions import reveal_type
         from myapp.models import RenamedField
         instance = RenamedField()
         reveal_type(instance.modelname) # N: Revealed type is "builtins.int"

--- a/tests/typecheck/fields/test_custom_fields.yml
+++ b/tests/typecheck/fields/test_custom_fields.yml
@@ -1,5 +1,6 @@
 -   case: test_custom_model_fields_with_generic_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User, CustomFieldValue
         user = User()
         reveal_type(user.id)  # N: Revealed type is "builtins.int"

--- a/tests/typecheck/fields/test_generic_foreign_key.yml
+++ b/tests/typecheck/fields/test_generic_foreign_key.yml
@@ -1,5 +1,6 @@
 -   case: generic_foreign_key_could_point_to_any_model_and_is_always_optional
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Tag, User
         myuser = User()
         Tag(content_object=None)
@@ -21,6 +22,7 @@
                     content_object = fields.GenericForeignKey()
 -   case: generic_foreign_key_subclass_could_point_to_any_model_and_is_always_optional
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Tag, User
         myuser = User()
         Tag(content_object=None)

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -33,6 +33,7 @@
                     id = models.AutoField(primary_key=True)
 -   case: nullable_field_with_strict_optional_true
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().text)  # N: Revealed type is "builtins.str"
         reveal_type(MyModel().text_nullable)  # N: Revealed type is "builtins.str | None"
@@ -51,6 +52,7 @@
 
 -   case: nullable_array_field
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().lst)  # N: Revealed type is "builtins.list[builtins.str] | None"
     installed_apps:
@@ -67,6 +69,7 @@
 
 -   case: nullable_foreign_key
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Publisher, Book
         reveal_type(Book().publisher)  # N: Revealed type is "myapp.models.Publisher | None"
         Book().publisher = 11  # E: Incompatible types in assignment (expression has type "int", variable has type "Publisher | Combinable | None")  [assignment]
@@ -85,6 +88,7 @@
 
 -   case: nullable_self_foreign_key
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Inventory
         parent = Inventory()
         core = Inventory(parent_id=parent.id)

--- a/tests/typecheck/fields/test_postgres_fields.yml
+++ b/tests/typecheck/fields/test_postgres_fields.yml
@@ -1,5 +1,6 @@
 -   case: array_field_descriptor_access
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         user = User(array=[])
         reveal_type(user.array)  # N: Revealed type is "builtins.list[Any]"
@@ -17,6 +18,7 @@
 
 -   case: array_field_base_field_parsed_into_generic_typevar
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         user = User()
         reveal_type(user.members)  # N: Revealed type is "builtins.list[builtins.int]"

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1,5 +1,6 @@
 -   case: test_foreign_key_field_with_related_name
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book, Publisher
         book = Book()
         reveal_type(book.publisher)  # N: Revealed type is "myapp.models.Publisher"
@@ -20,6 +21,7 @@
 
 -   case: foreign_key_field_creates_attribute_with_underscore_id
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book
         book = Book()
         reveal_type(book.publisher_id)  # N: Revealed type is "builtins.int"
@@ -40,6 +42,7 @@
 
 -   case: foreign_key_field_custom_to_field
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book, Publisher
         from uuid import UUID
         book = Book()
@@ -64,6 +67,7 @@
 
 -   case: foreign_key_field_different_order_of_params
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book, Publisher
         book = Book()
         reveal_type(book.publisher)  # N: Revealed type is "myapp.models.Publisher"
@@ -88,6 +92,7 @@
 
 -   case: foreign_key_subclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import A
         reveal_type(A.objects.get().b)  # N: Revealed type is "myapp.models.B"
     installed_apps:
@@ -111,6 +116,7 @@
 
 -   case: to_parameter_as_string_with_application_name__model_imported
     main: |
+        from typing_extensions import reveal_type
         from myapp2.models import Book
         book = Book()
         reveal_type(book.publisher)  # N: Revealed type is "myapp.models.Publisher"
@@ -133,6 +139,7 @@
 
 -   case: one_to_one_field_no_related_name
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User, Profile
         reveal_type(User().profile)  # N: Revealed type is "myapp.models.Profile"
         reveal_type(Profile().user)  # N: Revealed type is "myapp.models.User"
@@ -157,6 +164,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
+                from typing_extensions import reveal_type
                 from django.db import models
                 class App(models.Model):
                     def method(self) -> None:
@@ -175,6 +183,7 @@
 
 -   case: test_circular_dependency_in_imports_with_string_based
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import View
         reveal_type(View().app.views)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.View]"
         View().app.unknown  # E: "App" has no attribute "unknown"  [attr-defined]
@@ -192,6 +201,7 @@
         -   path: myapp2/__init__.py
         -   path: myapp2/models.py
             content: |
+                from typing_extensions import reveal_type
                 from django.db import models
                 class App(models.Model):
                     def method(self) -> None:
@@ -199,6 +209,7 @@
 
 -   case: models_related_managers_work_with_direct_model_inheritance_and_with_inheritance_from_other_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import App
         reveal_type(App().views)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.View]"
         reveal_type(App().views2)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.View2]"
@@ -218,6 +229,7 @@
 
 -   case: models_imported_inside_init_file_foreign_key
     main: |
+        from typing_extensions import reveal_type
         from myapp2.models import View
         reveal_type(View().app.views)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp2.models.View]"
     installed_apps:
@@ -243,6 +255,7 @@
 
 -   case: models_imported_inside_init_file_one_to_one_field
     main: |
+        from typing_extensions import reveal_type
         from myapp2.models import Profile
         reveal_type(Profile().user)  # N: Revealed type is "myapp.models.user.User"
         reveal_type(Profile().user.profile)  # N: Revealed type is "myapp2.models.Profile"
@@ -270,6 +283,7 @@
 
 -   case: models_triple_circular_reference
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import App
         reveal_type(App().owner)  # N: Revealed type is "myapp.models.user.User"
         reveal_type(App().owner.profile)  # N: Revealed type is "myapp.models.profile.Profile"
@@ -300,6 +314,7 @@
 
 -   case: many_to_many_field_converts_to_queryset_of_model_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import App, Member
         reveal_type(Member().apps)  # N: Revealed type is "myapp.models.App_ManyRelatedManager[myapp.models.Member_apps]"
         reveal_type(Member().apps.get())  # N: Revealed type is "myapp.models.App"
@@ -333,6 +348,7 @@
 
 -   case: many_to_many_works_with_string_if_imported
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Member
         reveal_type(Member().apps)  # N: Revealed type is "myapp2.models.App_ManyRelatedManager[myapp.models.Member_apps]"
     installed_apps:
@@ -354,6 +370,7 @@
 
 -   case: foreign_key_with_self
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().parent)  # N: Revealed type is "myapp.models.User"
     installed_apps:
@@ -368,6 +385,7 @@
 
 -   case: many_to_many_with_self
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().friends)  # N: Revealed type is "myapp.models.User_ManyRelatedManager[myapp.models.User_friends]"
         reveal_type(User().friends.get())  # N: Revealed type is "myapp.models.User"
@@ -407,6 +425,7 @@
 
 -   case: if_no_related_name_is_passed_create_default_related_managers
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Publisher
         reveal_type(Publisher().book_set)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Book]"
     installed_apps:
@@ -424,6 +443,7 @@
 -   case: underscore_id_attribute_has_set_type_of_primary_key_if_explicit
     main: |
         import datetime
+        from typing_extensions import reveal_type
         from myapp.models import Book, Book2
 
         reveal_type(Book().publisher_id)  # N: Revealed type is "builtins.str"
@@ -458,6 +478,7 @@
 
 -   case: if_model_is_defined_as_name_of_the_class_look_for_it_in_the_same_app
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book
         reveal_type(Book().publisher)  # N: Revealed type is "myapp.models.publisher.Publisher"
     installed_apps:
@@ -504,6 +525,7 @@
 
 -   case: test_foreign_key_field_without_backwards_relation
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book, Publisher
         book = Book()
         reveal_type(book.publisher)  # N: Revealed type is "myapp.models.Publisher"
@@ -512,8 +534,8 @@
         reveal_type(publisher.books)
         reveal_type(publisher.books2)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Book]"
     out: |
-        main:6: error: "Publisher" has no attribute "books"; maybe "books2"?  [attr-defined]
-        main:6: note: Revealed type is "Any"
+        main:7: error: "Publisher" has no attribute "books"; maybe "books2"?  [attr-defined]
+        main:7: note: Revealed type is "Any"
     installed_apps:
         - myapp
     files:
@@ -531,6 +553,7 @@
 
 -   case: to_parameter_could_be_resolved_if_passed_from_settings
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book
         book = Book()
         reveal_type(book.publisher)  # N: Revealed type is "myapp.models.Publisher"
@@ -552,6 +575,7 @@
 
 -   case: foreign_key_with_custom_app_name
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyMain
         reveal_type(MyMain().user)  # N: Revealed type is "myapp2.models.MyUser"
     installed_apps:
@@ -580,6 +604,7 @@
 
 -   case: related_field_to_extracted_from_function
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Profile
         reveal_type(Profile().user)  # N: Revealed type is "myapp.models.User"
     installed_apps:
@@ -599,6 +624,7 @@
 
 -   case: related_manager_name_defined_by_pattern
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Publisher
         reveal_type(Publisher().books)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Book]"
         reveal_type(Publisher().articles)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Article]"
@@ -623,6 +649,7 @@
 
 -   case: test_related_fields_returned_as_descriptors_from_model_class
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Author, Blog, Publisher, Profile
         reveal_type(Author.blogs)  # N: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[myapp.models.Blog, myapp.models.Author_blogs]"
         reveal_type(Author.blogs.through)  # N: Revealed type is "type[myapp.models.Author_blogs]"
@@ -651,6 +678,7 @@
 
 -   case: test_foreign_key_from_superclass_inherits_correctly
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser, Book, Article, LibraryEntity
         reveal_type(Book().registered_by_user)  # N: Revealed type is "myapp.models.MyUser"
         reveal_type(Article().registered_by_user)  # N: Revealed type is "myapp.models.MyUser"
@@ -679,6 +707,7 @@
 
 -   case: test_foreign_key_from_superclass_inherits_correctly_when_also_inheriting_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser, Book, Article, LibraryEntity
         reveal_type(Book().registered_by_user)  # N: Revealed type is "myapp.models.MyUser"
         reveal_type(Article().registered_by_user)  # N: Revealed type is "myapp.models.MyUser"
@@ -751,6 +780,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
+                from typing_extensions import reveal_type
                 from django.db import models
                 from django.db.models.manager import Manager
                 class TransactionQuerySet(models.QuerySet):
@@ -771,13 +801,14 @@
                 class TransactionLog(models.Model):
                     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
     out: |
-        myapp/models:13: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.TransactionLog]"
-        myapp/models:15: note: Revealed type is "myapp.models.ManagerFromTransactionQuerySet[myapp.models.Transaction]"
-        myapp/models:16: note: Revealed type is "None"
+        myapp/models:14: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.TransactionLog]"
+        myapp/models:16: note: Revealed type is "myapp.models.ManagerFromTransactionQuerySet[myapp.models.Transaction]"
+        myapp/models:17: note: Revealed type is "None"
 
 
 -   case: resolve_primary_keys_for_foreign_keys_with_abstract_self_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().parent)  # N: Revealed type is "myapp.models.AbstractUser"
         reveal_type(User().parent_id)  # N: Revealed type is "builtins.int"
@@ -801,6 +832,7 @@
 
 -   case: nullable_foreign_key_with_init_overridden
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import A
         reveal_type(A.objects.get().b)  # N: Revealed type is "myapp.models.B | None"
     installed_apps:
@@ -827,6 +859,7 @@
 
 -   case: related_manager_is_a_subclass_of_default_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User, Order, Product
         reveal_type(User().orders)  # N: Revealed type is "myapp.models.Order_RelatedManager"
         reveal_type(User().orders.get())  # N: Revealed type is "myapp.models.Order"
@@ -867,6 +900,7 @@
 
 -   case: related_manager_shared_between_multiple_relations
     main: |
+        from typing_extensions import reveal_type
         from myapp.models.store import Store
         from myapp.models.user import User
         reveal_type(Store().purchases)  # N: Revealed type is "myapp.models.purchase.Purchase_RelatedManager"
@@ -926,6 +960,7 @@
 
 -   case: explicitly_declared_related_manager_is_not_overridden
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().purchases)  # N: Revealed type is "builtins.int"
         User().purchases.filter()  # E: "int" has no attribute "filter"  [attr-defined]
@@ -994,6 +1029,7 @@
 
 -   case: callable_reverse_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import SalesMan
         sales_man = SalesMan()
         reveal_type(sales_man.client) # N: Revealed type is "myapp.models.CustomUser_ManyRelatedManager[myapp.models.SalesMan_client]"
@@ -1087,6 +1123,7 @@
 
 -   case: test_explicit_reverse_many_to_one_descriptor
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Other
         reveal_type(Other.explicit_descriptor)  # N: Revealed type is "django.db.models.fields.related_descriptors.ReverseManyToOneDescriptor[myapp.models.MyModel]"
         reveal_type(Other().explicit_descriptor)  # N: Revealed type is "myapp.models.MyModel_RelatedManager"
@@ -1117,6 +1154,7 @@
 
 -   case: test_reverse_one_to_one_descriptor
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, Other
         reveal_type(MyModel.first.RelatedObjectDoesNotExist)
         reveal_type(Other.mymodel)
@@ -1136,14 +1174,14 @@
             other.has_explicit_name = Other()
             other.has_explicit_name = None
     out: |
-        main:2: note: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
-        main:3: note: Revealed type is "django.db.models.fields.related_descriptors.ReverseOneToOneDescriptor[myapp.models.Other, myapp.models.MyModel]"
-        main:4: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.MyModel, myapp.models.MyModel]"
-        main:5: note: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
+        main:3: note: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
+        main:4: note: Revealed type is "django.db.models.fields.related_descriptors.ReverseOneToOneDescriptor[myapp.models.Other, myapp.models.MyModel]"
+        main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.MyModel, myapp.models.MyModel]"
         main:6: note: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
-        main:9: note: Revealed type is "myapp.models.MyModel"
-        main:14: error: Incompatible types in assignment (expression has type "Other", variable has type "MyModel | None")  [assignment]
-        main:17: error: Incompatible types in assignment (expression has type "Other", variable has type "MyModel | None")  [assignment]
+        main:7: note: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
+        main:10: note: Revealed type is "myapp.models.MyModel"
+        main:15: error: Incompatible types in assignment (expression has type "Other", variable has type "MyModel | None")  [assignment]
+        main:18: error: Incompatible types in assignment (expression has type "Other", variable has type "MyModel | None")  [assignment]
     installed_apps:
         -   myapp
     files:
@@ -1162,6 +1200,7 @@
 
 -   case: test_many_to_many
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, Other
         reveal_type(MyModel.auto_through.through.objects.get())
         reveal_type(MyModel().auto_through.get())
@@ -1206,40 +1245,40 @@
         reveal_type(MyModel().custom_through.through)
         reveal_type(MyModel().custom_through.through.my_model_id)
     out: |
-        main:2: note: Revealed type is "myapp.models.MyModel_auto_through"
-        main:3: note: Revealed type is "myapp.models.Other"
-        main:4: note: Revealed type is "myapp.models.MyModel"
-        main:6: note: Revealed type is "myapp.models.CustomThrough"
-        main:7: note: Revealed type is "myapp.models.Other"
-        main:8: note: Revealed type is "builtins.int"
-        main:9: note: Revealed type is "myapp.models.MyModel"
-        main:12: note: Revealed type is "builtins.int"
+        main:3: note: Revealed type is "myapp.models.MyModel_auto_through"
+        main:4: note: Revealed type is "myapp.models.Other"
+        main:5: note: Revealed type is "myapp.models.MyModel"
+        main:7: note: Revealed type is "myapp.models.CustomThrough"
+        main:8: note: Revealed type is "myapp.models.Other"
+        main:9: note: Revealed type is "builtins.int"
+        main:10: note: Revealed type is "myapp.models.MyModel"
         main:13: note: Revealed type is "builtins.int"
-        main:14: note: Revealed type is "myapp.models.MyModel"
-        main:15: note: Revealed type is "builtins.int"
-        main:16: note: Revealed type is "myapp.models.Other"
-        main:17: note: Revealed type is "builtins.int"
-        main:19: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
-        main:20: note: Revealed type is "django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor[django.db.models.fields.related.ForeignKey[myapp.models.MyModel | django.db.models.expressions.Combinable, myapp.models.MyModel]]"
-        main:21: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
-        main:23: note: Revealed type is "type[myapp.models.MyModel_other_again]"
-        main:24: note: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[myapp.models.MyModel, myapp.models.MyModel_auto_through]"
-        main:25: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
-        main:26: note: Revealed type is "myapp.models.MyModel_auto_through"
-        main:28: note: Revealed type is "builtins.str"
+        main:14: note: Revealed type is "builtins.int"
+        main:15: note: Revealed type is "myapp.models.MyModel"
+        main:16: note: Revealed type is "builtins.int"
+        main:17: note: Revealed type is "myapp.models.Other"
+        main:18: note: Revealed type is "builtins.int"
+        main:20: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
+        main:21: note: Revealed type is "django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor[django.db.models.fields.related.ForeignKey[myapp.models.MyModel | django.db.models.expressions.Combinable, myapp.models.MyModel]]"
+        main:22: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
+        main:24: note: Revealed type is "type[myapp.models.MyModel_other_again]"
+        main:25: note: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[myapp.models.MyModel, myapp.models.MyModel_auto_through]"
+        main:26: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
+        main:27: note: Revealed type is "myapp.models.MyModel_auto_through"
         main:29: note: Revealed type is "builtins.str"
-        main:30: note: Revealed type is "def (*objs: myapp.models.MyModel | builtins.int, through_defaults: typing.Mapping[builtins.str, Any] | None =)"
-        main:32: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
+        main:30: note: Revealed type is "builtins.str"
+        main:31: note: Revealed type is "def (*objs: myapp.models.MyModel | builtins.int, through_defaults: typing.Mapping[builtins.str, Any] | None =)"
         main:33: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
-        main:35: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.MyModel_auto_through]"
-        main:36: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
-        main:37: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str | None, builtins.int]]"
-        main:38: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.MyModel_other_again]"
-        main:39: note: Revealed type is "type[myapp.models.MyModel_other_again]"
-        main:40: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str | None, builtins.int]]"
-        main:41: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.CustomThrough]"
-        main:42: note: Revealed type is "type[myapp.models.CustomThrough]"
-        main:43: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str, builtins.int]]"
+        main:34: note: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_auto_through]"
+        main:36: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.MyModel_auto_through]"
+        main:37: note: Revealed type is "type[myapp.models.MyModel_auto_through]"
+        main:38: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str | None, builtins.int]]"
+        main:39: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.MyModel_other_again]"
+        main:40: note: Revealed type is "type[myapp.models.MyModel_other_again]"
+        main:41: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str | None, builtins.int]]"
+        main:42: note: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.CustomThrough]"
+        main:43: note: Revealed type is "type[myapp.models.CustomThrough]"
+        main:44: note: Revealed type is "django.db.models.fields._FieldDescriptor[django.db.models.fields.AutoField[django.db.models.expressions.Combinable | builtins.int | builtins.str, builtins.int]]"
     installed_apps:
         -   myapp
     files:
@@ -1277,6 +1316,7 @@
 
 -   case: test_many_to_many_with_lazy_references
     main: |
+        from typing_extensions import reveal_type
         from first.models import First
         reveal_type(First().thirds.get())
         reveal_type(First.thirds.through.objects.get())
@@ -1287,12 +1327,12 @@
         reveal_type(Third().fourths.get())
         reveal_type(Third.fourths.through.objects.get())
     out: |
-        main:2: note: Revealed type is "third.models.Third"
-        main:3: note: Revealed type is "second.models.Second"
-        main:4: note: Revealed type is "first.models.First"
-        main:5: note: Revealed type is "third.models.Third"
-        main:8: note: Revealed type is "third.models.Fourth"
-        main:9: note: Revealed type is "third.models.Third_fourths"
+        main:3: note: Revealed type is "third.models.Third"
+        main:4: note: Revealed type is "second.models.Second"
+        main:5: note: Revealed type is "first.models.First"
+        main:6: note: Revealed type is "third.models.Third"
+        main:9: note: Revealed type is "third.models.Fourth"
+        main:10: note: Revealed type is "third.models.Third_fourths"
     installed_apps:
         -   first
         -   second
@@ -1326,12 +1366,13 @@
 
 -   case: test_many_to_many_lazy_references_with_implicit_app_label
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Child
         reveal_type(Child.parents)
         reveal_type(Child().parents)
     out: |
-        main:2: note: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[Any, Any]"
-        main:3: note: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[Any, Any]"
+        main:3: note: Revealed type is "django.db.models.fields.related_descriptors.ManyToManyDescriptor[Any, Any]"
+        main:4: note: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[Any, Any]"
         myapp/models/child:5: error: Need type annotation for "parents"  [var-annotated]
         myapp/models/child:6: error: Need type annotation for "other_parents"  [var-annotated]
     installed_apps:
@@ -1359,6 +1400,7 @@
 
 -   case: test_relations_with_bad_arguments
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         def f(arg: type[MyModel]) -> MyModel:
             instance = arg(field=1, unknown=2)
@@ -1381,6 +1423,7 @@
 
 -   case: test_reverse_of_inherited_many_to_many_fields
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Other
         other = Other()
         reveal_type(other.abstract_of_concrete_parent)  # N: Revealed type is "myapp.models.ConcreteParent_ManyRelatedManager[myapp.models.ConcreteParent_m2m_1]"
@@ -1422,6 +1465,7 @@
 
 -   case: test_m2m_related_managers_supports_renamed_imports
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         from other.models import Other
         reveal_type(MyModel.m2m_1.through.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel_m2m_1]"
@@ -1455,6 +1499,7 @@
 
 -   case: test_m2m_from_abstract_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import First, Second
         reveal_type(First().others)  # N: Revealed type is "myapp.models.Other_ManyRelatedManager[myapp.models.First_others]"
         reveal_type(First().others.get())  # N: Revealed type is "myapp.models.Other"
@@ -1491,6 +1536,7 @@
 
 -   case: test_m2m_self_on_abstract_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import First, Second
         reveal_type(First().others)  # N: Revealed type is "myapp.models.First_ManyRelatedManager[myapp.models.First_others]"
         reveal_type(First().others.get())  # N: Revealed type is "myapp.models.First"
@@ -1550,6 +1596,7 @@
 
 -   case: test_reverse_m2m_relation_checks_other_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Author
         # With builtin manager/queryset
         Author().book_set.filter(featured=True)
@@ -1601,6 +1648,7 @@
 
 -   case: test_many_to_many_field_null
     main: |
+        from typing_extensions import reveal_type
         from django.db import models
         class Person(models.Model):
             friends = models.ManyToManyField("self", null=True, blank=True)

--- a/tests/typecheck/http/test_response.yml
+++ b/tests/typecheck/http/test_response.yml
@@ -1,4 +1,5 @@
 - case: response_object_has_text_of_type_str
   main: |
+      from typing_extensions import reveal_type
       from django.http.response import HttpResponse
       reveal_type(HttpResponse().text)  # N: Revealed type is "builtins.str"

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -1,6 +1,6 @@
 -   case: annotate_using_with_annotations
     main: |
-        from typing_extensions import Annotated
+        from typing_extensions import Annotated, reveal_type
         from myapp.models import User
         from django_stubs_ext import WithAnnotations, Annotations
         from django.db.models.expressions import Value
@@ -46,7 +46,7 @@
 -   case: annotate_using_with_annotations_typeddict
     main: |
         from typing import Any
-        from typing_extensions import Annotated, TypedDict
+        from typing_extensions import Annotated, TypedDict, reveal_type
         from myapp.models import User
         from django_stubs_ext import WithAnnotations, Annotations
         from django.db.models.expressions import Value
@@ -128,6 +128,7 @@
 
 -   case: annotate_basic
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         from django.db.models.expressions import F
 
@@ -153,6 +154,7 @@
 
 -   case: annotate_no_field_name
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         from django.db.models import Count
 
@@ -202,6 +204,7 @@
 
 -   case: annotate_twice_works
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         from django.db.models.expressions import F
 
@@ -229,7 +232,7 @@
         from django_stubs_ext import WithAnnotations
         from django.db.models import QuerySet
         from django.db.models.expressions import F
-        from typing_extensions import TypedDict
+        from typing_extensions import TypedDict, reveal_type
 
         qs = User.objects.filter(id=1)
 
@@ -275,6 +278,7 @@
 
 -   case: annotate_values_or_values_list_before_or_after_annotate_broadens_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         from django.db.models.expressions import F
 
@@ -399,6 +403,7 @@
 
 - case: test_annotate_allows_any_lookups_in_filter
   main: |
+    from typing_extensions import reveal_type
     from django.db import models
     from myapp.models import Blog
 
@@ -409,9 +414,9 @@
     qs.filter(distance__lt__lt=10)
     qs.filter(distance__unknown_lookup=10)
   out: |
-    main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
     main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
     main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
+    main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})], myapp.models.Blog@AnnotatedWith[TypedDict({'distance': Any})]]"
   installed_apps:
     - myapp
   files:

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -1,5 +1,6 @@
 -   case: self_return_management
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, MyModelWithoutSelf
         reveal_type(MyModel.objects.example_simple())  # N: Revealed type is "myapp.models.MyQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.example_list())  # N: Revealed type is "builtins.list[myapp.models.MyQuerySet[myapp.models.MyModel]]"
@@ -38,6 +39,7 @@
                     objects = QuerySetWithoutSelf.as_manager()
 -   case: declares_manager_type_like_django
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromMyQuerySet[myapp.models.MyModel]"
     installed_apps:
@@ -56,6 +58,7 @@
 
 -   case: includes_django_methods_returning_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects.none)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel]"
@@ -79,6 +82,7 @@
 
 -   case: model_gets_generated_manager_as_default_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "builtins.str"
@@ -100,6 +104,7 @@
 
 -   case: resolves_name_collision_with_other_module_level_object
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, ManagerFromModelQuerySet
         reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "builtins.int"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
@@ -122,6 +127,7 @@
 
 -   case: includes_custom_queryset_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
         reveal_type(MyModel.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
@@ -147,6 +153,7 @@
 
 -   case: includes_custom_queryset_methods_on_unions
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel1, MyModel2
         kls: type[MyModel1 | MyModel2] = MyModel1
         reveal_type(kls.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet1 | myapp.models.ModelQuerySet2"
@@ -184,6 +191,7 @@
 
 -   case: handles_call_outside_of_model_class_definition
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, MyModelManager
         reveal_type(MyModelManager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[Any]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -205,6 +213,7 @@
 
 -   case: handles_name_collision_when_declared_outside_of_model_class_body
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, ManagerFromModelQuerySet
         reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[Any]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
@@ -226,6 +235,7 @@
 
 -   case: handles_type_var_in_subclasses_of_subclasses_of_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, MyOtherModel
         reveal_type(MyModel.objects.example_2())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.example())  # N: Revealed type is "myapp.models.MyModel"
@@ -291,6 +301,7 @@
 
 -   case: handles_type_vars
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, BaseQuerySet
         reveal_type(MyModel.objects.example())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.example_list())  # N: Revealed type is "builtins.list[myapp.models.MyModel]"
@@ -351,6 +362,7 @@
 
 -   case: reuses_generated_type_when_called_identically_for_multiple_managers
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects_1)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects_2)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -373,6 +385,7 @@
 
 -   case: generates_new_manager_class_when_name_colliding_with_explicit_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
         reveal_type(MyModel.objects.custom_method())  # N: Revealed type is "builtins.int"
@@ -396,6 +409,7 @@
 
 -   case: handles_type_collision_with_from_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, FromQuerySet
         reveal_type(FromQuerySet)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
         reveal_type(MyModel.from_queryset)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -418,6 +432,7 @@
 
 -   case: nested_queryset_class_definition
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromMyQuerySet[myapp.models.MyModel]"
     installed_apps:
@@ -434,6 +449,7 @@
 
 -   case: queryset_as_manager_foreignkey_cycle
     main: |
+        from typing_extensions import reveal_type
         from payments.models import Payout
         reveal_type(Payout.objects)  # N: Revealed type is "payments.models.ManagerFromPayoutQuerySet[payments.models.Payout]"
 

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -1,5 +1,6 @@
 -   case: queryset_basic_methods_return_type
     main: |
+        from typing_extensions import reveal_type
         from django.utils import timezone
         from myapp.models import Blog
 
@@ -53,6 +54,7 @@
 
 -   case: queryset_missing_method
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
         User.objects.not_existing_method()  # E: "Manager[User]" has no attribute "not_existing_method"  [attr-defined]
@@ -68,6 +70,7 @@
 
 -   case: queryset_method_of_union
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel1, MyModel2
         kls: type[MyModel1 | MyModel2] = MyModel1
         reveal_type(kls.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel1] | django.db.models.manager.Manager[myapp.models.MyModel2]"
@@ -87,6 +90,7 @@
 
 -   case: select_related_returns_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book
         reveal_type(Book.objects.select_related())
         reveal_type(Book.objects.filter(pk=1).select_related())
@@ -105,32 +109,32 @@
         Book.objects.select_related(True)
         Book.objects.all().select_related(True)
     out: |
-      main:2: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
       main:3: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
-      main:12: error: No overload variant of "select_related" of "Manager" matches argument types "str", "None"  [call-overload]
-      main:12: note: Possible overload variants:
-      main:12: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
-      main:12: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
-      main:13: error: No overload variant of "select_related" of "QuerySet" matches argument types "str", "None"  [call-overload]
+      main:4: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
+      main:13: error: No overload variant of "select_related" of "Manager" matches argument types "str", "None"  [call-overload]
       main:13: note: Possible overload variants:
       main:13: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
       main:13: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
-      main:14: error: No overload variant of "select_related" of "Manager" matches argument type "int"  [call-overload]
+      main:14: error: No overload variant of "select_related" of "QuerySet" matches argument types "str", "None"  [call-overload]
       main:14: note: Possible overload variants:
       main:14: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
       main:14: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
-      main:15: error: No overload variant of "select_related" of "QuerySet" matches argument type "int"  [call-overload]
+      main:15: error: No overload variant of "select_related" of "Manager" matches argument type "int"  [call-overload]
       main:15: note: Possible overload variants:
       main:15: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
       main:15: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
-      main:16: error: No overload variant of "select_related" of "Manager" matches argument type "bool"  [call-overload]
+      main:16: error: No overload variant of "select_related" of "QuerySet" matches argument type "int"  [call-overload]
       main:16: note: Possible overload variants:
       main:16: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
       main:16: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
-      main:17: error: No overload variant of "select_related" of "QuerySet" matches argument type "bool"  [call-overload]
+      main:17: error: No overload variant of "select_related" of "Manager" matches argument type "bool"  [call-overload]
       main:17: note: Possible overload variants:
       main:17: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
       main:17: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
+      main:18: error: No overload variant of "select_related" of "QuerySet" matches argument type "bool"  [call-overload]
+      main:18: note: Possible overload variants:
+      main:18: note:     def select_related(self, None, /) -> QuerySet[Book, Book]
+      main:18: note:     def select_related(self, *fields: str) -> QuerySet[Book, Book]
 
     installed_apps:
         - myapp
@@ -147,6 +151,7 @@
 
 -   case: prefetch_related_returns_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Book
         reveal_type(Book.objects.prefetch_related())
         reveal_type(Book.objects.filter(pk=1).prefetch_related())
@@ -165,32 +170,32 @@
         Book.objects.prefetch_related(True)
         Book.objects.all().prefetch_related(True)
     out: |
-      main:2: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
       main:3: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
-      main:12: error: No overload variant of "prefetch_related" of "Manager" matches argument types "str", "None"  [call-overload]
-      main:12: note: Possible overload variants:
-      main:12: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
-      main:12: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
-      main:13: error: No overload variant of "prefetch_related" of "QuerySet" matches argument types "str", "None"  [call-overload]
+      main:4: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, myapp.models.Book]"
+      main:13: error: No overload variant of "prefetch_related" of "Manager" matches argument types "str", "None"  [call-overload]
       main:13: note: Possible overload variants:
       main:13: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
       main:13: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
-      main:14: error: No overload variant of "prefetch_related" of "Manager" matches argument type "int"  [call-overload]
+      main:14: error: No overload variant of "prefetch_related" of "QuerySet" matches argument types "str", "None"  [call-overload]
       main:14: note: Possible overload variants:
       main:14: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
       main:14: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
-      main:15: error: No overload variant of "prefetch_related" of "QuerySet" matches argument type "int"  [call-overload]
+      main:15: error: No overload variant of "prefetch_related" of "Manager" matches argument type "int"  [call-overload]
       main:15: note: Possible overload variants:
       main:15: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
       main:15: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
-      main:16: error: No overload variant of "prefetch_related" of "Manager" matches argument type "bool"  [call-overload]
+      main:16: error: No overload variant of "prefetch_related" of "QuerySet" matches argument type "int"  [call-overload]
       main:16: note: Possible overload variants:
       main:16: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
       main:16: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
-      main:17: error: No overload variant of "prefetch_related" of "QuerySet" matches argument type "bool"  [call-overload]
+      main:17: error: No overload variant of "prefetch_related" of "Manager" matches argument type "bool"  [call-overload]
       main:17: note: Possible overload variants:
       main:17: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
       main:17: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
+      main:18: error: No overload variant of "prefetch_related" of "QuerySet" matches argument type "bool"  [call-overload]
+      main:18: note: Possible overload variants:
+      main:18: note:     def prefetch_related(self, None, /) -> QuerySet[Book, Book]
+      main:18: note:     def [_LookupT: str, _PrefetchedQuerySetT: QuerySet[Model, Model], _ToAttrT: str] prefetch_related(self, *lookups: str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> QuerySet[Book, Book]
 
     installed_apps:
         - myapp

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -1,5 +1,6 @@
 -   case: from_queryset_self_return_management
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, MyModelWithoutSelf
         reveal_type(MyModel.objects.example_simple())  # N: Revealed type is "myapp.models.MyQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.example_list())  # N: Revealed type is "builtins.list[myapp.models.MyQuerySet[myapp.models.MyModel]]"
@@ -47,6 +48,7 @@
 
 -   case: from_queryset_model_inheritance
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Base, Sub
         reveal_type(Base.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.Base]"
         reveal_type(Sub.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.Sub]"
@@ -72,6 +74,7 @@
 
 -   case: from_queryset_with_base_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -99,6 +102,7 @@
 
 -   case: from_queryset_queryset_imported_from_other_module
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -149,6 +153,7 @@
 
 -   case: from_queryset_custom_manager_subclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import NewManager
         reveal_type(NewManager().example())  # N: Revealed type is "myapp.models.MyModel"
     installed_apps:
@@ -185,6 +190,7 @@
                     objects = NewManager()
 -   case: handles_subclasses_of_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects.example())  # N: Revealed type is "myapp.models.MyModel"
     installed_apps:
@@ -221,6 +227,7 @@
 
 -   case: from_queryset_generated_manager_imported_from_other_module
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.querysets.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -271,6 +278,7 @@
 
 -   case: from_queryset_annotates_manager_variable_as_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import NewManager
         reveal_type(NewManager)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
     installed_apps:
@@ -288,6 +296,7 @@
 
 -   case: from_queryset_with_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -310,6 +319,7 @@
 
 -   case: from_queryset_with_manager_of_union
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel1, MyModel2
         kls: type[MyModel1 | MyModel2] = MyModel1
         reveal_type(kls.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel1] | myapp.models.ManagerFromModelQuerySet2[myapp.models.MyModel2]"
@@ -342,6 +352,7 @@
 
 -   case: from_queryset_returns_intersection_of_manager_and_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, NewManager
         reveal_type(NewManager())  # N: Revealed type is "myapp.models.ModelBaseManagerFromModelQuerySet[Never]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ModelBaseManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -368,6 +379,7 @@
 
 -   case: from_queryset_with_class_name_provided
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, NewManager, OtherModel, OtherManager
         reveal_type(NewManager())  # N: Revealed type is "myapp.models.NewManager[Never]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
@@ -402,6 +414,7 @@
 
 -   case: from_queryset_with_class_inheritance
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -426,6 +439,7 @@
 
 -   case: from_queryset_with_manager_in_another_directory_and_imports
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -455,6 +469,7 @@
 -   case: from_queryset_with_inherited_manager_and_typing_no_return
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -487,6 +502,7 @@
 
 -   case: from_queryset_with_decorated_queryset_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
@@ -515,6 +531,7 @@
 
 -   case: from_queryset_model_gets_generated_manager_as_default_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "builtins.str"
@@ -551,6 +568,7 @@
 
 -   case: from_queryset_can_resolve_explicit_any_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method(1))  # N: Revealed type is "Any"
@@ -580,6 +598,7 @@
 
 -   case: test_queryset_in_model_class_body
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
         reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
@@ -610,6 +629,7 @@
 
 -   case: test_queryset_in_model_class_body_subclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.BaseManagerFromBaseQuerySet"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.BaseModel"
@@ -638,6 +658,7 @@
 
 -   case: from_queryset_includes_methods_returning_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects.alias)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
         reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
@@ -717,6 +738,7 @@
 
 -   case: reuses_type_when_called_twice_identically
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, FirstManager, SecondManager
         reveal_type(FirstManager)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
         reveal_type(SecondManager)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
@@ -742,6 +764,7 @@
 
 -   case: handles_name_collision_with_generated_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, ManagerFromModelQuerySet
         reveal_type(ManagerFromModelQuerySet())  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[Never]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
@@ -763,6 +786,7 @@
 
 -   case: resolves_name_collision_with_other_module_level_object
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel, Generated, ManagerFromModelQuerySet
         reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "builtins.int"
         reveal_type(Generated())  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet2[Never]"
@@ -786,6 +810,7 @@
 
 -   case: accepts_explicit_none_as_class_name
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import PositionalNone, NoneAsKwarg
         reveal_type(PositionalNone)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
         reveal_type(NoneAsKwarg)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
@@ -806,6 +831,7 @@
 
 -   case: uses_fallback_class_name_when_argument_is_not_string_expression
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import StrCallable
         reveal_type(StrCallable)  # N: Revealed type is "def [_T <: django.db.models.base.Model] () -> myapp.models.ManagerFromModelQuerySet[_T`1]"
     installed_apps:
@@ -824,6 +850,7 @@
 
 -   case: queryset_inheritable_does_not_clobber_super_init
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import BaseManager
 
         reveal_type(BaseManager().ttl)  # N: Revealed type is "builtins.int"
@@ -855,6 +882,7 @@
 
 -   case: test_from_queryset_with_deferral
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Concrete
         reveal_type(Concrete.objects.qs_meth())  # N: Revealed type is "builtins.int"
         reveal_type(Concrete.objects.manager_meth())  # N: Revealed type is "builtins.str"
@@ -890,6 +918,7 @@
 
 -   case: test_from_queryset_with_concrete_subclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Concrete
         reveal_type(Concrete.objects)  # N: Revealed type is "myapp.models.ConcreteManager"
         reveal_type(Concrete.objects.get())  # N: Revealed type is "myapp.models.Concrete"
@@ -926,7 +955,7 @@
 -   case: test_queryset_arg_as_unsupported_expressions
     main: |
         from typing import Generic, TypeVar
-        from typing_extensions import TypeAlias
+        from typing_extensions import TypeAlias, reveal_type
         from django.db import models
         from django.db.models.manager import Manager
 
@@ -950,6 +979,7 @@
 
 -   case: test_reverse_manager_with_foreign_key
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import B
         reveal_type(B().a_set.filter(field="something"))  # N: Revealed type is "myapp.models.QS"
     installed_apps:

--- a/tests/typecheck/managers/querysets/test_iteration.yml
+++ b/tests/typecheck/managers/querysets/test_iteration.yml
@@ -1,5 +1,6 @@
 -   case: sync_for
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
 
         for user in User.objects.all():
@@ -17,6 +18,7 @@
 
 -   case: async_for
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
 
         async def main() -> None:

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -5,7 +5,7 @@
         from myapp.models import Article, Tag
         from django.db.models import Prefetch, F, QuerySet
         from django.db import models
-        from typing_extensions import Literal, TypedDict
+        from typing_extensions import Literal, TypedDict, reveal_type
         from django_stubs_ext import WithAnnotations
 
         ### Noop (to_attr not provided)
@@ -163,6 +163,7 @@
     main: |
         from django.db.models import Prefetch, F
         from django.contrib.auth.models import User, Group
+        from typing_extensions import reveal_type
 
         user = (
             User.objects
@@ -238,6 +239,7 @@
 
 -   case: raw_queryset_prefetch_related_signatures
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Person, Book
         from django.db.models import Prefetch
 

--- a/tests/typecheck/managers/querysets/test_querysetany.yml
+++ b/tests/typecheck/managers/querysets/test_querysetany.yml
@@ -1,6 +1,7 @@
 - case: queryset_isinstance_check
   main: |
     from typing import Any
+    from typing_extensions import reveal_type
     from django.db.models.query import QuerySet
     from django_stubs_ext import QuerySetAny
 

--- a/tests/typecheck/managers/querysets/test_union_type.yml
+++ b/tests/typecheck/managers/querysets/test_union_type.yml
@@ -1,5 +1,6 @@
 -   case: union_queryset_custom_method
     main: |
+        from typing_extensions import reveal_type
         from django.db.models import QuerySet
         from myapp.models import User, Order
 

--- a/tests/typecheck/managers/querysets/test_values.yml
+++ b/tests/typecheck/managers/querysets/test_values.yml
@@ -1,5 +1,6 @@
 -   case: queryset_values_method_returns_typeddict
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         values = Blog.objects.values('num_posts', 'text').get()
         reveal_type(values)  # N: Revealed type is "TypedDict({'num_posts': builtins.int, 'text': builtins.str})"
@@ -22,6 +23,7 @@
 
 -   case: queryset_values_all_values
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         all_values_dict = Blog.objects.values().get()
         reveal_type(all_values_dict)  # N: Revealed type is "TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})"
@@ -43,6 +45,7 @@
 
 -   case: queryset_foreign_key_object_always_a_primary_key
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         values1 = Blog.objects.values('publisher').get()
         reveal_type(values1)  # N: Revealed type is "TypedDict({'publisher': builtins.int})"
@@ -69,6 +72,7 @@
 
 -   case: values_with_related_model_fields
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Entry
         values = Entry.objects.values('blog__num_articles', 'blog__publisher__name').get()
         reveal_type(values)  # N: Revealed type is "TypedDict({'blog__num_articles': builtins.int, 'blog__publisher__name': builtins.str})"
@@ -92,6 +96,7 @@
 
 -   case: select_all_related_model_values_for_every_current_value
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Publisher
         related_model_values = Publisher.objects.values('id', 'blog__name').get()
         reveal_type(related_model_values)  # N: Revealed type is "TypedDict({'id': builtins.int, 'blog__name': builtins.str})"
@@ -110,6 +115,7 @@
 
 -   case: values_of_many_to_many_field
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Author, Book
         reveal_type(Book.objects.values('authors'))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'authors': builtins.int})]"
         reveal_type(Author.objects.values('books'))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Author, TypedDict({'books': builtins.int})]"
@@ -127,6 +133,7 @@
 
 -   case: queryset_values_blank_charfield
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         values = Blog.objects.values('text').get()
         reveal_type(values)  # N: Revealed type is "TypedDict({'text': builtins.str})"
@@ -145,6 +152,7 @@
 
 -   case: queryset_values_with_expressions
     main: |
+        from typing_extensions import reveal_type
         from django.db.models import F
         from django.db.models.functions import Lower
         from myapp.models import Blog
@@ -155,11 +163,11 @@
         reveal_type(Blog.objects.values("id", foo=F("id")))
         reveal_type(Blog.objects.values("id", lower_text=Lower("text")))
     out: |
-      main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
-      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
-      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'foo': Any})]"
-      main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'foo': Any})]"
-      main:9: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'lower_text': Any})]"
+      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int})]"
+      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'num_posts': builtins.int, 'text': builtins.str})]"
+      main:8: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'foo': Any})]"
+      main:9: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'foo': Any})]"
+      main:10: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, TypedDict({'id': builtins.int, 'lower_text': Any})]"
     installed_apps:
         - myapp
     files:
@@ -174,6 +182,7 @@
 
 -   case: queryset_values_m2m_fk_with_expressions
     main: |
+        from typing_extensions import reveal_type
         from django.db.models import F
         from django.db.models.functions import Lower
         from myapp.models import Book
@@ -181,8 +190,8 @@
         reveal_type(Book.objects.values(premium_price=F("premiumbookdetails__price")))
         reveal_type(Book.objects.values(team_name=F("authors__name")))
     out: |
-      main:5: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'premium_price': Any})]"
-      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'team_name': Any})]"
+      main:6: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'premium_price': Any})]"
+      main:7: note: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, TypedDict({'team_name': Any})]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -1,5 +1,6 @@
 -   case: values_list_simple_field_returns_queryset_of_tuples
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser.objects.values_list('name').get())  # N: Revealed type is "tuple[builtins.str]"
         reveal_type(MyUser.objects.values_list('id', 'name').get())  # N: Revealed type is "tuple[builtins.int, builtins.str]"
@@ -28,6 +29,7 @@
 
 -   case: values_list_field_repetition
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
 
         # Values tuples can have the same field repeated
@@ -49,6 +51,7 @@
 
 -   case: values_list_types_are_field_types
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Concrete
         ret = list(Concrete.objects.values_list('id', 'data'))
         reveal_type(ret)  # N: Revealed type is "builtins.list[tuple[builtins.int, builtins.dict[builtins.str, builtins.str]]]"
@@ -69,6 +72,7 @@
 
 -   case: values_list_supports_queryset_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         from django.db.models.functions import Length
         query = MyUser.objects.values_list('name')
@@ -92,6 +96,7 @@
 
 -   case: values_list_related_model_fields
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Post, Blog
         values_tuple = Post.objects.values_list('blog', 'blog__num_posts', 'blog__publisher', 'blog__publisher__name').get()
         reveal_type(values_tuple[0])  # N: Revealed type is "builtins.int"
@@ -119,6 +124,7 @@
 
 -   case: values_list_flat_true_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser, MyUser2
         reveal_type(MyUser.objects.values_list('name', flat=True).get())  # N: Revealed type is "builtins.str"
         reveal_type(MyUser.objects.values_list('name', 'age', flat=True).get())
@@ -127,8 +133,8 @@
         reveal_type(MyUser.objects.values_list(flat=True)[0])  # N: Revealed type is "builtins.int"
         reveal_type(MyUser2.objects.values_list(flat=True)[0])  # N: Revealed type is "builtins.str"
     out: |
-        main:3: error: 'flat' is not valid when 'values_list' is called with more than one field  [misc]
-        main:3: note: Revealed type is "Any"
+        main:4: error: 'flat' is not valid when 'values_list' is called with more than one field  [misc]
+        main:4: note: Revealed type is "Any"
     installed_apps:
         - myapp
     files:
@@ -144,6 +150,7 @@
 
 -   case: values_list_named_true
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         values_named_tuple = MyUser.objects.values_list('name', 'age', named=True).get()
         reveal_type(values_named_tuple)  # N: Revealed type is "tuple[builtins.str, builtins.int, fallback=main.Row]"
@@ -180,11 +187,12 @@
 
 -   case: values_list_flat_true_named_true_error
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser.objects.values_list('name', flat=True, named=True).get())
     out: |
-        main:2: error: 'flat' and 'named' can't be used together  [misc]
-        main:2: note: Revealed type is "Any"
+        main:3: error: 'flat' and 'named' can't be used together  [misc]
+        main:3: note: Revealed type is "Any"
     installed_apps:
         - myapp
     files:
@@ -197,19 +205,20 @@
 
 -   case: invalid_lookups
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         reveal_type(Blog.objects.values_list('unknown').get())
         reveal_type(Blog.objects.values_list('unknown', flat=True).get())
         reveal_type(Blog.objects.values_list('unknown', named=True).get())
         reveal_type(Blog.objects.values_list('publisher__unknown').get())
     out: |
-        main:2: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
-        main:2: note: Revealed type is "Any"
         main:3: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
         main:3: note: Revealed type is "Any"
         main:4: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
         main:4: note: Revealed type is "Any"
-        main:5: note: Revealed type is "tuple[Any]"
+        main:5: error: Cannot resolve keyword 'unknown' into field. Choices are: id, publisher, publisher_id  [misc]
+        main:5: note: Revealed type is "Any"
+        main:6: note: Revealed type is "tuple[Any]"
     installed_apps:
         - myapp
     files:
@@ -224,6 +233,7 @@
 
 -   case: named_true_with_related_model_fields
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Entry, Blog
         values = Entry.objects.values_list('blog__num_articles', 'blog__publisher__name', named=True).get()
         reveal_type(values.blog__num_articles)  # N: Revealed type is "builtins.int"
@@ -254,6 +264,7 @@
 
 -   case: values_list_flat_true_with_ids
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog, Publisher
         reveal_type(Blog.objects.values_list('id', flat=True))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, builtins.int]"
         reveal_type(Blog.objects.values_list('publisher', flat=True))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog, builtins.int]"
@@ -274,6 +285,7 @@
 
 -   case: subclass_of_queryset_has_proper_typings_on_methods
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import TransactionQuerySet
         reveal_type(TransactionQuerySet())  # N: Revealed type is "myapp.models.TransactionQuerySet"
         reveal_type(TransactionQuerySet().values())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Transaction, TypedDict({'id': builtins.int, 'total': builtins.int})]"
@@ -292,6 +304,7 @@
 
 -   case: values_list_of_many_to_many_field
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Author, Book
         reveal_type(Book.objects.values_list('authors'))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Book, tuple[builtins.int]]"
         reveal_type(Author.objects.values_list('books'))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Author, tuple[builtins.int]]"
@@ -308,6 +321,7 @@
                     authors = models.ManyToManyField(Author, related_name='books')
 -   case: queryset_values_list_blank_charfield
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog
         values = Blog.objects.values_list('text').get()
         reveal_type(values)  # N: Revealed type is "tuple[builtins.str]"
@@ -324,6 +338,7 @@
                     text = models.CharField(max_length=100, blank=True)
 -   case: handles_field_with_same_name_on_other_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import A
         reveal_type(A.objects.values_list("name", "b__name").get())  # N: Revealed type is "tuple[builtins.int, builtins.str]"
     installed_apps:

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -1,5 +1,6 @@
 -   case: test_every_model_has_objects_queryset_available
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
         reveal_type(User.objects.get())  # N: Revealed type is "myapp.models.User"
@@ -15,6 +16,7 @@
 
 -   case: every_model_has_its_own_objects_queryset
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Parent, Child
         reveal_type(Parent.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.Parent]"
         reveal_type(Child.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.Child]"
@@ -32,6 +34,7 @@
 
 -   case: test_model_objects_attribute_present_in_case_of_model_cls_passed_as_generic_parameter
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Base, MyModel
         base_instance = Base(MyModel)
         reveal_type(base_instance.model_cls._default_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
@@ -42,6 +45,7 @@
         -   path: myapp/models.py
             content: |
                 from typing import Generic, TypeVar
+                from typing_extensions import reveal_type
                 from django.db import models
 
                 _T = TypeVar('_T', bound=models.Model)
@@ -57,6 +61,7 @@
 
 -   case: test_base_manager_called_on_model_cls_as_generic_parameter
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Base, MyModel
         base_instance = Base(MyModel)
         reveal_type(base_instance.model_cls._base_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
@@ -67,6 +72,7 @@
         -   path: myapp/models.py
             content: |
                 from typing import Generic, TypeVar
+                from typing_extensions import reveal_type
                 from django.db import models
 
                 _T = TypeVar('_T', bound=models.Model)
@@ -82,6 +88,7 @@
 
 -   case: if_custom_manager_defined_it_is_set_to_default_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.CustomManager[myapp.models.MyModel]"
     installed_apps:
@@ -100,6 +107,7 @@
 
 -   case: if_default_manager_name_is_passed_set_default_manager_to_it
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.Manager2[myapp.models.MyModel]"
     installed_apps:
@@ -125,6 +133,7 @@
 
 -   case: test_leave_as_is_if_objects_is_set_and_fill_typevars_with_outer_class
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser.objects)  # N: Revealed type is "myapp.models.UserManager"
         reveal_type(MyUser.objects.get())  # N: Revealed type is "myapp.models.MyUser"
@@ -146,6 +155,7 @@
 
 -   case: model_imported_from_different_file
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Inventory, Band
         reveal_type(Inventory.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.main.Inventory]"
         reveal_type(Band.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.Band]"
@@ -167,6 +177,7 @@
 
 -   case: managers_that_defined_on_other_models_do_not_influence
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import AbstractPerson, Book
         reveal_type(AbstractPerson.abstract_persons)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.AbstractPerson]"
         reveal_type(Book.published_objects)  # N: Revealed type is "myapp.models.PublishedBookManager"
@@ -194,16 +205,17 @@
 
 -   case: managers_inherited_from_abstract_classes_multiple_inheritance
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import AbstractBase1, AbstractBase2, Child
         reveal_type(Child.manager1)
         reveal_type(Child.restricted)
         reveal_type(AbstractBase1.manager1)
         reveal_type(AbstractBase2.restricted)
     out: |
-        main:2: note: Revealed type is "myapp.models.CustomManager1"
-        main:3: note: Revealed type is "myapp.models.CustomManager2"
-        main:4: note: Revealed type is "myapp.models.CustomManager1"
-        main:5: note: Revealed type is "myapp.models.CustomManager2"
+        main:3: note: Revealed type is "myapp.models.CustomManager1"
+        main:4: note: Revealed type is "myapp.models.CustomManager2"
+        main:5: note: Revealed type is "myapp.models.CustomManager1"
+        main:6: note: Revealed type is "myapp.models.CustomManager2"
     installed_apps:
         - myapp
     files:
@@ -231,6 +243,7 @@
 
 -   case: managers_inherited_from_abstract_classes_multiple_inheritance_with_generic
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import AbstractBase1, AbstractBase2, Child
         reveal_type(Child.manager1)  # N: Revealed type is "myapp.models.CustomManager1[myapp.models.Child]"
         reveal_type(Child.manager1.get())  # N: Revealed type is "myapp.models.Child"
@@ -269,6 +282,7 @@
 
 -   case: model_has_a_manager_of_the_same_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import UnrelatedModel, MyModel
         reveal_type(UnrelatedModel.objects) # N: Revealed type is "django.db.models.manager.Manager[myapp.models.UnrelatedModel]"
         reveal_type(UnrelatedModel.objects.first()) # N: Revealed type is "myapp.models.UnrelatedModel | None"
@@ -290,6 +304,7 @@
 
 -   case: manager_without_annotation_of_the_model_gets_it_from_outer_one
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import UnrelatedModel2, MyModel2
         reveal_type(UnrelatedModel2.objects) # N: Revealed type is "django.db.models.manager.Manager[myapp.models.UnrelatedModel2]"
         reveal_type(UnrelatedModel2.objects.first()) # N: Revealed type is "myapp.models.UnrelatedModel2 | None"
@@ -311,6 +326,7 @@
 
 -   case: inherited_manager_has_the_proper_type_of_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import ParentOfMyModel3, MyModel3
         reveal_type(ParentOfMyModel3.objects) # N: Revealed type is "django.db.models.manager.Manager[myapp.models.ParentOfMyModel3]"
         reveal_type(ParentOfMyModel3.objects.first()) # N: Revealed type is "myapp.models.ParentOfMyModel3 | None"
@@ -332,6 +348,7 @@
 
 -   case: inheritance_with_explicit_type_on_child_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import ParentOfMyModel4, MyModel4
         reveal_type(ParentOfMyModel4.objects) # N: Revealed type is "django.db.models.manager.Manager[myapp.models.ParentOfMyModel4]"
         reveal_type(ParentOfMyModel4.objects.first()) # N: Revealed type is "myapp.models.ParentOfMyModel4 | None"
@@ -355,6 +372,7 @@
 # TODO: make it work someday
 #-   case: inheritance_of_two_models_with_custom_objects_manager
 #    main: |
+#        from typing_extensions import reveal_type
 #        from myapp.models import MyBaseUser, MyUser
 #        reveal_type(MyBaseUser.objects)  # N: Revealed type is "myapp.models.MyBaseManager[myapp.models.MyBaseUser]"
 #        reveal_type(MyBaseUser.objects.get())  # N: Revealed type is "myapp.models.MyBaseUser"
@@ -381,6 +399,7 @@
 
 -   case: custom_manager_returns_proper_model_types
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User.objects)  # N: Revealed type is "myapp.models.MyManager[myapp.models.User]"
         reveal_type(User.objects.select_related())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User, myapp.models.User]"
@@ -414,6 +433,7 @@
 
 -   case: custom_manager_annotate_method_before_type_declaration
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import ModelA, ModelB, ManagerA
         reveal_type(ModelA.objects)  # N: Revealed type is "myapp.models.ManagerA[myapp.models.ModelA]"
         reveal_type(ModelA.objects.do_something)  # N: Revealed type is "def (other_obj: myapp.models.ModelB) -> builtins.str"
@@ -480,6 +500,7 @@
 
 -   case: regression_manager_scope_foreign
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.on_site)  # N: Revealed type is "django.contrib.sites.managers.CurrentSiteManager[myapp.models.MyModel]"
     installed_apps:
@@ -506,6 +527,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
+                from typing_extensions import reveal_type
                 from django.db import models
 
                 def LocalManager() -> models.Manager:
@@ -575,41 +597,42 @@
                     reveal_type(user.booking_set.all().custom)
                     reveal_type(user.booking_set.all().first())
     out: |
-        myapp/models:13: error: Couldn't resolve related manager 'booking_set' for relation 'myapp.models.Booking.renter'.  [django-manager-missing]
-        myapp/models:13: error: Couldn't resolve related manager 'bookingowner_set' for relation 'myapp.models.Booking.owner'.  [django-manager-missing]
-        myapp/models:20: error: Could not resolve manager type for "myapp.models.Booking.objects"  [django-manager-missing]
-        myapp/models:23: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.objects"  [django-manager-missing]
-        myapp/models:24: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.second_objects"  [django-manager-missing]
-        myapp/models:27: error: Could not resolve manager type for "myapp.models.AbstractUnresolvable.objects"  [django-manager-missing]
-        myapp/models:36: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
+        myapp/models:14: error: Couldn't resolve related manager 'booking_set' for relation 'myapp.models.Booking.renter'.  [django-manager-missing]
+        myapp/models:14: error: Couldn't resolve related manager 'bookingowner_set' for relation 'myapp.models.Booking.owner'.  [django-manager-missing]
+        myapp/models:21: error: Could not resolve manager type for "myapp.models.Booking.objects"  [django-manager-missing]
+        myapp/models:24: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.objects"  [django-manager-missing]
+        myapp/models:25: error: Could not resolve manager type for "myapp.models.TwoUnresolvable.second_objects"  [django-manager-missing]
+        myapp/models:28: error: Could not resolve manager type for "myapp.models.AbstractUnresolvable.objects"  [django-manager-missing]
         myapp/models:37: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
-        myapp/models:39: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Booking]"
-        myapp/models:40: note: Revealed type is "django.db.models.manager.Manager[myapp.models.Booking]"
-        myapp/models:42: note: Revealed type is "myapp.models.UnknownManager[myapp.models.TwoUnresolvable]"
+        myapp/models:38: note: Revealed type is "django.db.models.manager.Manager[myapp.models.User]"
+        myapp/models:40: note: Revealed type is "myapp.models.UnknownManager[myapp.models.Booking]"
+        myapp/models:41: note: Revealed type is "django.db.models.manager.Manager[myapp.models.Booking]"
         myapp/models:43: note: Revealed type is "myapp.models.UnknownManager[myapp.models.TwoUnresolvable]"
-        myapp/models:44: note: Revealed type is "django.db.models.manager.Manager[myapp.models.TwoUnresolvable]"
-        myapp/models:46: note: Revealed type is "myapp.models.UnknownManager[myapp.models.InvisibleUnresolvable]"
-        myapp/models:47: note: Revealed type is "django.db.models.manager.Manager[myapp.models.InvisibleUnresolvable]"
-        myapp/models:49: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Booking]"
+        myapp/models:44: note: Revealed type is "myapp.models.UnknownManager[myapp.models.TwoUnresolvable]"
+        myapp/models:45: note: Revealed type is "django.db.models.manager.Manager[myapp.models.TwoUnresolvable]"
+        myapp/models:47: note: Revealed type is "myapp.models.UnknownManager[myapp.models.InvisibleUnresolvable]"
+        myapp/models:48: note: Revealed type is "django.db.models.manager.Manager[myapp.models.InvisibleUnresolvable]"
         myapp/models:50: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Booking]"
-        myapp/models:53: note: Revealed type is "def () -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
-        myapp/models:54: note: Revealed type is "Any"
-        myapp/models:55: note: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
-        myapp/models:56: note: Revealed type is "Any"
-        myapp/models:57: note: Revealed type is "myapp.models.Booking | None"
-        myapp/models:58: note: Revealed type is "myapp.models.Booking"
-        myapp/models:59: note: Revealed type is "builtins.list[myapp.models.Booking]"
+        myapp/models:51: note: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Booking]"
+        myapp/models:54: note: Revealed type is "def () -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:55: note: Revealed type is "Any"
+        myapp/models:56: note: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.UnknownQuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:57: note: Revealed type is "Any"
+        myapp/models:58: note: Revealed type is "myapp.models.Booking | None"
+        myapp/models:59: note: Revealed type is "myapp.models.Booking"
         myapp/models:60: note: Revealed type is "builtins.list[myapp.models.Booking]"
-        myapp/models:64: note: Revealed type is "def () -> django.db.models.query.QuerySet[myapp.models.Booking, myapp.models.Booking]"
-        myapp/models:65: error: "RelatedManager[Booking]" has no attribute "custom"  [attr-defined]
-        myapp/models:65: note: Revealed type is "Any"
-        myapp/models:66: note: Revealed type is "def (*args: Any, **kwargs: Any) -> django.db.models.query.QuerySet[myapp.models.Booking, myapp.models.Booking]"
-        myapp/models:67: error: "QuerySet[Booking, Booking]" has no attribute "custom"  [attr-defined]
-        myapp/models:67: note: Revealed type is "Any"
-        myapp/models:68: note: Revealed type is "myapp.models.Booking | None"
+        myapp/models:61: note: Revealed type is "builtins.list[myapp.models.Booking]"
+        myapp/models:65: note: Revealed type is "def () -> django.db.models.query.QuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:66: error: "RelatedManager[Booking]" has no attribute "custom"  [attr-defined]
+        myapp/models:66: note: Revealed type is "Any"
+        myapp/models:67: note: Revealed type is "def (*args: Any, **kwargs: Any) -> django.db.models.query.QuerySet[myapp.models.Booking, myapp.models.Booking]"
+        myapp/models:68: error: "QuerySet[Booking, Booking]" has no attribute "custom"  [attr-defined]
+        myapp/models:68: note: Revealed type is "Any"
+        myapp/models:69: note: Revealed type is "myapp.models.Booking | None"
 
 -   case: subclass_manager_without_type_parameters
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MySubModel
         reveal_type(MySubModel.objects) # N: Revealed type is "myapp.models.MySubManager[myapp.models.MySubModel]"
         reveal_type(MySubModel.objects.get()) # N: Revealed type is "myapp.models.MySubModel"
@@ -639,6 +662,7 @@
 
 -   case: subclass_manager_without_type_parameters_disallow_any_generics
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MySubModel
         reveal_type(MySubModel.objects)
         reveal_type(MySubModel.objects.get())
@@ -648,8 +672,8 @@
         [mypy-myapp.models]
         disallow_any_generics = true
     out: |
-        main:2: note: Revealed type is "myapp.models.MySubManager"
-        main:3: note: Revealed type is "Any"
+        main:3: note: Revealed type is "myapp.models.MySubManager"
+        main:4: note: Revealed type is "Any"
         myapp/models:9: error: Missing type parameters for generic type "MyManager"  [type-arg]
     files:
         -   path: myapp/__init__.py
@@ -674,14 +698,15 @@
 
 -   case: nested_manager_class_definition
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.objects)
         reveal_type(MyModel.objects.get())
     installed_apps:
         - myapp
     out: |
-        main:2: note: Revealed type is "myapp.models.MyModel.MyManager[myapp.models.MyModel]"
-        main:3: note: Revealed type is "myapp.models.MyModel"
+        main:3: note: Revealed type is "myapp.models.MyModel.MyManager[myapp.models.MyModel]"
+        main:4: note: Revealed type is "myapp.models.MyModel"
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
@@ -713,6 +738,7 @@
 
 -   case: test_does_not_populate_an_unexpected_type_argument
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel.populated_manager)  # N: Revealed type is "myapp.models.PopulatedManager"
         reveal_type(MyModel.populated_manager.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -765,6 +791,7 @@
 # Regression test for #2304
 -   case: test_objects_managers_is_kept_with_specific_import_graph
     main: |
+        from typing_extensions import reveal_type
         from zerver.models import RealmFilter
         reveal_type(RealmFilter.objects)  # N: Revealed type is "django.db.models.manager.Manager[zerver.models.linkifiers.RealmFilter]"
     installed_apps:

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -1,5 +1,6 @@
 - case: test_filter_on_abstract_user_pk
   main: |
+    from typing_extensions import reveal_type
     from django.contrib.auth.models import AbstractUser
     AbstractUser.objects.get(pk=1)
     AbstractUser.objects.get(pk__in=[1])
@@ -25,6 +26,7 @@
     -   path: myapp/__init__.py
     -   path: myapp/models.py
         content: |
+            from typing_extensions import reveal_type
             from django.db import models
 
             class BaseManager(models.Manager):
@@ -178,6 +180,7 @@
     -   path: myapp/models.py
         content: |
             from typing import Protocol, TypeVar
+            from typing_extensions import reveal_type
             from django.db import models
             from django_stubs_ext.db.models import TypedModelMeta
 

--- a/tests/typecheck/models/test_contrib_models.yml
+++ b/tests/typecheck/models/test_contrib_models.yml
@@ -1,5 +1,6 @@
 -   case: contrib_auth_model_fields
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.models import User
         reveal_type(User().username)  # N: Revealed type is "builtins.str"
         reveal_type(User().password)  # N: Revealed type is "builtins.str"
@@ -36,6 +37,7 @@
 
 -   case: can_override_abstract_user_manager
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyBaseUser, MyUser
         reveal_type(MyBaseUser.objects)  # N: Revealed type is "myapp.models.MyBaseUserManager"
         reveal_type(MyBaseUser.objects.all())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.MyBaseUser, myapp.models.MyBaseUser]"
@@ -64,6 +66,7 @@
 
 -   case: can_combine_permissions_mixin_and_abstract_base_user
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.base_user import AbstractBaseUser
         from django.contrib.auth.models import PermissionsMixin
         from myapp.models import AuthUser
@@ -72,10 +75,10 @@
         reveal_type(PermissionsMixin._meta)
         reveal_type(AbstractBaseUser._meta)
     out: |
-        main:4: note: Revealed type is "django.db.models.options.Options[myapp.models.AuthUser]"
         main:5: note: Revealed type is "django.db.models.options.Options[myapp.models.AuthUser]"
-        main:6: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.models.PermissionsMixin]"
-        main:7: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.base_user.AbstractBaseUser]"
+        main:6: note: Revealed type is "django.db.models.options.Options[myapp.models.AuthUser]"
+        main:7: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.models.PermissionsMixin]"
+        main:8: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.base_user.AbstractBaseUser]"
     installed_apps:
         - django.contrib.auth
         - myapp
@@ -93,6 +96,7 @@
 
 -   case: test_relation_specified_by_auth_user_model
     main: |
+        from typing_extensions import reveal_type
         from other.models import Other
         reveal_type(Other().users.get())
         reveal_type(Other.users.through)
@@ -103,14 +107,14 @@
 
         reveal_type(Other().unq_user)
     out: |
-        main:2: note: Revealed type is "myapp.models.MyUser"
-        main:3: note: Revealed type is "type[other.models.Other_users]"
-        main:4: note: Revealed type is "myapp.models.MyUser"
+        main:3: note: Revealed type is "myapp.models.MyUser"
+        main:4: note: Revealed type is "type[other.models.Other_users]"
         main:5: note: Revealed type is "myapp.models.MyUser"
+        main:6: note: Revealed type is "myapp.models.MyUser"
 
-        main:7: note: Revealed type is "myapp.models.MyUser"
+        main:8: note: Revealed type is "myapp.models.MyUser"
 
-        main:9: note: Revealed type is "myapp.models.MyUser"
+        main:10: note: Revealed type is "myapp.models.MyUser"
     custom_settings: |
         INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth', 'myapp', 'other')
         AUTH_USER_MODEL='myapp.MyUser'
@@ -135,10 +139,11 @@
 
 -   case: test_relate_to_auth_user_model_when_auth_not_installed
     main: |
+        from typing_extensions import reveal_type
         from other.models import Other
         reveal_type(Other().user)
     out: |
-        main:2: note: Revealed type is "myapp.models.MyUser"
+        main:3: note: Revealed type is "myapp.models.MyUser"
     custom_settings: |
         INSTALLED_APPS = ('django.contrib.contenttypes', 'myapp', 'other')
         AUTH_USER_MODEL='myapp.MyUser'
@@ -161,6 +166,7 @@
 
 -   case: test_permissions_inherited_reverse_relations
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth.models import Group, Permission
         from django.contrib.contenttypes.models import ContentType
         reveal_type(Permission().user_set)  # N: Revealed type is "django.contrib.auth.models.User_ManyRelatedManager[django.contrib.auth.models.User_user_permissions]"

--- a/tests/typecheck/models/test_create.yml
+++ b/tests/typecheck/models/test_create.yml
@@ -17,6 +17,7 @@
 
 -   case: model_recognises_parent_attributes
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Child
         c = Child.objects.create(name='Maxim', lastname='Maxim2')
         reveal_type(c.id)  # N: Revealed type is "builtins.int"
@@ -115,6 +116,7 @@
 
 -   case: when_default_for_primary_key_is_specified_allow_none_to_be_set
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         first = MyModel(id=None)
         reveal_type(first.id)  # N: Revealed type is "builtins.int"
@@ -157,6 +159,7 @@
 -   case: default_manager_acreate_is_typechecked
     main: |
         import asyncio
+        from typing_extensions import reveal_type
         from myapp.models import User
         async def amain() -> None:
             reveal_type(await User.objects.acreate(pk=1, name='Max', age=10))  # N: Revealed type is "myapp.models.User"

--- a/tests/typecheck/models/test_extra_methods.yml
+++ b/tests/typecheck/models/test_extra_methods.yml
@@ -1,5 +1,6 @@
 -   case: if_field_has_choices_set_model_has_get_FIELDNAME_display_method
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         user = MyUser(name='user', gender='M')
         user.get_name_display()  # E: "MyUser" has no attribute "get_name_display"; maybe "get_gender_display"?  [attr-defined]
@@ -29,6 +30,7 @@
         disallow_any_generics = {{ allow_any }}
         disallow_any_explicit = {{ allow_any }}
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser().get_next_by_date())  # N: Revealed type is "myapp.models.MyUser"
         reveal_type(MyUser().get_next_by_datetime())  # N: Revealed type is "myapp.models.MyUser"

--- a/tests/typecheck/models/test_inheritance.yml
+++ b/tests/typecheck/models/test_inheritance.yml
@@ -48,6 +48,7 @@
 
 -   case: fail_if_no_such_attribute_on_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import B
         b_instance = B()
         reveal_type(b_instance.b_attr) # N: Revealed type is "builtins.int"
@@ -68,6 +69,7 @@
 
 -   case: fields_recognized_if_base_model_is_subclass_of_models_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().username)  # N: Revealed type is "builtins.str"
     installed_apps:
@@ -89,6 +91,7 @@
 
 -   case: django_contrib_gis_base_model_mixin_inheritance
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import User
         reveal_type(User().name)  # N: Revealed type is "builtins.str"
         reveal_type(User().updated_at)  # N: Revealed type is "datetime.datetime"
@@ -112,6 +115,7 @@
 
 -   case: test_manager_typevar_through_bounds
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import ResultProcessorConcrete
         reveal_type(ResultProcessorConcrete().f())  # N: Revealed type is "myapp.models.Concrete"
     installed_apps:

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -261,6 +261,7 @@
 
 -   case: field_set_type_honors_type_redefinition
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         non_init = MyModel()
         reveal_type(non_init.redefined_set_type)
@@ -282,19 +283,19 @@
             unset_set_type=[],
         )
     out: |
-        main:3: note: Revealed type is "builtins.int"
         main:4: note: Revealed type is "builtins.int"
-        main:5: note: Revealed type is "builtins.list[builtins.int]"
-        main:6: note: Revealed type is "builtins.int"
-        main:7: note: Revealed type is "Any"
-        main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
-        main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int | float")  [assignment]
-        main:11: error: Incompatible types in assignment (expression has type "list[str]", variable has type "Sequence[int | float]")  [assignment]
-        main:12: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "float | int | str | Combinable")  [assignment]
-        main:14: error: Incompatible type for "redefined_set_type" of "MyModel" (got "str", expected "int")  [misc]
-        main:14: error: Incompatible type for "redefined_union_set_type" of "MyModel" (got "str", expected "int | float")  [misc]
-        main:14: error: Incompatible type for "redefined_array_set_type" of "MyModel" (got "int", expected "Sequence[int | float]")  [misc]
-        main:14: error: Incompatible type for "default_set_type" of "MyModel" (got "list[Any]", expected "float | int | str | Combinable")  [misc]
+        main:5: note: Revealed type is "builtins.int"
+        main:6: note: Revealed type is "builtins.list[builtins.int]"
+        main:7: note: Revealed type is "builtins.int"
+        main:8: note: Revealed type is "Any"
+        main:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
+        main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int | float")  [assignment]
+        main:12: error: Incompatible types in assignment (expression has type "list[str]", variable has type "Sequence[int | float]")  [assignment]
+        main:13: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "float | int | str | Combinable")  [assignment]
+        main:15: error: Incompatible type for "redefined_set_type" of "MyModel" (got "str", expected "int")  [misc]
+        main:15: error: Incompatible type for "redefined_union_set_type" of "MyModel" (got "str", expected "int | float")  [misc]
+        main:15: error: Incompatible type for "redefined_array_set_type" of "MyModel" (got "int", expected "Sequence[int | float]")  [misc]
+        main:15: error: Incompatible type for "default_set_type" of "MyModel" (got "list[Any]", expected "float | int | str | Combinable")  [misc]
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -1,5 +1,6 @@
 -   case: meta_attribute_has_a_type_of_current_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser._meta)  # N: Revealed type is "django.db.models.options.Options[myapp.models.MyUser]"
     installed_apps:
@@ -14,6 +15,7 @@
 
 -   case: get_field_returns_proper_field_type
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         reveal_type(MyUser._meta.get_field('base_name'))  # N: Revealed type is "django.db.models.fields.CharField[builtins.str | builtins.int | django.db.models.expressions.Combinable, builtins.str]"
         reveal_type(MyUser.base_name.field)  # N: Revealed type is "django.db.models.fields.CharField[builtins.str | builtins.int | django.db.models.expressions.Combinable, builtins.str]"
@@ -41,6 +43,7 @@
 
 -   case: get_field_with_abstract_inheritance
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import AbstractModel
         class MyModel(AbstractModel):
             pass

--- a/tests/typecheck/models/test_metaclass.yml
+++ b/tests/typecheck/models/test_metaclass.yml
@@ -1,5 +1,6 @@
 -   case: test_contributions_from_modelbase_metaclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Abstract1, Abstract2, Concrete1, Concrete2, Concrete3
         from django.db import models
 
@@ -75,6 +76,7 @@
 
 -   case: test_custom_model_base_metaclass
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import This, Other
 
         this = This(field=Other())

--- a/tests/typecheck/models/test_primary_key.yml
+++ b/tests/typecheck/models/test_primary_key.yml
@@ -1,5 +1,6 @@
 - case: test_access_to_id_field_through_self_if_no_primary_key_defined
   main: |
+    from typing_extensions import reveal_type
     from myapp.models import MyModel
     x = MyModel.objects.get(id=1)
     reveal_type(x.id)  # N: Revealed type is "builtins.int"
@@ -12,6 +13,7 @@
     - path: myapp/__init__.py
     - path: myapp/models.py
       content: |
+        from typing_extensions import reveal_type
         from django.db import models
         class MyModel(models.Model):
             def __str__(self) -> str:
@@ -22,6 +24,7 @@
 
 - case: test_access_to_id_field_through_self_if_primary_key_is_defined
   main: |
+    from typing_extensions import reveal_type
     from myapp.models import MyModel
     x = MyModel.objects.get(id='a')
     reveal_type(x.id)  # N: Revealed type is "builtins.str"
@@ -34,6 +37,7 @@
     - path: myapp/__init__.py
     - path: myapp/models.py
       content: |
+        from typing_extensions import reveal_type
         from django.db import models
         class MyModel(models.Model):
             id = models.CharField(max_length=10, primary_key=True)
@@ -45,6 +49,7 @@
 
 - case: test_access_to_id_field_through_self_if_primary_key_has_different_name
   main: |
+    from typing_extensions import reveal_type
     from myapp.models import MyModel
     x = MyModel.objects.get(primary='a')
     reveal_type(x.primary)  # N: Revealed type is "builtins.str"
@@ -59,6 +64,7 @@
     - path: myapp/__init__.py
     - path: myapp/models.py
       content: |
+        from typing_extensions import reveal_type
         from django.db import models
         class MyModel(models.Model):
             primary = models.CharField(max_length=10, primary_key=True)

--- a/tests/typecheck/models/test_proxy_models.yml
+++ b/tests/typecheck/models/test_proxy_models.yml
@@ -1,5 +1,6 @@
 -   case: foreign_key_to_proxy_model_accepts_first_non_proxy_model
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import Blog, Publisher, PublisherProxy
         Blog(publisher=Publisher())
         Blog.objects.create(publisher=Publisher())

--- a/tests/typecheck/models/test_related_fields.yml
+++ b/tests/typecheck/models/test_related_fields.yml
@@ -1,5 +1,6 @@
 -   case: test_related_name_custom_manager
     main: |
+      from typing_extensions import reveal_type
       from app1.models import Model1
       from app2.models import Model2
 
@@ -90,6 +91,7 @@
 
 -   case: test_related_name_foreign_object_multi_column
     main: |
+      from typing_extensions import reveal_type
       from app1.models import Model1, Model2
 
       reveal_type(Model2.model_1.field) # N: Revealed type is "django.db.models.fields.related.ForeignObject[app1.models.Model1, app1.models.Model1]"
@@ -126,6 +128,7 @@
 
 - case: test_processes_other_relations_when_one_field_is_broken
   main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         reveal_type(MyModel().others)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[myapp.models.Other]"
   installed_apps:
@@ -146,6 +149,7 @@
 
 - case: test_related_fields_with_two_generic_parameters
   main: |
+        from typing_extensions import reveal_type
         from myapp.models import Address, School, Student
         reveal_type(Student().school)  # N: Revealed type is "myapp.models.School"
         reveal_type(Student().address)  # N: Revealed type is "myapp.models.Address"
@@ -174,6 +178,7 @@
 - case: test_related_fields_with_one_generic_parameter
   expect_fail: True
   main: |
+        from typing_extensions import reveal_type
         from myapp.models import Address, School, Student
         reveal_type(Student().school)  # N: Revealed type is "myapp.models.School"
         reveal_type(Student().address)  # N: Revealed type is "myapp.models.Address"

--- a/tests/typecheck/models/test_state.yml
+++ b/tests/typecheck/models/test_state.yml
@@ -1,5 +1,6 @@
 -   case: state_attribute_has_a_type_of_model_state
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyUser
         user = MyUser(pk=1)
         reveal_type(user._state)  # N: Revealed type is "django.db.models.base.ModelState"

--- a/tests/typecheck/template/test_library.yml
+++ b/tests/typecheck/template/test_library.yml
@@ -1,5 +1,6 @@
 -   case: register_filter_unnamed
     main: |
+        from typing_extensions import reveal_type
         from django import template
         register = template.Library()
 
@@ -11,6 +12,7 @@
 
 -   case: register_filter_named
     main: |
+        from typing_extensions import reveal_type
         from django import template
         register = template.Library()
 
@@ -22,6 +24,7 @@
 
 -   case: register_simple_tag_no_args
     main: |
+        from typing_extensions import reveal_type
         import datetime
         from django import template
         register = template.Library()
@@ -34,6 +37,7 @@
 
 -   case: register_simple_tag_context
     main: |
+        from typing_extensions import reveal_type
         from django import template
         from typing import Any
         register = template.Library()
@@ -47,6 +51,7 @@
 
 -   case: register_simple_tag_named
     main: |
+        from typing_extensions import reveal_type
         from django import template
         register = template.Library()
 
@@ -58,6 +63,7 @@
 
 -   case: register_simple_tag_via_call
     main: |
+        from typing_extensions import reveal_type
         from django import template
         register = template.Library()
 
@@ -68,6 +74,7 @@
 
 -   case: register_simple_block_tag
     main: |
+        from typing_extensions import reveal_type
         import datetime
         from django import template
         register = template.Library()
@@ -91,6 +98,7 @@
 
 -   case: register_tag_no_args
     main: |
+        from typing_extensions import reveal_type
         from django import template
         from django.template.base import Parser, Token
         from django.template.defaulttags import CycleNode
@@ -104,6 +112,7 @@
 
 -   case: register_tag_named
     main: |
+        from typing_extensions import reveal_type
         from django import template
         from django.template.base import Parser, Token
         from django.template.defaulttags import CycleNode
@@ -117,6 +126,7 @@
 
 -   case: register_inclusion_tag
     main: |
+        from typing_extensions import reveal_type
         from django import template
         register = template.Library()
 

--- a/tests/typecheck/test/test_client.yml
+++ b/tests/typecheck/test/test_client.yml
@@ -1,5 +1,6 @@
 - case: client_methods
   main: |
+      from typing_extensions import reveal_type
       from django.test.client import Client
       client = Client()
       response = client.get('foo')
@@ -15,6 +16,7 @@
       response.json()
 - case: async_client_methods
   main: |
+      from typing_extensions import reveal_type
       from django.test.client import AsyncClient
       async def main() -> None:
         client = AsyncClient()
@@ -30,6 +32,7 @@
         response.json()
 - case: request_factories
   main: |
+      from typing_extensions import reveal_type
       from django.test.client import RequestFactory, AsyncRequestFactory
       factory = RequestFactory()
       request = factory.get('foo')

--- a/tests/typecheck/test/test_testcase.yml
+++ b/tests/typecheck/test/test_testcase.yml
@@ -1,5 +1,6 @@
 -   case: testcase_client_attr
     main: |
+      from typing_extensions import reveal_type
       from django.test.testcases import TestCase
 
       class ExampleTestCase(TestCase):

--- a/tests/typecheck/test/test_utils.yml
+++ b/tests/typecheck/test/test_utils.yml
@@ -1,5 +1,6 @@
 -   case: override_settings
     main: |
+        from typing_extensions import reveal_type
         from django.test import override_settings
         from django.conf import settings
         @override_settings(FOO='bar')

--- a/tests/typecheck/test_annotated.yml
+++ b/tests/typecheck/test_annotated.yml
@@ -2,7 +2,7 @@
 -   case: annotated_should_not_interfere
     main: |
         from dataclasses import dataclass
-        from typing_extensions import Annotated, TypedDict
+        from typing_extensions import Annotated, TypedDict, reveal_type
         from myapp.models import Blog
 
         class IntegerType:

--- a/tests/typecheck/test_config.yml
+++ b/tests/typecheck/test_config.yml
@@ -1,5 +1,6 @@
 -   case: pyproject_toml_config
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         mymodel = MyModel(user_id=1)
         reveal_type(mymodel.id)  # N: Revealed type is "builtins.int"
@@ -15,6 +16,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
+                from typing_extensions import reveal_type
                 from typing import TYPE_CHECKING
                 from typing_extensions import reveal_type
                 from django.db import models
@@ -25,6 +27,7 @@
 
 -   case: generate_pyproject_toml_and_settings_file_from_installed_apps_key
     main: |
+        from typing_extensions import reveal_type
         from myapp.models import MyModel
         mymodel = MyModel(user_id=1)
         reveal_type(mymodel.id)  # N: Revealed type is "builtins.int"

--- a/tests/typecheck/test_forms.yml
+++ b/tests/typecheck/test_forms.yml
@@ -28,6 +28,7 @@
 -   case: formview_methods_on_forms_return_proper_types
     main: |
         from typing import Any
+        from typing_extensions import reveal_type
         from django import forms
         from django.http import HttpRequest, HttpResponse
         from django.views.generic.edit import FormView
@@ -87,6 +88,7 @@
 
 -   case: updateview_form_valid_has_form_save
     main: |
+        from typing_extensions import reveal_type
         from django import forms
         from django.http import HttpResponse
         from django.views.generic.edit import UpdateView

--- a/tests/typecheck/test_formsets.yml
+++ b/tests/typecheck/test_formsets.yml
@@ -1,6 +1,7 @@
 - case: inlineformset_factory
   main: |
     from typing import Any
+    from typing_extensions import reveal_type
     from django import forms
     from myapp.models import Article, Category
     ArticleFS: type[forms.BaseInlineFormSet[Article, Category, Any]] = forms.inlineformset_factory(Category, Article)

--- a/tests/typecheck/test_helpers.yml
+++ b/tests/typecheck/test_helpers.yml
@@ -12,6 +12,7 @@
 
 -   case: transaction_atomic_decorator
     main: |
+        from typing_extensions import reveal_type
         from django.db import transaction
 
         @transaction.atomic()
@@ -46,6 +47,7 @@
 
 -   case: mark_safe_decorator_and_function
     main: |
+        from typing_extensions import reveal_type
         from django.utils.safestring import mark_safe
         s = 'hello'
         reveal_type(mark_safe(s))  # N: Revealed type is "django.utils.safestring.SafeString"

--- a/tests/typecheck/test_import_all.yml
+++ b/tests/typecheck/test_import_all.yml
@@ -680,4 +680,7 @@
         import django.views.static
     mypy_config: |
         [mypy-redis.*]
-        ignore_errors = True
+        ignore_errors = true
+        [mypy-yaml.*]
+        disallow_untyped_defs = false
+        disallow_incomplete_defs = false

--- a/tests/typecheck/test_mail.yml
+++ b/tests/typecheck/test_mail.yml
@@ -1,5 +1,6 @@
 -   case: check_email_message_attach
     main: |
+        from typing_extensions import reveal_type
         from email.mime.text import MIMEText
         from email.mime.image import MIMEImage
         from django.core.mail.message import EmailMessage

--- a/tests/typecheck/test_request.yml
+++ b/tests/typecheck/test_request.yml
@@ -1,5 +1,6 @@
 -   case: request_object_has_user_of_type_auth_user_model
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         reveal_type(HttpRequest().user)  # N: Revealed type is "myapp.models.MyUser | django.contrib.auth.models.AnonymousUser"
         # check that other fields work ok
@@ -16,6 +17,7 @@
                     pass
 -   case: request_object_user_can_be_discriminated
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         request = HttpRequest()
         reveal_type(request.user) # N: Revealed type is "django.contrib.auth.models.User | django.contrib.auth.models.AnonymousUser"
@@ -28,6 +30,7 @@
         INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth')
 -   case: request_object_user_without_auth_and_contenttypes_apps
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         request = HttpRequest()
         reveal_type(request.user) # N: Revealed type is "django.contrib.auth.base_user.AbstractBaseUser | django.contrib.auth.models.AnonymousUser"
@@ -35,6 +38,7 @@
             reveal_type(request.user) # N: Revealed type is "django.contrib.auth.base_user.AbstractBaseUser"
 -   case: request_object_user_without_auth_but_with_contenttypes_apps
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         request = HttpRequest()
         reveal_type(request.user) # N: Revealed type is "django.contrib.auth.base_user.AbstractBaseUser | django.contrib.auth.models.AnonymousUser"
@@ -44,6 +48,7 @@
         INSTALLED_APPS = ('django.contrib.contenttypes',)
 -   case: subclass_request_not_changed_user_type
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         class MyRequest(HttpRequest):
             foo: int # Just do something
@@ -55,6 +60,7 @@
 
 -   case: subclass_request_changed_user_type
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
         from django.contrib.auth.models import User
         class MyRequest(HttpRequest):
@@ -67,6 +73,7 @@
 
 -   case: request_get_post
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
 
         request = HttpRequest()
@@ -85,6 +92,7 @@
 
 -   case: request_get_post_unreachable
     main: |
+        from typing_extensions import reveal_type
         from django.http.request import HttpRequest
 
         request = HttpRequest()

--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -1,6 +1,7 @@
 -   case: settings_loaded_from_different_files
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from django.conf import settings
         # standard settings
         reveal_type(settings.AUTH_USER_MODEL)  # N: Revealed type is "builtins.str"
@@ -22,6 +23,7 @@
 
 -   case: global_settings_are_always_loaded
     main: |
+        from typing_extensions import reveal_type
         from django.conf import settings
         reveal_type(settings.AUTH_USER_MODEL)  # N: Revealed type is "builtins.str"
         reveal_type(settings.AUTHENTICATION_BACKENDS)  # N: Revealed type is "typing.Sequence[builtins.str]"
@@ -36,6 +38,7 @@
     custom_settings: |
         from settings.basic_settings import *
     main: |
+        from typing_extensions import reveal_type
         from django.conf import settings
         reveal_type(settings.MEDIA_ROOT)  # N: Revealed type is "pathlib.Path"
         reveal_type(settings.MEDIA_ROOT / 'part')  # N: Revealed type is "pathlib.Path"
@@ -48,21 +51,23 @@
 
 -   case: settings_hasattr
     main: |
+      from typing_extensions import reveal_type
       from django.conf import settings
       if hasattr(settings, 'AUTH_USER_MODEL') and settings.AUTH_USER_MODEL:
           reveal_type(settings.AUTH_USER_MODEL)
       if hasattr(settings, 'NON_EXISTENT_SETTING') and settings.NON_EXISTENT_SETTING:
           reveal_type(settings.NON_EXISTENT_SETTING)
     out: |
-      main:3: note: Revealed type is "builtins.str"
-      main:4: error: 'Settings' object has no attribute 'NON_EXISTENT_SETTING'  [misc]
+      main:4: note: Revealed type is "builtins.str"
       main:5: error: 'Settings' object has no attribute 'NON_EXISTENT_SETTING'  [misc]
-      main:5: note: Revealed type is "Any"
+      main:6: error: 'Settings' object has no attribute 'NON_EXISTENT_SETTING'  [misc]
+      main:6: note: Revealed type is "Any"
 
 
 -   case: settings_loaded_from_runtime_magic
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from django.conf import settings
 
         # Global:
@@ -83,6 +88,7 @@
 -   case: settings_loaded_from_runtime_magic_strict_default
     disable_cache: true
     main: |
+        from typing_extensions import reveal_type
         from django.conf import settings
 
         # Global:

--- a/tests/typecheck/test_settings.yml
+++ b/tests/typecheck/test_settings.yml
@@ -12,7 +12,7 @@
         from base import *
         SECRET_KEY = 112233
         NUMBERS = ['one', 'two']
-        DICT = {}  # type: ignore
+        DICT = {}  # type: ignore[var-annotated]
     files:
         -   path: base.py
             content: |

--- a/tests/typecheck/test_shortcuts.yml
+++ b/tests/typecheck/test_shortcuts.yml
@@ -1,5 +1,6 @@
 -   case: get_object_or_404_returns_proper_types
     main: |
+        from typing_extensions import reveal_type
         from django.shortcuts import get_object_or_404, get_list_or_404
         from myapp.models import MyModel
 
@@ -22,6 +23,7 @@
 
 -   case: get_user_model_returns_proper_class
     main: |
+        from typing_extensions import reveal_type
         from django.contrib.auth import get_user_model
         UserModel = get_user_model()
         reveal_type(UserModel.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyUser]"
@@ -39,7 +41,7 @@
 -   case: check_render_function_arguments_annotations
     main: |
         from typing import Any
-        from typing_extensions import TypedDict
+        from typing_extensions import TypedDict, reveal_type
         from django.shortcuts import render
         from django.http.request import HttpRequest
 
@@ -50,6 +52,7 @@
 
 -   case: check_redirect_return_annotation
     main: |
+        from typing_extensions import reveal_type
         from django.shortcuts import redirect
         reveal_type(redirect(to = '', permanent = True)) # N: Revealed type is "django.http.response.HttpResponsePermanentRedirect"
         reveal_type(redirect(to = '', permanent = False)) # N: Revealed type is "django.http.response.HttpResponseRedirect"

--- a/tests/typecheck/utils/test_datastructures.yml
+++ b/tests/typecheck/utils/test_datastructures.yml
@@ -1,6 +1,7 @@
 -   case: multivaluedict
     main: |
       from django.utils.datastructures import MultiValueDict
+      from typing_extensions import reveal_type
 
       # check constructors
       var1 = MultiValueDict()  # E: Need type annotation for "var1"  [var-annotated]

--- a/tests/typecheck/utils/test_decorators.yml
+++ b/tests/typecheck/utils/test_decorators.yml
@@ -1,5 +1,6 @@
 -   case: classonlymethod
     main: |
+      from typing_extensions import reveal_type
       from django.utils.decorators import classonlymethod
 
       class Bananaman:
@@ -10,6 +11,7 @@
       reveal_type(Bananaman.count_bananas)  # N: Revealed type is "def () -> builtins.int"
 -   case: method_decorator_class
     main: |
+      from typing_extensions import reveal_type
       from django.views.generic.base import View
       from django.utils.decorators import method_decorator
       from django.contrib.auth.decorators import login_required
@@ -19,6 +21,7 @@
 -   case: method_decorator_function
     main: |
       from typing import Any
+      from typing_extensions import reveal_type
       from django.views.generic.base import View
       from django.utils.decorators import method_decorator
       from django.contrib.auth.decorators import login_required

--- a/tests/typecheck/utils/test_encoding.yml
+++ b/tests/typecheck/utils/test_encoding.yml
@@ -1,5 +1,6 @@
 -   case: force_bytes_or_str
     main: |
+      from typing_extensions import reveal_type
       from django.utils.encoding import force_bytes, force_str
       class S(str):
           pass

--- a/tests/typecheck/utils/test_functional.yml
+++ b/tests/typecheck/utils/test_functional.yml
@@ -2,6 +2,7 @@
     main: |
       from django.utils.functional import cached_property
       from typing import ClassVar
+      from typing_extensions import reveal_type
 
       class Foo:
           @cached_property
@@ -34,6 +35,7 @@
 
 -   case: str_promise_proxy
     main:  |
+      from typing_extensions import reveal_type
       from django.utils.functional import Promise, lazystr, _StrPromise
 
       s = lazystr("asd")
@@ -67,6 +69,7 @@
     main: |
       from typing import Any
       from django.utils.functional import classproperty
+      from typing_extensions import reveal_type
 
       class Foo:
           @classproperty

--- a/tests/typecheck/utils/test_timezone.yml
+++ b/tests/typecheck/utils/test_timezone.yml
@@ -1,30 +1,32 @@
 -   case: is_naive_correct
     main: |
+      from typing_extensions import reveal_type
       from django.utils.timezone import is_naive
       from datetime import date, time, datetime
       reveal_type(is_naive(date(2020, 1, 1)))
       reveal_type(is_naive(datetime(2020, 1, 1)))
       reveal_type(is_naive(time()))
     out: |
-      main:3: error: No overload variant of "is_naive" matches argument type "date"  [call-overload]
-      main:3: note: Possible overload variants:
-      main:3: note:     def is_naive(value: time) -> Literal[True]
-      main:3: note:     def is_naive(value: datetime) -> bool
-      main:3: note: Revealed type is "Any"
-      main:4: note: Revealed type is "builtins.bool"
-      main:5: note: Revealed type is "Literal[True]"
+      main:4: error: No overload variant of "is_naive" matches argument type "date"  [call-overload]
+      main:4: note: Possible overload variants:
+      main:4: note:     def is_naive(value: time) -> Literal[True]
+      main:4: note:     def is_naive(value: datetime) -> bool
+      main:4: note: Revealed type is "Any"
+      main:5: note: Revealed type is "builtins.bool"
+      main:6: note: Revealed type is "Literal[True]"
 -   case: is_aware_correct
     main: |
+      from typing_extensions import reveal_type
       from django.utils.timezone import is_aware
       from datetime import date, time, datetime
       reveal_type(is_aware(date(2020, 1, 1)))
       reveal_type(is_aware(datetime(2020, 1, 1)))
       reveal_type(is_aware(time()))
     out: |
-      main:3: error: No overload variant of "is_aware" matches argument type "date"  [call-overload]
-      main:3: note: Possible overload variants:
-      main:3: note:     def is_aware(value: time) -> Literal[False]
-      main:3: note:     def is_aware(value: datetime) -> bool
-      main:3: note: Revealed type is "Any"
-      main:4: note: Revealed type is "builtins.bool"
-      main:5: note: Revealed type is "Literal[False]"
+      main:4: error: No overload variant of "is_aware" matches argument type "date"  [call-overload]
+      main:4: note: Possible overload variants:
+      main:4: note:     def is_aware(value: time) -> Literal[False]
+      main:4: note:     def is_aware(value: datetime) -> bool
+      main:4: note: Revealed type is "Any"
+      main:5: note: Revealed type is "builtins.bool"
+      main:6: note: Revealed type is "Literal[False]"

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -38,6 +38,7 @@
 
 -   case: generic_form_views
     main: |
+        from typing_extensions import reveal_type
         from django.views.generic.edit import CreateView, UpdateView
         from django import forms
         from myapp.models import Article
@@ -66,6 +67,7 @@
 
 -   case: generic_form_views_different_form_classes
     main: |
+        from typing_extensions import reveal_type
         from django.views.generic.edit import CreateView
         from django import forms
         from myapp.models import Article

--- a/tests/typecheck/views/test_function_based_views.yml
+++ b/tests/typecheck/views/test_function_based_views.yml
@@ -18,6 +18,7 @@
 
 -   case: http_response_content
     main: |
+      from typing_extensions import reveal_type
       from django.http.request import HttpRequest
       from django.http.response import HttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -68,6 +69,7 @@
 
 -   case: streaming_http_response_streaming_content
     main: |
+      from typing_extensions import reveal_type
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _
@@ -133,6 +135,7 @@
 -   case: streaming_http_response_async_streaming_content
     main: |
       import typing
+      from typing_extensions import reveal_type
       from django.http.request import HttpRequest
       from django.http.response import StreamingHttpResponse
       from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
I went through the mypy configuration and cleaned up a number of things:

- Removed a number of unnecessary options, e.g. already enabled by `strict`
- Removed `allow_redefinition` [^1]
- Enabled a number of additional error codes:
  - [x] `deprecated`
  - [x] `exhaustive-match`
  - [ ] `explicit-override` [^2]
  - [x] `ignore-without-code`
  - [ ] ~`mutable-override`~ [^3]
  - [x] `possibly-undefined`
  - [x] `redundant-expr`
  - [x] `redundant-self`
  - [x] `truthy-bool`
  - [x] `truthy-iterable`
  - [x] `unimported-reveal` [^4]
  - [x] `unused-awaitable`

[^1]: Perhaps we can enable `allow_redefinition_new` later or just wait for it to be the default...
[^2]: This was a bit more noisy in the stubs, so better done in a separate pull request.
[^3]: This just doesn't play nicely with Django, so not worth supporting.
[^4]: We should remove patching `reveal_type()` and `reveal_locals()` to `builtins` in `django_stubs_ext`, especially as `typing.reveal_type()` is available. With the addition of `unimported-reveal` in this pull request, we'll catch any stray uses in django-stubs so we can't make a bad release. Something for a follow up.