### PR TITLE
Django 6.0: Add `databases=` parameter to `check_generic_foreign_keys`, `check_model_name_lengths`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .pytest_cache/
 .ruff_cache/
 .venv/
+venv/
 __pycache__/
 django-source/
 out/

--- a/django-stubs/contrib/contenttypes/checks.pyi
+++ b/django-stubs/contrib/contenttypes/checks.pyi
@@ -5,8 +5,14 @@ from django.apps.config import AppConfig
 from django.core.checks.messages import CheckMessage
 
 def check_generic_foreign_keys(
-    app_configs: Sequence[AppConfig] | None = None, **kwargs: Any
+    app_configs: Sequence[AppConfig] | None,
+      *,
+      databases: Sequence[str] | None = ...,
+      **kwargs: Any
 ) -> Sequence[CheckMessage]: ...
 def check_model_name_lengths(
-    app_configs: Sequence[AppConfig] | None = None, **kwargs: Any
+    app_configs: Sequence[AppConfig] | None,
+        *,
+        databases: Sequence[str] | None = ...,
+      **kwargs: Any
 ) -> Sequence[CheckMessage]: ...

--- a/django-stubs/contrib/contenttypes/checks.pyi
+++ b/django-stubs/contrib/contenttypes/checks.pyi
@@ -5,14 +5,8 @@ from django.apps.config import AppConfig
 from django.core.checks.messages import CheckMessage
 
 def check_generic_foreign_keys(
-    app_configs: Sequence[AppConfig] | None,
-      *,
-      databases: Sequence[str] | None = ...,
-      **kwargs: Any
+    app_configs: Sequence[AppConfig] | None, *, databases: Sequence[str] | None = ..., **kwargs: Any
 ) -> Sequence[CheckMessage]: ...
 def check_model_name_lengths(
-    app_configs: Sequence[AppConfig] | None,
-        *,
-        databases: Sequence[str] | None = ...,
-      **kwargs: Any
+    app_configs: Sequence[AppConfig] | None, *, databases: Sequence[str] | None = ..., **kwargs: Any
 ) -> Sequence[CheckMessage]: ...

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -21,8 +21,6 @@ django.contrib.auth.management.RenamePermission
 django.contrib.auth.management.rename_permissions
 django.contrib.auth.templatetags
 django.contrib.auth.templatetags.auth
-django.contrib.contenttypes.checks.check_generic_foreign_keys
-django.contrib.contenttypes.checks.check_model_name_lengths
 django.contrib.contenttypes.fields.GenericForeignKey.ct_field_attname
 django.contrib.contenttypes.fields.GenericForeignKey.get_prefetch_queryset
 django.contrib.contenttypes.management.get_contenttypes_and_models


### PR DESCRIPTION
I added stubs for check_generic_foreign_keys and check_model_name_lengths functions in contrib/contenttypes/checks.pyi
#2944 
