### PR TITLE
Update middleware types

### DIFF
--- a/django-stubs/contrib/redirects/middleware.pyi
+++ b/django-stubs/contrib/redirects/middleware.pyi
@@ -1,10 +1,10 @@
-from typing import Any
+from typing import ClassVar
 
 from django.http.request import HttpRequest
-from django.http.response import HttpResponse
+from django.http.response import HttpResponse, HttpResponseBase, HttpResponseRedirectBase
 from django.utils.deprecation import MiddlewareMixin
 
 class RedirectFallbackMiddleware(MiddlewareMixin):
-    response_gone_class: Any
-    response_redirect_class: Any
+    response_gone_class: ClassVar[type[HttpResponseBase]]
+    response_redirect_class: ClassVar[type[HttpResponseRedirectBase]]
     def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse: ...

--- a/django-stubs/middleware/common.pyi
+++ b/django-stubs/middleware/common.pyi
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import ClassVar
 
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseBase, HttpResponsePermanentRedirect
+from django.http.response import HttpResponseBase, HttpResponsePermanentRedirect, HttpResponseRedirectBase
 from django.utils.deprecation import MiddlewareMixin
 
 class CommonMiddleware(MiddlewareMixin):
-    response_redirect_class: Any
+    response_redirect_class: ClassVar[type[HttpResponseRedirectBase]]
     def process_request(self, request: HttpRequest) -> HttpResponsePermanentRedirect | None: ...
     def should_redirect_with_slash(self, request: HttpRequest) -> bool: ...
     def get_full_path_with_slash(self, request: HttpRequest) -> str: ...

--- a/django-stubs/middleware/locale.pyi
+++ b/django-stubs/middleware/locale.pyi
@@ -1,10 +1,10 @@
-from typing import Any
+from typing import ClassVar
 
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseBase
+from django.http.response import HttpResponseBase, HttpResponseRedirectBase
 from django.utils.deprecation import MiddlewareMixin
 
 class LocaleMiddleware(MiddlewareMixin):
-    response_redirect_class: Any
+    response_redirect_class: ClassVar[type[HttpResponseRedirectBase]]
     def process_request(self, request: HttpRequest) -> None: ...
     def process_response(self, request: HttpRequest, response: HttpResponseBase) -> HttpResponseBase: ...

--- a/tests/assert_type/middleware/test_middleware.py
+++ b/tests/assert_type/middleware/test_middleware.py
@@ -1,0 +1,42 @@
+from django.contrib.redirects.middleware import RedirectFallbackMiddleware
+from django.http.response import (
+    FileResponse,
+    HttpResponse,
+    HttpResponseGone,
+    HttpResponsePermanentRedirect,
+    HttpResponseRedirect,
+    HttpResponseRedirectBase,
+)
+from django.middleware.common import CommonMiddleware
+from django.middleware.locale import LocaleMiddleware
+
+
+class CustomCommonMiddleware(CommonMiddleware):
+    response_redirect_class = HttpResponsePermanentRedirect
+
+
+class BrokenCustomCommonMiddleware(CommonMiddleware):
+    response_redirect_class = FileResponse  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+
+class CustomLocaleMiddleware(LocaleMiddleware):
+    response_redirect_class = HttpResponseRedirect
+
+
+class BrokenCustomLocaleMiddleware(CommonMiddleware):
+    response_redirect_class = FileResponse  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+
+class CustomRedirectFallbackMiddleware(RedirectFallbackMiddleware):
+    response_redirect_class = HttpResponseRedirect
+    response_gone_class = HttpResponseGone
+
+
+class CustomRedirectFallbackMiddleware2(RedirectFallbackMiddleware):
+    response_redirect_class = HttpResponseRedirectBase
+    response_gone_class = HttpResponse
+
+
+class BrokenCustomRedirectFallbackMiddleware(RedirectFallbackMiddleware):
+    response_redirect_class = HttpResponse  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    response_gone_class = 12  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]


### PR DESCRIPTION
# I have made things!
Narrow the types for:
- `CommonMiddleware`
- `LocaleMiddleware`
- `RedirectFallbackMiddleware`

Without that I was having `no-any-return` mypy issues when subclassing