### PR TITLE
Validate `select_related` lookups

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -168,6 +168,7 @@ class NewSemanalDjangoPlugin(Plugin):
             "prefetch_related": partial(
                 querysets.extract_prefetch_related_annotations, django_context=self.django_context
             ),
+            "select_related": partial(querysets.validate_select_related, django_context=self.django_context),
         }
 
     def get_method_hook(self, fullname: str) -> Callable[[MethodContext], MypyType] | None:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -645,7 +645,7 @@ def _validate_select_related_lookup(
     """Validate a single select_related lookup string."""
     if not lookup.strip():
         ctx.api.fail(
-            f'Invalid field name "{lookup}" in select_related lookup. Cannot be whitespace-only',
+            f'Invalid field name "{lookup}" in select_related lookup',
             ctx.context,
         )
         return False

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -99,8 +99,8 @@
         Book.objects.all().select_related()
         Book.objects.select_related(None)
         Book.objects.all().select_related(None)
-        Book.objects.select_related("author", "dd") # Should be Error on invalid lookup 'dd' !
-        Book.objects.all().select_related("author", "dd") # Should be Error on invalid lookup 'dd' !
+        Book.objects.select_related("author", "dd") # E: Invalid field name "dd" in select_related lookup. Choices are: author  [misc]
+        Book.objects.all().select_related("author", "dd") # E: Invalid field name "dd" in select_related lookup. Choices are: author  [misc]
 
         Book.objects.select_related("None", None)
         Book.objects.all().select_related("None", None)

--- a/tests/typecheck/managers/querysets/test_select_related.yml
+++ b/tests/typecheck/managers/querysets/test_select_related.yml
@@ -94,8 +94,8 @@
         Article.objects.select_related(invalid_lookup)  # No error - variables not validated
 
         # Intermediary variable validated if literal
-        invalid_lookup: Literal["nonexistent"] = "nonexistent"
-        Article.objects.select_related(invalid_lookup)  # E: Invalid field name "nonexistent" in select_related lookup. Choices are: author, category  [misc]
+        invalid_lookup2: Literal["nonexistent"] = "nonexistent"
+        Article.objects.select_related(invalid_lookup2)  # E: Invalid field name "nonexistent" in select_related lookup. Choices are: author, category  [misc]
 
         # Chaining with invalid lookups
         qs3 = Article.objects.select_related("author").select_related("invalid")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, category  [misc]
@@ -105,8 +105,8 @@
         Article.objects.select_related("author", "invalid", "category")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, category  [misc]
 
         # Whitespace-only lookup (invalid)
-        Article.objects.select_related("")   # E: Invalid field name "" in select_related lookup. Cannot be whitespace-only  [misc]
-        Article.objects.select_related("   ")  # E: Invalid field name "   " in select_related lookup. Cannot be whitespace-only  [misc]
+        Article.objects.select_related("")   # E: Invalid field name "" in select_related lookup  [misc]
+        Article.objects.select_related("   ")  # E: Invalid field name "   " in select_related lookup  [misc]
 
     files:
         -   path: myapp/__init__.py

--- a/tests/typecheck/managers/querysets/test_select_related.yml
+++ b/tests/typecheck/managers/querysets/test_select_related.yml
@@ -1,0 +1,137 @@
+-   case: select_related_valid_lookups
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article, Author, Category, Blog, Post
+
+        # Valid forward relations
+        Article.objects.select_related("author")
+        Article.objects.select_related("category")
+
+        # Valid reverse relations (unique=True)
+        Author.objects.select_related("profile")
+
+        # Valid chained lookups
+        Article.objects.select_related("author__profile")
+        Article.objects.select_related("category__parent")
+        Post.objects.select_related("blog__owner")
+        Post.objects.select_related("category__parent__parent")
+
+        # Multiple valid lookups
+        Article.objects.select_related("author", "category")
+        Article.objects.select_related("author__profile", "category")
+
+        # Self-referential relationships
+        Category.objects.select_related("parent")
+        Category.objects.select_related("parent__parent")
+
+        # Variables containing strings
+        author_lookup = "aaa"
+        Article.objects.select_related(author_lookup)
+
+        # Dynamic lookups (should not be validated)
+        def get_lookup() -> str:
+            return "author"
+
+        Article.objects.select_related(get_lookup())
+
+        # Chaining select_related calls
+        qs1 = Article.objects.select_related("author")
+        qs2 = qs1.select_related("category")
+        Article.objects.select_related("author").select_related("category")
+
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Category(models.Model):
+                    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True)
+
+                class Author(models.Model):
+                    pass
+
+                class AuthorProfile(models.Model):
+                    author = models.OneToOneField(Author, on_delete=models.CASCADE, related_name='profile')
+
+                class Blog(models.Model):
+                    owner = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+                class Article(models.Model):
+                    title = models.CharField(max_length=200)  # Keep for testing non-relation field
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    category = models.ForeignKey(Category, on_delete=models.CASCADE)
+
+                class Post(models.Model):
+                    blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    category = models.ForeignKey(Category, on_delete=models.CASCADE)
+
+-   case: select_related_invalid_lookups
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article, Author, Category, Post
+        from typing import Literal
+
+        # Invalid field names
+        Article.objects.select_related("nonexistent")  # E: Invalid field name "nonexistent" in select_related lookup. Choices are: author, category  [misc]
+        Article.objects.select_related("title")  # E: Invalid field name "title" in select_related lookup. Choices are: author, category  [misc]
+
+        # Invalid chained lookups
+        Article.objects.select_related("author__nonexistent")  # E: Invalid field name "nonexistent" in select_related lookup. Choices are: profile  [misc]
+        Article.objects.select_related("category__invalid")  # E: Invalid field name "invalid" in select_related lookup. Choices are: parent  [misc]
+
+        # Reverse many-to-many (not allowed)
+        Category.objects.select_related("article_set")  # E: Invalid field name "article_set" in select_related lookup. Choices are: parent  [misc]
+
+        # Mixed valid and invalid in same call
+        Post.objects.select_related("blog", "invalid")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, blog, category  [misc]
+
+        # Intermediary variable not validated if non literal
+        invalid_lookup = "nonexistent"
+        Article.objects.select_related(invalid_lookup)  # No error - variables not validated
+
+        # Intermediary variable validated if literal
+        invalid_lookup: Literal["nonexistent"] = "nonexistent"
+        Article.objects.select_related(invalid_lookup)  # E: Invalid field name "nonexistent" in select_related lookup. Choices are: author, category  [misc]
+
+        # Chaining with invalid lookups
+        qs3 = Article.objects.select_related("author").select_related("invalid")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, category  [misc]
+        Article.objects.select_related("author").select_related("invalid")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, category  [misc]
+
+        # Multiple arguments with invalid lookups
+        Article.objects.select_related("author", "invalid", "category")  # E: Invalid field name "invalid" in select_related lookup. Choices are: author, category  [misc]
+
+        # Whitespace-only lookup (invalid)
+        Article.objects.select_related("")   # E: Invalid field name "" in select_related lookup. Cannot be whitespace-only  [misc]
+        Article.objects.select_related("   ")  # E: Invalid field name "   " in select_related lookup. Cannot be whitespace-only  [misc]
+
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Category(models.Model):
+                    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True)
+
+                class Author(models.Model):
+                    pass
+
+                class AuthorProfile(models.Model):
+                    author = models.OneToOneField(Author, on_delete=models.CASCADE, related_name='profile')
+
+                class Blog(models.Model):
+                    owner = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+                class Article(models.Model):
+                    title = models.CharField(max_length=200)  # Keep for testing non-relation field
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    category = models.ForeignKey(Category, on_delete=models.CASCADE)
+
+                class Post(models.Model):
+                    blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    category = models.ForeignKey(Category, on_delete=models.CASCADE)


### PR DESCRIPTION
# I have made things!

Similar to #2804, implement validation of the lookups passed to `.select_related(...)`.

The implementation is mostly extracted and adapted from `django.db.models.sql.compiler.SQLCompiler.get_related_selections`

PS: The `querysets.py` file is starting to get quite big, do you mind if I turn it into a module with a file per qs method ? (`select_related.py`, `prefetch_related.py` ...)