### PR TITLE
Fix dispatch_uid type: str -> _AnyHashable

### DIFF
--- a/django-stubs/db/models/signals.pyi
+++ b/django-stubs/db/models/signals.pyi
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from django.apps.registry import Apps
 from django.db.models.base import Model
 from django.dispatch import Signal
+from django.dispatch.dispatcher import _AnyHashable
 
 class_prepared: Signal
 
@@ -12,14 +13,14 @@ class ModelSignal(Signal):
         receiver: Callable,
         sender: type[Model] | str | None = None,
         weak: bool = True,
-        dispatch_uid: str | None = None,
+        dispatch_uid: _AnyHashable | None = None,
         apps: Apps | None = None,
     ) -> None: ...
     def disconnect(  # type: ignore[override]
         self,
         receiver: Callable | None = None,
         sender: type[Model] | str | None = None,
-        dispatch_uid: str | None = None,
+        dispatch_uid: _AnyHashable | None = None,
         apps: Apps | None = None,
     ) -> bool | None: ...
 

--- a/django-stubs/dispatch/dispatcher.pyi
+++ b/django-stubs/dispatch/dispatcher.pyi
@@ -1,7 +1,9 @@
 import threading
-from collections.abc import Callable, Hashable, MutableMapping
+from collections.abc import Callable, MutableMapping
 from logging import Logger
-from typing import Any, TypeVar
+from typing import Any, TypeAlias, TypeVar
+
+_AnyHashable: TypeAlias = Any
 
 NONE_ID: int
 NO_RECEIVERS: Any
@@ -16,10 +18,14 @@ class Signal:
 
     def __init__(self, use_caching: bool = False) -> None: ...
     def connect(
-        self, receiver: Callable, sender: object | None = None, weak: bool = True, dispatch_uid: Hashable | None = None
+        self,
+        receiver: Callable,
+        sender: object | None = None,
+        weak: bool = True,
+        dispatch_uid: _AnyHashable | None = None,
     ) -> None: ...
     def disconnect(
-        self, receiver: Callable | None = None, sender: object | None = None, dispatch_uid: str | None = None
+        self, receiver: Callable | None = None, sender: object | None = None, dispatch_uid: _AnyHashable | None = None
     ) -> bool: ...
     def has_listeners(self, sender: Any | None = None) -> bool: ...
     def send(self, sender: Any, **named: Any) -> list[tuple[Callable, str | None]]: ...
@@ -35,6 +41,6 @@ def receiver(
     *,
     sender: object | None = ...,
     weak: bool = ...,
-    dispatch_uid: Hashable | None = ...,
+    dispatch_uid: _AnyHashable | None = ...,
     **named: Any,
 ) -> Callable[[_F], _F]: ...


### PR DESCRIPTION
# I have made things!

Django accepts any hashable value for `dispatch_uid` (used as dict key).


## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
