### PR TITLE
Fix PK field lookup for Django < 5.2

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -784,9 +784,9 @@ def _validate_bulk_update_field(
         ctx.api.fail(f'"{method}()" can only be used with concrete fields. Got "{field_name}"', ctx.context)
         return False
 
-    all_pk_fields = set(opts.pk_fields)
+    all_pk_fields = set(getattr(opts, "pk_fields", [opts.pk]))
     for parent in opts.all_parents:
-        all_pk_fields.update(parent._meta.pk_fields)
+        all_pk_fields.update(getattr(parent._meta, "pk_fields", [parent._meta.pk]))
 
     if field in all_pk_fields:
         ctx.api.fail(f'"{method}()" cannot be used with primary key fields. Got "{field_name}"', ctx.context)


### PR DESCRIPTION
The `pk_fields` attribute was added in Django 5.2 to support composite primary keys. Fall back to using the `pk` attribute in earlier versions of Django.

Regression in 736e30f591d59d044248c15097bfd999ae659985.