### PR TITLE
Django 6.0: update ADMINS and MANAGERS setting type

### DIFF
--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -10,7 +10,9 @@ from typing_extensions import NotRequired
 
 from django_stubs_ext.settings import TemplatesSetting
 
-_Admins: TypeAlias = list[tuple[str, str]]
+# Note: the tuple element format for ADMINS or MANAGERS is deprecated. Use a
+# list of strings instead.
+_Admins: TypeAlias = list[str] | list[tuple[str, str]]
 
 ####################
 # CORE             #


### PR DESCRIPTION
From the Django 6.0 release notes:

> Setting [ADMINS](https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-ADMINS) or [MANAGERS](https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-MANAGERS) to a list of (name, address) tuples is deprecated. Set to a list of email address strings instead. Django never used the name portion. To include a name, format the address string as '"Name" \<address\>' or use Python’s [email.utils.formataddr()](https://docs.python.org/3/library/email.utils.html#email.utils.formataddr).

https://docs.djangoproject.com/en/dev/releases/6.0/#id2