### PR TITLE
Django 6.0: support passing MIMEPart object to EmailMessage.attach

### DIFF
--- a/django-stubs/core/mail/message.pyi
+++ b/django-stubs/core/mail/message.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from email.message import Message
+from email.message import Message, MIMEPart
 from email.mime.base import MIMEBase
 from email.mime.message import MIMEMessage
 from email.mime.multipart import MIMEMultipart
@@ -99,6 +99,8 @@ class EmailMessage:
     def attach(
         self, filename: str | None = None, content: _AttachmentContent | None = None, mimetype: str | None = None
     ) -> None: ...
+    @overload
+    def attach(self, filename: MIMEPart) -> None: ...
     def attach_file(self, path: str, mimetype: str | None = None) -> None: ...
 
 class EmailMultiAlternatives(EmailMessage):


### PR DESCRIPTION
From the Django 6.0 release notes:

> [EmailMessage.attach()](https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.EmailMessage.attach) now accepts a [MIMEPart](https://docs.python.org/3/library/email.message.html#email.message.MIMEPart) object from Python’s modern email API.

https://docs.djangoproject.com/en/dev/releases/6.0/#email