### PR TITLE
CI: Only run branch tests on Renovate branches where it's needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-      - "renovate/**"
+      # Renovate "automerge" branches -- there is no PR, so branch tests are used instead
+      - "renovate/lock-file-maintenance"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Follow-up to https://github.com/typeddjango/django-stubs/pull/2893#discussion_r2517081578 -- prevent unnecessary test runs in Renovate branches.

Currently only "lock file maintenace" has automerge enabled, other Renovate branches will use PR tests not branch tests.
