### PR TITLE
Add stubs for django.contrib.postgres.search.Lexeme and CombinedLexeme

### DIFF
--- a/django-stubs/contrib/postgres/search.pyi
+++ b/django-stubs/contrib/postgres/search.pyi
@@ -2,7 +2,7 @@ from typing import Any, ClassVar, TypeAlias
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Expression, Field, FloatField, TextField
-from django.db.models.expressions import Combinable, CombinedExpression, Func
+from django.db.models.expressions import Combinable, CombinedExpression, Func, Value
 from django.db.models.lookups import Lookup
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import Self
@@ -142,3 +142,16 @@ class TrigramWordDistance(TrigramWordBase): ...
 class TrigramStrictWordDistance(TrigramWordBase): ...
 class TrigramWordSimilarity(TrigramWordBase): ...
 class TrigramStrictWordSimilarity(TrigramWordBase): ...
+
+class Lexeme(Value):
+    def __init__(
+        self,
+        value: Any,
+        output_field: Any | None = None,
+        *,
+        invert: bool = False,
+        prefix: bool = False,
+        weight: Any | None = None,
+    ) -> None: ...
+
+class CombinedLexeme(CombinedExpression): ...

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -75,8 +75,6 @@ django.contrib.postgres.operations.CryptoExtension.__init__
 django.contrib.postgres.operations.HStoreExtension.__init__
 django.contrib.postgres.operations.TrigramExtension.__init__
 django.contrib.postgres.operations.UnaccentExtension.__init__
-django.contrib.postgres.search.CombinedLexeme
-django.contrib.postgres.search.Lexeme
 django.contrib.postgres.search.LexemeCombinable
 django.contrib.postgres.search.multiple_spaces_re
 django.contrib.postgres.search.normalize_spaces


### PR DESCRIPTION
`LexemeCombinable` is a bit more difficult to implement because it's imcompatible with `Combinable`, as it would return a `CombinedLexeme` instead of a `Combinable` for the relevant dunder methods. Not sure how to handle that.