### PR TITLE
Remove `str` from enum label types when we know for sure the labels are lazy

### DIFF
--- a/mypy_django_plugin/transformers/choices.py
+++ b/mypy_django_plugin/transformers/choices.py
@@ -1,4 +1,4 @@
-from enum import auto, Enum
+from enum import Enum, auto
 
 from mypy.nodes import MemberExpr, NameExpr, SuperExpr, TypeAlias, TypeInfo, Var
 from mypy.plugin import AttributeContext

--- a/mypy_django_plugin/transformers/choices.py
+++ b/mypy_django_plugin/transformers/choices.py
@@ -1,3 +1,5 @@
+from enum import auto, Enum
+
 from mypy.nodes import MemberExpr, NameExpr, SuperExpr, TypeAlias, TypeInfo, Var
 from mypy.plugin import AttributeContext
 from mypy.typeanal import make_optional_type
@@ -38,50 +40,69 @@ def _get_enum_members(info: TypeInfo) -> list[str]:
     ]
 
 
-def _has_lazy_label(node: TypeInfo) -> bool:
-    """
-    Check whether a choices type has any lazy strings for labels.
+class _LabelLaziness(Enum):
+    LAZY = auto()
+    NON_LAZY = auto()
+    MIXED = auto()
 
-    This is used to determine choices types that do not use lazy strings for labels such that a
-    more simple type can be used instead of the default in the stubs.
+    @classmethod
+    def make(cls, lazy: bool | None) -> "_LabelLaziness":
+        return cls.LAZY if lazy else cls.NON_LAZY
+
+
+def _is_lazy_string(ty: MypyType | None) -> bool:
+    proper_type = get_proper_type(ty)
+    return isinstance(proper_type, Instance) and proper_type.type.has_base(fullnames.STR_PROMISE_FULLNAME)
+
+
+def _is_lazy_member(node: TypeInfo, member_name: str) -> bool:
+    if (sym := node.get(member_name)) is None:
+        return False
+
+    _member_type = get_proper_type(sym.type)
+    if not isinstance(_member_type, TupleType):
+        # Member has auto-generated plain string label - enum.auto() or no explicit label.
+        return False
+
+    if _member_type.length() < 2:
+        # There need to be at least two items in the tuple.
+        return False
+
+    return _is_lazy_string(_member_type.items[-1])
+
+
+def _label_laziness(node: TypeInfo) -> _LabelLaziness:
+    """
+    Check whether a choices type has lazy strings for labels.
+
+    This is used to determine whether a choices type uses lazy strings or non-lazy string for
+    labels such that a more simple type can be used instead of the default in the stubs.
     """
     assert node.is_enum
 
     if (sym := node.get("__empty__")) is not None:
-        _empty_type = get_proper_type(sym.type)
-        if isinstance(_empty_type, Instance) and _empty_type.type.has_base(fullnames.STR_PROMISE_FULLNAME):
-            # If the empty label is lazy, then we don't need to check all the members.
-            return True
+        lazy = _is_lazy_string(sym.type)
+    else:
+        lazy = None
 
     # TODO: [mypy 1.14+] Use `node.enum_members` and remove `_get_enum_members()` backport.
     for member_name in _get_enum_members(node):
-        if (sym := node.get(member_name)) is None:
-            continue
+        member_lazy = _is_lazy_member(node, member_name)
+        if lazy is None:
+            lazy = member_lazy
+        elif lazy != member_lazy:
+            return _LabelLaziness.MIXED
 
-        _member_type = get_proper_type(sym.type)
-        if not isinstance(_member_type, TupleType):
-            # Member has auto-generated plain string label - enum.auto() or no explicit label.
-            continue
-
-        if _member_type.length() < 2:
-            # There need to be at least two items in the tuple.
-            continue
-
-        _label_type = get_proper_type(_member_type.items[-1])
-        if isinstance(_label_type, Instance) and _label_type.type.has_base(fullnames.STR_PROMISE_FULLNAME):
-            # If any member label is lazy, then we don't need to check the remaining members.
-            return True
-
-    return False
+    return _LabelLaziness.make(lazy)
 
 
-def _try_replace_label(typ: ProperType, has_lazy_label: bool) -> MypyType:
+def _try_replace_label(typ: ProperType, label_laziness: _LabelLaziness) -> MypyType:
     """
     Attempt to replace a label with a modified version.
 
-    If there are no lazy strings for labels, remove the lazy string type.
+    If there are no lazy strings for labels, remove the lazy string type, and vice-versa.
     """
-    if has_lazy_label:
+    if label_laziness is _LabelLaziness.MIXED:
         return typ
 
     if not isinstance(typ, UnionType):
@@ -91,7 +112,8 @@ def _try_replace_label(typ: ProperType, has_lazy_label: bool) -> MypyType:
     items = [
         t
         for t in map(get_proper_type, typ.items)
-        if isinstance(t, Instance) and not t.type.has_base(fullnames.STR_PROMISE_FULLNAME)
+        if isinstance(t, Instance)
+        and t.type.has_base(fullnames.STR_PROMISE_FULLNAME) == (label_laziness is _LabelLaziness.LAZY)
     ]
 
     # If we only have one item use that, otherwise make a new union.
@@ -208,13 +230,13 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
 
     # When `__empty__` is defined, the `.choices` and `.values` properties will include `None` for
     # the blank choice which is labelled by the value of `__empty__`.
-    has_empty_label = node.get("__empty__") is not None
+    empty_label = node.get("__empty__")
 
     # When `__empty__` is not a lazy string and the labels on all members are not lazy strings, the
     # label can be simplified to only be a simple string type. This keeps the benefits of accurate
     # typing when the lazy labels are being used, but reduces the pain of having to manage a union
     # of a simple and lazy string type where it's not necessary.
-    has_lazy_label = _has_lazy_label(node)
+    label_laziness = _label_laziness(node)
 
     if (
         name == "choices"
@@ -228,8 +250,8 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
             value_arg, label_arg = choice_arg.items
             label_arg = get_proper_type(label_arg)
             value_arg = get_proper_type(value_arg)
-            new_label_arg = _try_replace_label(label_arg, has_lazy_label)
-            new_value_arg = _try_replace_value(value_arg, base_type, has_empty_label)
+            new_label_arg = _try_replace_label(label_arg, label_laziness)
+            new_value_arg = _try_replace_value(value_arg, base_type, empty_label is not None)
             if new_label_arg is not label_arg or new_value_arg is not value_arg:
                 new_choice_arg = choice_arg.copy_modified(items=[new_value_arg, new_label_arg])
                 return default_attr_type.copy_modified(args=[new_choice_arg])
@@ -241,7 +263,7 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
         and len(default_attr_type.args) == 1
     ):
         label_arg = get_proper_type(default_attr_type.args[0])
-        new_label_arg = _try_replace_label(label_arg, has_lazy_label)
+        new_label_arg = _try_replace_label(label_arg, label_laziness)
         if new_label_arg is not label_arg:
             return default_attr_type.copy_modified(args=[new_label_arg])
 
@@ -252,12 +274,15 @@ def transform_into_proper_attr_type(ctx: AttributeContext) -> MypyType:
         and len(default_attr_type.args) == 1
     ):
         value_arg = get_proper_type(default_attr_type.args[0])
-        new_value_arg = _try_replace_value(value_arg, base_type, has_empty_label)
+        new_value_arg = _try_replace_value(value_arg, base_type, empty_label is not None)
         if new_value_arg is not value_arg:
             return default_attr_type.copy_modified(args=[new_value_arg])
 
-    elif name in ("__empty__", "label"):
-        return _try_replace_label(default_attr_type, has_lazy_label)
+    elif name == "label":
+        return _try_replace_label(default_attr_type, label_laziness)
+
+    elif name == "__empty__" and empty_label is not None:
+        return _try_replace_label(default_attr_type, _LabelLaziness.make(_is_lazy_string(empty_label.type)))
 
     elif name == "value":
         # Pass in `False` because `.value` will never return `None`.

--- a/tests/assert_type/db/models/test_enums.py
+++ b/tests/assert_type/db/models/test_enums.py
@@ -2,7 +2,7 @@ import enum
 from typing import Any, Literal, TypeVar
 
 from django.db.models import Choices, IntegerChoices, Model, TextChoices
-from django.utils.functional import _StrOrPromise
+from django.utils.functional import _StrOrPromise, _StrPromise
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import assert_type
 
@@ -135,23 +135,23 @@ class DeckModel(Model):
 
 # Assertions for an integer choices type that uses a lazy translatable string for all labels.
 assert_type(Suit.names, list[str])
-assert_type(Suit.labels, list[_StrOrPromise])
+assert_type(Suit.labels, list[_StrPromise])  # pyright: ignore[reportAssertTypeFailure]
 assert_type(Suit.values, list[int])
-assert_type(Suit.choices, list[tuple[int, _StrOrPromise]])
+assert_type(Suit.choices, list[tuple[int, _StrPromise]])  # pyright: ignore[reportAssertTypeFailure]
 assert_type(Suit.CLUB, Literal[Suit.CLUB])
 assert_type(Suit.CLUB.name, Literal["CLUB"])
-assert_type(Suit.CLUB.label, _StrOrPromise)
+assert_type(Suit.CLUB.label, _StrPromise)  # pyright: ignore[reportAssertTypeFailure]
 assert_type(Suit.CLUB.value, int)
 assert_type(Suit.CLUB.do_not_call_in_templates, Literal[True])
 
 # Assertions for a text choices type that uses a lazy translatable string for all labels.
 assert_type(YearInSchool.names, list[str])
-assert_type(YearInSchool.labels, list[_StrOrPromise])
+assert_type(YearInSchool.labels, list[_StrPromise])  # pyright: ignore[reportAssertTypeFailure]
 assert_type(YearInSchool.values, list[str])
-assert_type(YearInSchool.choices, list[tuple[str, _StrOrPromise]])
+assert_type(YearInSchool.choices, list[tuple[str, _StrPromise]])  # pyright: ignore[reportAssertTypeFailure]
 assert_type(YearInSchool.SENIOR, Literal[YearInSchool.SENIOR])
 assert_type(YearInSchool.SENIOR.name, Literal["SENIOR"])
-assert_type(YearInSchool.SENIOR.label, _StrOrPromise)
+assert_type(YearInSchool.SENIOR.label, _StrPromise)  # pyright: ignore[reportAssertTypeFailure]
 assert_type(YearInSchool.SENIOR.value, str)
 assert_type(YearInSchool.SENIOR.do_not_call_in_templates, Literal[True])
 
@@ -166,7 +166,7 @@ assert_type(Vehicle.CAR.name, Literal["CAR"])
 assert_type(Vehicle.CAR.label, _StrOrPromise)
 assert_type(Vehicle.CAR.value, int)
 assert_type(Vehicle.CAR.do_not_call_in_templates, Literal[True])
-assert_type(Vehicle.__empty__, _StrOrPromise)
+assert_type(Vehicle.__empty__, _StrPromise)  # pyright: ignore[reportAssertTypeFailure]
 
 # Assertions for an text choices type that defines `__empty__` and uses plain strings for all labels.
 # Note: Suppress errors from pyright as the mypy plugin handles making types optional.
@@ -289,6 +289,6 @@ assert_type([member.value for choices in x3 for member in choices], list[Any])
 
 
 # Assertions for choices objects defined and aliased in a model.
-assert_type(DeckModel.Suit.choices, list[tuple[int, _StrOrPromise]])
-assert_type(DeckModel.House.choices, list[tuple[int, _StrOrPromise]])
+assert_type(DeckModel.Suit.choices, list[tuple[int, _StrPromise]])  # pyright: ignore[reportAssertTypeFailure]
+assert_type(DeckModel.House.choices, list[tuple[int, _StrPromise]])  # pyright: ignore[reportAssertTypeFailure]
 assert_type(DeckModel.Joker.choices, list[tuple[str, str]])  # pyright: ignore[reportAssertTypeFailure]


### PR DESCRIPTION
# I have made things!

Improves the mypy plugin to drop `str` from the types of labels created via `gettext_lazy`.

Instead of calculating and passing around a `bool` indicating whether an enum has any lazy label, the code now calculates a `_LabelLaziness` enum with three members - `LAZY`, `NON_LAZY`, and `MIXED` - and drops `str` from the label type for `_LabelLaziness.LAZY`.

## Related issues

Closes https://github.com/typeddjango/django-stubs/issues/2887
