### PR TITLE
Use same `uv` workspace for `django-stubs-ext` also

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,21 +16,17 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Setup python to build package
-        uses: actions/setup-python@v6
+      - name: Install uv & Python
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.12'
-      - name: Install build
-        run: python -m pip install build
+          python-version: "3.13"
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Build ext package
-        run: python -m build ext/
+        run: uv build --package=django-stubs-ext
       - name: Publish ext to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          packages-dir: ext/dist/
 
   build-and-publish:
     runs-on: ubuntu-latest
@@ -49,6 +45,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build package
-        run: uv build
+        run: uv build --package=django-stubs
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,5 +180,4 @@ jobs:
         run: env --unset=UV_FROZEN uv lock --check
       - name: Build
         run: |
-          uv build .
-          uv build ext/
+          uv build --all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,5 +179,4 @@ jobs:
       - name: Ensure uv.lock is up to date
         run: env --unset=UV_FROZEN uv lock --check
       - name: Build
-        run: |
-          uv build --all
+        run: uv build --all-packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ Funding = "https://github.com/sponsors/typeddjango"
 
 [tool.uv.sources]
 django-stubs = { workspace = true }
-django-stubs-ext = { path = "ext", editable = true }
+django-stubs-ext = { workspace = true }
+
+[tool.uv.workspace]
+members = ["ext"]
 
 [build-system]
 requires = ["uv_build>=0.8.22,<0.9.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[manifest]
+members = [
+    "django-stubs",
+    "django-stubs-ext",
+]
+
 [[package]]
 name = "asgiref"
 version = "3.9.1"


### PR DESCRIPTION
Previously, both the top-level project and the `ext` subdirectory had their own `.venv`, their own `uv.lock` (although `ext/uv.lock` was never committed to git).

With a shared workspace, these now only exist at the top level.

Also, for the release workflow, the top-level `dist/` output directory is now shared -- no more `ext/dist/`.
