### PR TITLE
Updated `.pre-commit-config` and `CONTRIBUTING.MD` to Python 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_language_version:
-  python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -17,7 +15,7 @@ repos:
         args: [--fix=lf]
       - id: check-case-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.12.12
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
@@ -27,11 +25,11 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies:
-        - tomli
+          - tomli
 
 ci:
-    autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
-    autofix_prs: true
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: weekly
-    submodules: false
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  submodules: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,12 @@ In order to be able to continuously sync your fork with the origin repository's 
 To do so follow this [official github guide](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
 
 ### Dependency Setup
+
 We use [uv](https://github.com/astral-sh/uv) to manage our dev dependencies.
 To install it, see their [installation guide](https://docs.astral.sh/uv/getting-started/installation/)
 
 Once it's done, simply run the following command to automatically setup a virtual environment and install dev dependencies:
+
 ```bash
 uv sync
 source .venv/bin/activate
@@ -78,14 +80,15 @@ rm -r .mypy_cache
 Run `./scripts/stubtest.sh` to test that stubs and sources are in-line.
 
 We have some special files to allow errors:
+
 1. `scripts/stubtest/allowlist.txt` where we store things that we really don't care about: hacks, django internal utility modules, things that are handled by our plugin, things that are not representable by type system, etc
 2. `scripts/stubtest/allowlist_todo.txt` where we store all errors there are right now. Basically, this is a TODO list: we need to work through this list and fix things (or move entries to real `allowlist.txt`). In the end, ideally we can remove this file.
-3. `scripts/stubtest/allowlist_todo_django51.txt` where we store new errors from the Django 5.0 to 5.1 upgrade. This is an extra TODO list.
+3. `scripts/stubtest/allowlist_todo_django51.txt` where we store new errors from the Django 5.0 to 5.2 upgrade. This is an extra TODO list.
 
 You might also want to disable `incremental` mode while working on `stubtest` changes.
 This mode leads to several known problems (stubs do not show up or have strange errors).
 
-**Important**: right now we only run `stubtest` on Python 3.12 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.
+**Important**: right now we only run `stubtest` on Python 3.13 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.
 
 ## Submission Guidelines
 
@@ -112,7 +115,6 @@ If it does, please add the new generic class to the `_need_generic` list in the 
 We only add hints for private attributes when it has some demonstrated real-world use case.
 That means from a third-party package or some well described snippet for a project.
 This rule helps us avoid tying in too closely to Django’s undocumented internals.
-
 
 ## Releasing `django-stubs`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ We have some special files to allow errors:
 
 1. `scripts/stubtest/allowlist.txt` where we store things that we really don't care about: hacks, django internal utility modules, things that are handled by our plugin, things that are not representable by type system, etc
 2. `scripts/stubtest/allowlist_todo.txt` where we store all errors there are right now. Basically, this is a TODO list: we need to work through this list and fix things (or move entries to real `allowlist.txt`). In the end, ideally we can remove this file.
-3. `scripts/stubtest/allowlist_todo_django51.txt` where we store new errors from the Django 5.0 to 5.2 upgrade. This is an extra TODO list.
+3. `scripts/stubtest/allowlist_todo_django52.txt` where we store new errors from the Django 5.0 to 5.2 upgrade. This is an extra TODO list.
 
 You might also want to disable `incremental` mode while working on `stubtest` changes.
 This mode leads to several known problems (stubs do not show up or have strange errors).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,6 @@ We have some special files to allow errors:
 You might also want to disable `incremental` mode while working on `stubtest` changes.
 This mode leads to several known problems (stubs do not show up or have strange errors).
 
-**Important**: right now we only run `stubtest` on Python 3.13 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.
-
 ## Submission Guidelines
 
 The workflow for contributions is fairly simple:


### PR DESCRIPTION
# I have made things!

- Updated `.pre-commit-config.yaml` to drop  

```yaml
default_language_version:
  python: python3.12
```

as it’s redundant. `django-stubs` uses hooks that are already compatible with the latest stable Python versions.  
Keeping this pinned was only causing issues for new contributors, since `pre-commit install` failed with a `RuntimeError` if Python 3.12 wasn’t available.  

- Updated `CONTRIBUTING.md` to reflect Python 3.13 (the current stable release) instead of Python 3.12:  

> Important: right now we only run stubtest on Python 3.12 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.

---

## Related issues
Closes #2801
