### PR TITLE
Update assertContains and assertNotContains signatures

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -94,7 +94,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertNotContains(
         self,
         response: HttpResponseBase,
-        text: bytes | int | _StrOrPromise,
+        text: bytes | int | _StrOrPromise,
         status_code: int = ...,
         msg_prefix: str = ...,
         html: bool = ...,

--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -85,7 +85,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertContains(
         self,
         response: HttpResponseBase,
-        text: bytes | int | str,
+        text: bytes | int | str | _StrOrPromise,
         count: int | None = ...,
         status_code: int = ...,
         msg_prefix: str = ...,
@@ -94,7 +94,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertNotContains(
         self,
         response: HttpResponseBase,
-        text: bytes | str,
+        text: bytes | int | str | _StrOrPromise,
         status_code: int = ...,
         msg_prefix: str = ...,
         html: bool = ...,

--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -85,7 +85,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertContains(
         self,
         response: HttpResponseBase,
-        text: bytes | int | str | _StrOrPromise,
+        text: bytes | int | _StrOrPromise,
         count: int | None = ...,
         status_code: int = ...,
         msg_prefix: str = ...,
@@ -94,7 +94,7 @@ class SimpleTestCase(unittest.TestCase):
     def assertNotContains(
         self,
         response: HttpResponseBase,
-        text: bytes | int | str | _StrOrPromise,
+        text: bytes | int | _StrOrPromise,
         status_code: int = ...,
         msg_prefix: str = ...,
         html: bool = ...,


### PR DESCRIPTION
Any text passed to assertContains and assertNotContains will be casted with `str`, see https://github.com/django/django/blob/a0323a0c44135c28134672e6e633e5f4a7a68d5d/django/test/testcases.py#L580-L581