### PR TITLE
fix: in db.models make required_db_vendor str

### DIFF
--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Generic, TypeAlias, TypeVar, overload
 
 from django.apps.config import AppConfig
 from django.apps.registry import Apps
@@ -64,7 +64,7 @@ class Options(Generic[_M]):
     order_with_respect_to: str | None
     db_tablespace: str
     required_db_features: _ListOrTuple[str]
-    required_db_vendor: Literal["sqlite", "postgresql", "mysql", "oracle"] | None
+    required_db_vendor: str | None
     meta: type | None
     pk: Field
     auto_field: AutoField | None

--- a/ext/django_stubs_ext/db/models/__init__.py
+++ b/ext/django_stubs_ext/db/models/__init__.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import ClassVar, Literal
+    from typing import ClassVar
 
     from django.db.models import BaseConstraint, Index, OrderBy
     from django.utils.datastructures import _ListOrTuple
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         default_permissions: ClassVar[Sequence[str]]  # default: ("add", "change", "delete", "view")
         proxy: ClassVar[bool]  # default: False
         required_db_features: ClassVar[_ListOrTuple[str]]
-        required_db_vendor: ClassVar[Literal["sqlite", "postgresql", "mysql", "oracle"]]
+        required_db_vendor: ClassVar[str]
         select_on_save: ClassVar[bool]  # default: False
         indexes: ClassVar[_ListOrTuple[Index]]
         unique_together: ClassVar[Sequence[Sequence[str]]]


### PR DESCRIPTION
Spport 3rd party vendors like Snowflake and [others](https://djangopackages.org/grids/g/database-backends/).

Removes the need to ignore the line in model `Meta` (typed) and when comparing the field.
