### PR TITLE
fix: django.contrib.gis.utils.LayerMapping attribute types

### DIFF
--- a/django-stubs/contrib/gis/utils/layermapping.pyi
+++ b/django-stubs/contrib/gis/utils/layermapping.pyi
@@ -65,9 +65,9 @@ class LayerMapping:
     def save(
         self,
         verbose: bool = ...,
-        fid_range: bool = ...,
-        step: bool = ...,
-        progress: bool = ...,
+        fid_range: bool | tuple[int, int] | list[int] | slice = ...,
+        step: bool | int = ...,
+        progress: bool | int = ...,
         silent: bool = ...,
         stream: _Writer = ...,
         strict: bool = ...,


### PR DESCRIPTION
fid_range, step and progress allow more types than bool

To allow the correct usage of LayerMapping.save I extended the type definition of the attributes, according to the django source code and docstring.

https://github.com/django/django/blob/main/django/contrib/gis/utils/layermapping.py#L559