### PR TITLE
fix: allow `EmailMultiAlternatives` in `outbox`

### DIFF
--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -50,7 +50,7 @@ def mail_managers(
     html_message: str | None = None,
 ) -> None: ...
 
-outbox: list[EmailMessage]
+outbox: list[EmailMessage | EmailMultiAlternatives]
 
 __all__ = [
     "DEFAULT_ATTACHMENT_MIME_TYPE",

--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -50,7 +50,7 @@ def mail_managers(
     html_message: str | None = None,
 ) -> None: ...
 
-outbox: list[EmailMessage | EmailMultiAlternatives]
+outbox: Sequence[EmailMessage | EmailMultiAlternatives]
 
 __all__ = [
     "DEFAULT_ATTACHMENT_MIME_TYPE",

--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, MutableSequence, Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from django.utils.functional import _StrOrPromise
@@ -50,7 +50,7 @@ def mail_managers(
     html_message: str | None = None,
 ) -> None: ...
 
-outbox: MutableSequence[EmailMessage | EmailMultiAlternatives]
+outbox: list[EmailMessage | EmailMultiAlternatives]
 
 __all__ = [
     "DEFAULT_ATTACHMENT_MIME_TYPE",

--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, MutableSequence, Sequence
 from typing import Any
 
 from django.utils.functional import _StrOrPromise
@@ -50,7 +50,7 @@ def mail_managers(
     html_message: str | None = None,
 ) -> None: ...
 
-outbox: Sequence[EmailMessage | EmailMultiAlternatives]
+outbox: MutableSequence[EmailMessage | EmailMultiAlternatives]
 
 __all__ = [
     "DEFAULT_ATTACHMENT_MIME_TYPE",


### PR DESCRIPTION
According to the [Django docs on sending email](https://docs.djangoproject.com/en/5.2/topics/email/#in-memory-backend) the `outbox` attribute is:

> a list with an `EmailMessage` instance for each message that would be sent.

When you send single-message emails, they are direct instances of `EmailMessage`. When the emails are multipart, they are instances of `EmailMultiAlternatives`. While `EmailMultiAlternatives` inherits from `EmailMessage`, declaring `outbox` as `list[EmailMessage` is only partially correct, because the [`EmailMultiAlternatives`](https://docs.djangoproject.com/en/5.2/topics/email/#django.core.mail.EmailMultiAlternatives) introduces some properties and methods of its own, such as `alternatives`. If you access any of them, the type checker will complain. I think, thus, the correct type is:

```python
outbox: list[EmailMessage | EmailMultiAlternatives]
```