### PR TITLE
fix: allow to query decimal fields with int

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -263,7 +263,7 @@ class FloatField(Field[_ST, _GT]):
 class DecimalField(Field[_ST, _GT]):
     _pyi_private_set_type: str | float | decimal.Decimal | Combinable
     _pyi_private_get_type: decimal.Decimal
-    _pyi_lookup_exact_type: str | decimal.Decimal
+    _pyi_lookup_exact_type: str | int | decimal.Decimal
     # attributes
     max_digits: int
     decimal_places: int

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -45,6 +45,29 @@
                 class User(models.Model):
                     age = models.IntegerField()
 
+# Regression test for #2831
+-   case: filter_with_decimal
+    main: |
+        from myapp.models import MyModel
+        from decimal import Decimal
+
+        MyModel.objects.filter(a=1)
+        MyModel.objects.filter(a="1.0")
+        MyModel.objects.filter(a=Decimal(1.0))
+        MyModel.objects.filter(a=1.0)
+    out: |
+      main:7: error: Incompatible type for lookup 'a': (got "float", expected "str | int | Decimal")  [misc]
+
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class MyModel(models.Model):
+                    a = models.DecimalField()
 
 -   case: filter_with_multiple_fields
     main: |

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -54,10 +54,7 @@
         MyModel.objects.filter(a=1)
         MyModel.objects.filter(a="1.0")
         MyModel.objects.filter(a=Decimal(1.0))
-        MyModel.objects.filter(a=1.0)
-    out: |
-      main:7: error: Incompatible type for lookup 'a': (got "float", expected "str | int | Decimal")  [misc]
-
+        MyModel.objects.filter(a=1.0)  # E: Incompatible type for lookup 'a': (got "float", expected "str | int | Decimal")  [misc]
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
Django allow to query decimal fields with int, and given there should be no precision loss, we should accept ints to query such fields.

Note: even though we do accept floats when setting a value in a decimal field, I opted for only accepting ints in this PR, as to minimize the impact of the change.

## Related issues

Closes #2831
