### PR TITLE
Remove magically added `django.contrib.contenttypes` installed app in tests

### DIFF
--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -10,10 +10,8 @@ def django_plugin_hook(test_item: YamlTestItem) -> None:
     if installed_apps and custom_settings:
         raise ValueError('"installed_apps" and "custom_settings" are not compatible, please use one or the other')
 
-    if installed_apps is not None:
+    if installed_apps:
         # custom_settings is empty, add INSTALLED_APPS
-        if "django.contrib.contenttypes" not in installed_apps:
-            installed_apps += ["django.contrib.contenttypes"]
         installed_apps_as_str = "(" + ",".join([repr(app) for app in installed_apps]) + ",)"
         custom_settings += "INSTALLED_APPS = " + installed_apps_as_str
 

--- a/tests/typecheck/fields/test_generic_foreign_key.yml
+++ b/tests/typecheck/fields/test_generic_foreign_key.yml
@@ -10,6 +10,7 @@
         reveal_type(Tag().content_object)  # N: Revealed type is "Any | None"
     installed_apps:
         - myapp
+        - django.contrib.contenttypes
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
@@ -32,6 +33,7 @@
         reveal_type(Tag().content_object)  # N: Revealed type is "Any | None"
     installed_apps:
         - myapp
+        - django.contrib.contenttypes
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -28,6 +28,7 @@
         reveal_type(book.owner_id)  # N: Revealed type is "builtins.int"
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
         - myapp
     files:
         -   path: myapp/__init__.py

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -152,6 +152,7 @@
 
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
         - myapp
     files:
         -   path: myapp/__init__.py

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -160,6 +160,7 @@
 -   case: prefetch_related_and_annotate
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
     main: |
         from django.db.models import Prefetch, F
         from django.contrib.auth.models import User, Group
@@ -179,6 +180,7 @@
 -   case: prefetch_related_to_attr_conflict_with_annotate
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
     main: |
         from django.db.models import Prefetch, F
         from django.contrib.auth.models import User, Group
@@ -262,6 +264,7 @@
 -   case: prefetch_related_conflicting_prefetches_on_same_attr
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
     main: |
         from django.db.models import Prefetch
         from django.contrib.auth.models import User, Group
@@ -280,6 +283,7 @@
 -   case: prefetch_related_ambiguous_prefetches
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
     main: |
         from django.db.models import Prefetch
         from django.contrib.auth.models import User, Group

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -9,6 +9,8 @@
     reveal_type(au.pk)  # N: Revealed type is "Any"
   installed_apps:
     - django.contrib.auth
+    - django.contrib.contenttypes
+
 
 - case: test_filter_on_abstract_user_pk_wrong_name
   main: |
@@ -16,6 +18,8 @@
     AbstractUser.objects.get(pkey=1)  # ER: Cannot resolve keyword 'pkey' into field..*
   installed_apps:
     - django.contrib.auth
+    - django.contrib.contenttypes
+
 
 - case: test_fetch_pk_with_custom_manager_on_abstract_model
   main: |

--- a/tests/typecheck/models/test_contrib_models.yml
+++ b/tests/typecheck/models/test_contrib_models.yml
@@ -45,6 +45,7 @@
         reveal_type(MyUser.objects.all())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.MyUser, myapp.models.MyUser]"
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
         - myapp
     files:
         - path: myapp/__init__.py
@@ -81,6 +82,7 @@
         main:8: note: Revealed type is "django.db.models.options.Options[django.contrib.auth.base_user.AbstractBaseUser]"
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
         - myapp
     files:
         - path: myapp/__init__.py

--- a/tests/typecheck/test_config.yml
+++ b/tests/typecheck/test_config.yml
@@ -33,6 +33,7 @@
         reveal_type(mymodel.id)  # N: Revealed type is "builtins.int"
     installed_apps:
         - django.contrib.auth
+        - django.contrib.contenttypes
         - myapp
     files:
         - path: myapp/__init__.py


### PR DESCRIPTION
Instead, explicitly declare it when required.


See discussion in https://github.com/typeddjango/django-stubs/pull/2851#discussion_r2404147314