### PR TITLE
Make `View`, `TemplateView`, and `TemplateResponseMixin` generic on response type

### DIFF
--- a/django-stubs/contrib/auth/views.pyi
+++ b/django-stubs/contrib/auth/views.pyi
@@ -25,7 +25,7 @@ class LoginView(RedirectURLMixin, FormView[AuthenticationForm]):
     extra_context: Any
     def get_redirect_url(self) -> str: ...
 
-class LogoutView(RedirectURLMixin, TemplateView):
+class LogoutView(RedirectURLMixin, TemplateView[HttpResponse]):
     next_page: str | None
     redirect_field_name: str
     extra_context: Any

--- a/django-stubs/contrib/auth/views.pyi
+++ b/django-stubs/contrib/auth/views.pyi
@@ -29,7 +29,7 @@ class LoginView(RedirectURLMixin, FormView[_AuthForm]):
     redirect_authenticated_user: bool
     extra_context: Mapping[str, Any] | None
 
-class LogoutView(RedirectURLMixin, TemplateView):
+class LogoutView(RedirectURLMixin, TemplateView[HttpResponse]):
     next_page: str | None
     redirect_field_name: str
     extra_context: Mapping[str, Any] | None

--- a/django-stubs/views/generic/base.pyi
+++ b/django-stubs/views/generic/base.pyi
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
@@ -12,7 +12,9 @@ class ContextMixin:
     extra_context: Mapping[str, Any] | None
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]: ...
 
-class View:
+_ViewResponse = TypeVar("_ViewResponse", bound=HttpResponseBase, default=HttpResponseBase)
+
+class View(Generic[_ViewResponse]):
     http_method_names: Sequence[str]
     request: HttpRequest
     args: Any
@@ -20,9 +22,9 @@ class View:
     def __init__(self, **kwargs: Any) -> None: ...
     view_is_async: _Getter[bool] | bool
     @classmethod
-    def as_view(cls: Any, **initkwargs: Any) -> Callable[..., HttpResponseBase]: ...
+    def as_view(cls: Any, **initkwargs: Any) -> Callable[..., _ViewResponse]: ...
     def setup(self, request: HttpRequest, *args: Any, **kwargs: Any) -> None: ...
-    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> _ViewResponse: ...
     def http_method_not_allowed(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
 

--- a/django-stubs/views/generic/base.pyi
+++ b/django-stubs/views/generic/base.pyi
@@ -4,6 +4,7 @@ from typing import Any, Generic, TypeVar
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
+from django.template.response import TemplateResponse
 from django.utils.functional import _Getter
 
 logger: logging.Logger
@@ -28,17 +29,19 @@ class View(Generic[_ViewResponse]):
     def http_method_not_allowed(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
 
-class TemplateResponseMixin:
+_TemplateResponse = TypeVar("_TemplateResponse", bound=HttpResponse, default=TemplateResponse)
+
+class TemplateResponseMixin(Generic[_TemplateResponse]):
     template_name: str | None
     template_engine: str | None
-    response_class: type[HttpResponse]
+    response_class: type[_TemplateResponse]
     content_type: str | None
     request: HttpRequest
-    def render_to_response(self, context: dict[str, Any], **response_kwargs: Any) -> HttpResponse: ...
+    def render_to_response(self, context: dict[str, Any], **response_kwargs: Any) -> _TemplateResponse: ...
     def get_template_names(self) -> list[str]: ...
 
-class TemplateView(TemplateResponseMixin, ContextMixin, View):
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
+class TemplateView(TemplateResponseMixin[_TemplateResponse], ContextMixin, View[_TemplateResponse]):
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> _TemplateResponse: ...
 
 class RedirectView(View):
     permanent: bool

--- a/django-stubs/views/generic/base.pyi
+++ b/django-stubs/views/generic/base.pyi
@@ -4,6 +4,7 @@ from typing import Any, Generic
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
+from django.template.response import TemplateResponse
 from django.utils.functional import _Getter
 from typing_extensions import TypeVar, override
 
@@ -29,17 +30,19 @@ class View(Generic[_ViewResponse]):
     def http_method_not_allowed(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
 
-class TemplateResponseMixin:
+_TemplateResponse = TypeVar("_TemplateResponse", bound=HttpResponse, default=TemplateResponse)
+
+class TemplateResponseMixin(Generic[_TemplateResponse]):
     template_name: str | None
     template_engine: str | None
-    response_class: type[HttpResponse]
+    response_class: type[_TemplateResponse]
     content_type: str | None
     request: HttpRequest
-    def render_to_response(self, context: dict[str, Any], **response_kwargs: Any) -> HttpResponse: ...
+    def render_to_response(self, context: dict[str, Any], **response_kwargs: Any) -> _TemplateResponse: ...
     def get_template_names(self) -> list[str]: ...
 
-class TemplateView(TemplateResponseMixin, ContextMixin, View):
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
+class TemplateView(TemplateResponseMixin[_TemplateResponse], ContextMixin, View[_TemplateResponse]):
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> _TemplateResponse: ...
 
 class RedirectView(View):
     permanent: bool

--- a/django-stubs/views/generic/base.pyi
+++ b/django-stubs/views/generic/base.pyi
@@ -1,11 +1,11 @@
 import logging
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, Generic
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
 from django.utils.functional import _Getter
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 logger: logging.Logger
 
@@ -13,7 +13,9 @@ class ContextMixin:
     extra_context: Mapping[str, Any] | None
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]: ...
 
-class View:
+_ViewResponse = TypeVar("_ViewResponse", bound=HttpResponseBase, default=HttpResponseBase)
+
+class View(Generic[_ViewResponse]):
     http_method_names: Sequence[str]
     request: HttpRequest
     args: Any
@@ -21,9 +23,9 @@ class View:
     def __init__(self, **kwargs: Any) -> None: ...
     view_is_async: _Getter[bool] | bool
     @classmethod
-    def as_view(cls: Any, **initkwargs: Any) -> Callable[..., HttpResponseBase]: ...
+    def as_view(cls: Any, **initkwargs: Any) -> Callable[..., _ViewResponse]: ...
     def setup(self, request: HttpRequest, *args: Any, **kwargs: Any) -> None: ...
-    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> _ViewResponse: ...
     def http_method_not_allowed(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
 

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -28,6 +28,7 @@ from django.forms.models import BaseModelForm, BaseModelFormSet, ModelChoiceFiel
 from django.utils.connection import BaseConnectionHandler, ConnectionProxy
 from django.utils.functional import classproperty
 from django.views import View
+from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -86,6 +87,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),
     MPGeneric(View),
+    MPGeneric(TemplateResponseMixin),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -27,6 +27,7 @@ from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseModelForm, BaseModelFormSet, ModelChoiceField, ModelFormOptions
 from django.utils.connection import BaseConnectionHandler, ConnectionProxy
 from django.utils.functional import classproperty
+from django.views import View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -84,6 +85,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(ExpressionWrapper),
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),
+    MPGeneric(View),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -28,6 +28,7 @@ from django.forms.models import BaseModelForm, BaseModelFormSet, ModelChoiceFiel
 from django.utils.connection import BaseConnectionHandler, ConnectionProxy
 from django.utils.functional import LazyObject, classproperty
 from django.views import View
+from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -91,6 +92,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),
     MPGeneric(View),
+    MPGeneric(TemplateResponseMixin),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -27,6 +27,7 @@ from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseModelForm, BaseModelFormSet, ModelChoiceField, ModelFormOptions
 from django.utils.connection import BaseConnectionHandler, ConnectionProxy
 from django.utils.functional import LazyObject, classproperty
+from django.views import View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -89,6 +90,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(Subquery),
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),
+    MPGeneric(View),
     # These types do have native `__class_getitem__` method since django 3.1:
     MPGeneric(QuerySet, (3, 1)),
     MPGeneric(BaseManager, (3, 1)),

--- a/tests/assert_type/views/test_base.py
+++ b/tests/assert_type/views/test_base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from django.template.response import TemplateResponse
+from django.test import RequestFactory
+from django.views.generic import TemplateView
+from typing_extensions import assert_type
+
+
+class MyTemplateView(TemplateView):
+    template_name = "template.html"
+
+
+request = RequestFactory().get("/")
+response = MyTemplateView.as_view()(request)
+assert_type(response, TemplateResponse)
+assert_type(response.rendered_content, str)

--- a/tests/typecheck/views/generic/test_template.yml
+++ b/tests/typecheck/views/generic/test_template.yml
@@ -14,3 +14,23 @@
         class MyTemplateView(TemplateView):
             template_name = "template.html"
             extra_context = MappingProxyType({})
+
+-   case: template_view_returns_template_response
+    main: |
+        from typing import reveal_type
+
+        from django.views.generic import TemplateView
+        from django.test import RequestFactory
+
+
+        class MyView(TemplateView):
+            template_name = "template.html"
+
+
+        rf = RequestFactory()
+        request = rf.get("/")
+        view = MyView.as_view()
+        response = view(request)
+
+        reveal_type(response)  # N: Revealed type is "django.template.response.TemplateResponse"
+        reveal_type(response.rendered_content)  # N: Revealed type is "builtins.str"

--- a/tests/typecheck/views/generic/test_template.yml
+++ b/tests/typecheck/views/generic/test_template.yml
@@ -14,23 +14,3 @@
         class MyTemplateView(TemplateView):
             template_name = "template.html"
             extra_context = MappingProxyType({})
-
--   case: template_view_returns_template_response
-    main: |
-        from typing import reveal_type
-
-        from django.views.generic import TemplateView
-        from django.test import RequestFactory
-
-
-        class MyView(TemplateView):
-            template_name = "template.html"
-
-
-        rf = RequestFactory()
-        request = rf.get("/")
-        view = MyView.as_view()
-        response = view(request)
-
-        reveal_type(response)  # N: Revealed type is "django.template.response.TemplateResponse"
-        reveal_type(response.rendered_content)  # N: Revealed type is "builtins.str"


### PR DESCRIPTION
This allows us to specify that the default response type for template
views is a `TemplateResponse`.

N.B. The `LogoutView` may return a response that is not a template
response (i.e. a redirect), so we annotate it as returning a less
specific type. We have not been more specific about exactly which types
it returns because doing so might require it to also become generic to
support subclasses that return different specific response types.

We could take this further and make more generic view subclasses generic,
but wanted to verify this approach with y'all before pushing too far ahead. 

## Related issues

Fixes #2873
