### PR TITLE
BaseForm.add_error: Use covariant types 

### DIFF
--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator, MutableMapping, Sequence
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence, Mapping
 from typing import Any, ClassVar, overload
 
 from django.core.exceptions import ValidationError

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator, MutableMapping, Sequence, Mapping
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from typing import Any, ClassVar, overload
 
 from django.core.exceptions import ValidationError
@@ -60,7 +60,9 @@ class BaseForm(RenderableFormMixin):
     def non_field_errors(self) -> ErrorList: ...
     @overload
     def add_error(
-        self, field: None, error: Mapping[str, ValidationError | _StrOrPromise | Sequence[ValidationError | _StrOrPromise]]
+        self,
+        field: None,
+        error: Mapping[str, ValidationError | _StrOrPromise | Sequence[ValidationError | _StrOrPromise]],
     ) -> None: ...
     @overload
     def add_error(

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator, MutableMapping
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from typing import Any, ClassVar, overload
 
 from django.core.exceptions import ValidationError
@@ -60,11 +60,11 @@ class BaseForm(RenderableFormMixin):
     def non_field_errors(self) -> ErrorList: ...
     @overload
     def add_error(
-        self, field: None, error: dict[str, ValidationError | _StrOrPromise | list[ValidationError | _StrOrPromise]]
+        self, field: None, error: Mapping[str, ValidationError | _StrOrPromise | Sequence[ValidationError | _StrOrPromise]]
     ) -> None: ...
     @overload
     def add_error(
-        self, field: str | None, error: ValidationError | _StrOrPromise | list[ValidationError | _StrOrPromise]
+        self, field: str | None, error: ValidationError | _StrOrPromise | Sequence[ValidationError | _StrOrPromise]
     ) -> None: ...
     def has_error(self, field: str | None, code: str | None = None) -> bool: ...
     def full_clean(self) -> None: ...


### PR DESCRIPTION
Without this change, the user has to pass in exactly these types, since `list` and `dict` are invariant in the value type.

Please squash when merging.