### PR TITLE
fix: Nullable field generic get type parameter should be optional

### DIFF
--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -7,6 +7,7 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import AssignmentStmt, NameExpr, TypeInfo
 from mypy.plugin import FunctionContext
+from mypy.typeanal import make_optional_type
 from mypy.types import AnyType, Instance, NoneType, ProperType, TypeOfAny, UninhabitedType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
 
@@ -158,11 +159,17 @@ def set_descriptor_types_for_field(
     mapped_instance = map_instance_to_supertype(default_return_type, base_field_type)
     mapped_set_type, mapped_get_type = tuple(get_proper_type(arg) for arg in mapped_instance.args)
 
+    if (is_set_nullable or is_nullable) and not (isinstance(mapped_set_type, UninhabitedType)):
+        mapped_set_type = get_proper_type(make_optional_type(mapped_set_type))
+
+    if (is_get_nullable or is_nullable) and not (isinstance(mapped_get_type, UninhabitedType)):
+        mapped_get_type = get_proper_type(make_optional_type(mapped_get_type))
+
     # bail if either mapped_set_type or mapped_get_type have type Never
     if not (isinstance(mapped_set_type, UninhabitedType) or isinstance(mapped_get_type, UninhabitedType)):
         # always replace set_type and get_type with (non-Any) mapped types
-        set_type = helpers.convert_any_to_type(set_type, mapped_set_type)
-        get_type = get_proper_type(helpers.convert_any_to_type(get_type, mapped_get_type))
+        set_type = get_proper_type(helpers.convert_any_to_type(mapped_set_type, set_type))
+        get_type = get_proper_type(helpers.convert_any_to_type(mapped_get_type, get_type))
 
         # the get_type must be optional if the field is nullable
         if (is_get_nullable or is_nullable) and not (

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -161,8 +161,8 @@ def set_descriptor_types_for_field(
     # bail if either mapped_set_type or mapped_get_type have type Never
     if not (isinstance(mapped_set_type, UninhabitedType) or isinstance(mapped_get_type, UninhabitedType)):
         # always replace set_type and get_type with (non-Any) mapped types
-        set_type = helpers.convert_any_to_type(mapped_set_type, set_type)
-        get_type = get_proper_type(helpers.convert_any_to_type(mapped_get_type, get_type))
+        set_type = helpers.convert_any_to_type(set_type, mapped_set_type)
+        get_type = get_proper_type(helpers.convert_any_to_type(get_type, mapped_get_type))
 
         # the get_type must be optional if the field is nullable
         if (is_get_nullable or is_nullable) and not (

--- a/tests/typecheck/fields/test_custom_fields.yml
+++ b/tests/typecheck/fields/test_custom_fields.yml
@@ -8,11 +8,11 @@
         reveal_type(user.my_custom_field2)  # N: Revealed type is "myapp.models.CustomFieldValue"
         reveal_type(user.my_custom_field3)  # N: Revealed type is "builtins.bool"
         reveal_type(user.my_custom_field4)  # N: Revealed type is "myapp.models.CustomFieldValue"
-        reveal_type(user.my_custom_field5)  # N: Revealed type is "myapp.models.CustomFieldValue"
+        reveal_type(user.my_custom_field5)  # N: Revealed type is "myapp.models.CustomFieldValue | None"
         reveal_type(user.my_custom_field6)  # N: Revealed type is "myapp.models.CustomFieldValue"
-        reveal_type(user.my_custom_field7)  # N: Revealed type is "builtins.bool"
-        reveal_type(user.my_custom_field8)  # N: Revealed type is "myapp.models.CustomFieldValue"
-        reveal_type(user.my_custom_field9)  # N: Revealed type is "myapp.models.CustomFieldValue"
+        reveal_type(user.my_custom_field7)  # N: Revealed type is "builtins.bool | None"
+        reveal_type(user.my_custom_field8)  # N: Revealed type is "myapp.models.CustomFieldValue | None"
+        reveal_type(user.my_custom_field9)  # N: Revealed type is "myapp.models.CustomFieldValue | None"
         reveal_type(user.my_custom_field10)  # N: Revealed type is "builtins.bool"
         reveal_type(user.my_custom_field11)  # N: Revealed type is "builtins.bool"
         reveal_type(user.my_custom_field12)  # N: Revealed type is "myapp.models.CustomFieldValue | None"
@@ -65,12 +65,12 @@
                     my_custom_field_any1 = FieldImplicitAny()
                     my_custom_field_any2 = FieldExplicitAny()
 
-                    # test null=True on fields with non-optional generic types throw error
-                    my_custom_field5 = GenericField[CustomFieldValue | int, CustomFieldValue](null=True)  # E: GenericField is nullable but its generic get type parameter is not optional  [misc]
-                    my_custom_field6 = CustomValueField(null=True)  # E: CustomValueField is nullable but its generic get type parameter is not optional  [misc]
-                    my_custom_field7 = SingleTypeField[bool](null=True)  # E: SingleTypeField is nullable but its generic get type parameter is not optional  [misc]
-                    my_custom_field8 = AdditionalTypeVarField[CustomFieldValue | int, CustomFieldValue, bool](null=True)  # E: AdditionalTypeVarField is nullable but its generic get type parameter is not optional  [misc]
-                    my_custom_field9 = fields.Field[CustomFieldValue | int, CustomFieldValue](null=True)  # E: Field is nullable but its generic get type parameter is not optional  [misc]
+                    # test null=True on fields with non-optional generic automatically make type optional
+                    my_custom_field5 = GenericField[CustomFieldValue | int, CustomFieldValue](null=True)
+                    my_custom_field6 = CustomValueField(null=True)
+                    my_custom_field7 = SingleTypeField[bool](null=True)
+                    my_custom_field8 = AdditionalTypeVarField[CustomFieldValue | int, CustomFieldValue, bool](null=True)
+                    my_custom_field9 = fields.Field[CustomFieldValue | int, CustomFieldValue](null=True)
 
                     # test overriding fields that set _pyi_private_set_type or _pyi_private_get_type
                     my_custom_field10 = fields.SmallIntegerField[bool, bool]()

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -49,7 +49,31 @@
                 class MyModel(models.Model):
                     text_nullable = models.CharField(max_length=100, null=True)
                     text = models.CharField(max_length=100)
-
+-   case: nullable_field_with_strict_optional_false
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import MyModel
+        reveal_type(MyModel().text)  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel().text_nullable)  # N: Revealed type is "builtins.str"
+        MyModel().text = None
+        MyModel().text_nullable = None
+    installed_apps:
+        - myapp
+    mypy_config: |
+        [mypy]
+        disable_error_code =
+            overload-cannot-match,
+            override,
+            unused-ignore
+        strict_optional = false
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    text_nullable = models.CharField(max_length=100, null=True)
+                    text = models.CharField(max_length=100)
 -   case: nullable_array_field
     main: |
         from typing_extensions import reveal_type

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "django-stubs"
-version = "5.2.3"
+version = "5.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -295,7 +295,7 @@ tests = [
 
 [[package]]
 name = "django-stubs-ext"
-version = "5.2.3"
+version = "5.2.5"
 source = { editable = "ext" }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
> [!WARNING]
> I don't know what I'm doing

An attempt to fix the referenced issue, or at least an introduction of new unit test for nullable field with non strict optional. Please do point me to the right direction if this approach is wrong.

Without the change, the new unit test will fail:
```
================================================================= test session starts =================================================================
platform darwin -- Python 3.13.5, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/Dev/heryanto/django-stubs/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Volumes/Dev/heryanto/django-stubs
configfile: pytest.ini
plugins: shard-0.1.2, xdist-3.8.0, mypy-plugins-3.2.0
collected 6 items                                                                                                                                     
Running 6 items in this shard: tests/typecheck/fields/test_nullable.yml::autofield_can_be_set_to_none, tests/typecheck/fields/test_nullable.yml::nullable_field_with_strict_optional_true, tests/typecheck/fields/test_nullable.yml::nullable_field_with_strict_optional_false, tests/typecheck/fields/test_nullable.yml::nullable_array_field, tests/typecheck/fields/test_nullable.yml::nullable_foreign_key, tests/typecheck/fields/test_nullable.yml::nullable_self_foreign_key

tests/typecheck/fields/test_nullable.yml::autofield_can_be_set_to_none PASSED
tests/typecheck/fields/test_nullable.yml::nullable_field_with_strict_optional_true PASSED
tests/typecheck/fields/test_nullable.yml::nullable_field_with_strict_optional_false FAILED
tests/typecheck/fields/test_nullable.yml::nullable_array_field PASSED
tests/typecheck/fields/test_nullable.yml::nullable_foreign_key PASSED
tests/typecheck/fields/test_nullable.yml::nullable_self_foreign_key PASSED

====================================================================== FAILURES =======================================================================
______________________________________________________ nullable_field_with_strict_optional_false ______________________________________________________
/Volumes/Dev/heryanto/django-stubs/tests/typecheck/fields/test_nullable.yml:56: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Invalid output: 
E   Actual:
E     ../../../../../../Volumes/Dev/heryanto/django-stubs/django-stubs/contrib/auth/base_user.pyi:21: error: DateTimeField is nullable but its generic get type parameter is not optional  [misc] (diff)
E     main:3: note: Revealed type is "builtins.str" (diff)
E     main:4: note: Revealed type is "builtins.str" (diff)
E     myapp/models:3: error: CharField is nullable but its generic get type parameter is not optional  [misc] (diff)
E   Expected:
E     main:3: note: Revealed type is "builtins.str" (diff)
E     main:4: note: Revealed type is "builtins.str" (diff)
E   Alignment of first line difference:
E     E: main:3: note: Revealed type is "builtins.str"...
E     A: ../../../../../../Volumes/Dev/heryanto/django-stubs/django-stubs/contrib...
E        ^
=============================================================== short test summary info ===============================================================
FAILED tests/typecheck/fields/test_nullable.yml::nullable_field_with_strict_optional_false - 
============================================================= 1 failed, 5 passed in 7.45s =============================================================
```

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

Refs https://github.com/typeddjango/django-stubs/issues/2724

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->