### PR TITLE
CI: Downgrade to Python 3.10 for 'test-older-django'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
       {
           "matchPackageNames": ["mypy"],
           "rangeStrategy": "widen"
+      },
+      {
+          "matchPackageNames": ["python"],
+          "allowedVersions": "3.10"
       }
   ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          # NOTE: Keep renovate.json python "allowedVersions" in sync
           python-version: '3.10'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: 3.10
 
       - name: Install dependencies
         run: uv sync --no-dev --group tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: uv sync --no-dev --group tests


### PR DESCRIPTION
As discussed in https://github.com/typeddjango/django-stubs/pull/2901#discussion_r2517483959 -- let's try if it works.
