### PR TITLE
Switch to `uv_build` build system & cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,3 @@ jobs:
         run: |
           uv build .
           uv build ext/
-      - name: Check package metadata
-        run: |
-          uvx twine check --strict dist/*
-          uvx twine check --strict ext/dist/*

--- a/ext/pyproject.toml
+++ b/ext/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-build-backend = "hatchling.build"
-requires = ["hatchling"]
-
 [project]
 name = "django-stubs-ext"
 # NB! For clarity, keep version major.minor.patch in sync with django-stubs.
@@ -43,5 +39,10 @@ Homepage = "https://github.com/typeddjango/django-stubs"
 Funding = "https://github.com/sponsors/typeddjango"
 "Release notes" = "https://github.com/typeddjango/django-stubs/releases"
 
-[tool.hatch.build]
-packages = ["django_stubs_ext"]
+[build-system]
+requires = ["uv_build>=0.8.22,<0.9.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = ["django_stubs_ext"]
+module-root = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "django-stubs"
 version = "5.2.5"
@@ -80,8 +76,13 @@ Funding = "https://github.com/sponsors/typeddjango"
 django-stubs = { workspace = true }
 django-stubs-ext = { path = "ext", editable = true }
 
-[tool.hatch.build]
-packages = ["django-stubs", "mypy_django_plugin"]
+[build-system]
+requires = ["uv_build>=0.8.22,<0.9.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = ["django-stubs", "mypy_django_plugin"]
+module-root = ""
 
 [tool.codespell]
 ignore-words-list = "aadd,acount,nam,asend"


### PR DESCRIPTION
Solving follow-ups from #2846 comments.

* Switched build system `hatchling` -> `uv_build`
* Removed useless `twine check` from `build-and-check` CI job
