### PR TITLE
Fix the `log_action` deprecation notice

### DIFF
--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -12,7 +12,7 @@ DELETION: int
 ACTION_FLAG_CHOICES: Any
 
 class LogEntryManager(models.Manager[LogEntry]):
-    @deprecated("log_action() is deprecated and will be removed in Django 6.0. Use log_action_new() instead.")
+    @deprecated("log_action() is deprecated and will be removed in Django 6.0. Use log_actions() instead.")
     def log_action(
         self,
         user_id: int | str | UUID,


### PR DESCRIPTION
# I have made things!
`log_action_new` does not exist, I think it should be `log_actions`

ref: https://github.com/django/django/blob/373cb3037fe4e67adbac9ac43340391e859aa957/django/contrib/admin/models.py#L39


