### PR TITLE
Django 6.0: require kwargs for optional parameters in mail functions

### DIFF
--- a/django-stubs/core/mail/__init__.pyi
+++ b/django-stubs/core/mail/__init__.pyi
@@ -16,12 +16,13 @@ from .message import make_msgid as make_msgid
 from .utils import DNS_NAME as DNS_NAME
 from .utils import CachedDnsName as CachedDnsName
 
-def get_connection(backend: str | None = None, fail_silently: bool = False, **kwds: Any) -> Any: ...
+def get_connection(backend: str | None = None, *, fail_silently: bool = False, **kwds: Any) -> Any: ...
 def send_mail(
     subject: _StrOrPromise,
     message: _StrOrPromise,
     from_email: str | None,
     recipient_list: Sequence[str],
+    *,
     fail_silently: bool = False,
     auth_user: str | None = None,
     auth_password: str | None = None,
@@ -30,6 +31,7 @@ def send_mail(
 ) -> int: ...
 def send_mass_mail(
     datatuple: Iterable[tuple[str, str, str | None, list[str]]],
+    *,
     fail_silently: bool = False,
     auth_user: str | None = None,
     auth_password: str | None = None,
@@ -38,6 +40,7 @@ def send_mass_mail(
 def mail_admins(
     subject: _StrOrPromise,
     message: _StrOrPromise,
+    *,
     fail_silently: bool = False,
     connection: Any | None = None,
     html_message: str | None = None,
@@ -45,6 +48,7 @@ def mail_admins(
 def mail_managers(
     subject: _StrOrPromise,
     message: _StrOrPromise,
+    *,
     fail_silently: bool = False,
     connection: Any | None = None,
     html_message: str | None = None,

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -88,14 +88,9 @@ django.core.mail.EmailMessage.__init__
 django.core.mail.EmailMessage.message
 django.core.mail.EmailMultiAlternatives.__init__
 django.core.mail.backends.smtp.EmailBackend.prep_address
-django.core.mail.get_connection
-django.core.mail.mail_admins
-django.core.mail.mail_managers
 django.core.mail.message.EmailMessage.__init__
 django.core.mail.message.EmailMessage.message
 django.core.mail.message.EmailMultiAlternatives.__init__
-django.core.mail.send_mail
-django.core.mail.send_mass_mail
 django.core.paginator.AsyncPage
 django.core.paginator.AsyncPaginator
 django.core.paginator.BasePaginator


### PR DESCRIPTION
From the Django 6.0 release notes:

> All optional parameters (fail_silently and later) must be passed as keyword arguments to [get_connection()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.get_connection), [mail_admins()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.mail_admins), [mail_managers()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.mail_managers), [send_mail()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.send_mail), and [send_mass_mail()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.send_mass_mail).

https://docs.djangoproject.com/en/dev/releases/6.0/#positional-arguments-in-django-core-mail-apis