### PR TITLE
Test updated release workflow - Version 5.2.6a1 release

### DIFF
--- a/ext/pyproject.toml
+++ b/ext/pyproject.toml
@@ -2,7 +2,7 @@
 name = "django-stubs-ext"
 # NB! For clarity, keep version major.minor.patch in sync with django-stubs.
 # It's fine to skip django-stubs-ext releases, but when doing a release, update this to newest django-stubs version.
-version = "5.2.5"
+version = "5.2.6a1"
 description = "Monkey-patching and extensions for django-stubs"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-stubs"
-version = "5.2.5"
+version = "5.2.6a1"
 description = "Mypy stubs for Django"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "django",
-  "django-stubs-ext>=5.2.2",
+  "django-stubs-ext>=5.2.6a1",
   "tomli; python_version < '3.11'",
   # Types:
   "types-pyyaml",

--- a/uv.lock
+++ b/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "django-stubs"
-version = "5.2.5"
+version = "5.2.6a1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -319,7 +319,7 @@ tests = [
 
 [[package]]
 name = "django-stubs-ext"
-version = "5.2.5"
+version = "5.2.6a1"
 source = { editable = "ext" }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Testing, because recent PRs have touched the `release` workflow.

Using alpha version in case anything goes wrong -- so users won't be updated automatically.

* #2857
* #2846
