### PR TITLE
Allow plain `Form` in `DeleteView` type parameters

### DIFF
--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -66,9 +66,9 @@ class DeletionMixin(Generic[_M]):
     def delete(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def get_success_url(self) -> str: ...
 
-class BaseDeleteView(DeletionMixin[_M], FormMixin[_ModelFormT], BaseDetailView[_M], Generic[_M, _ModelFormT]):
+class BaseDeleteView(DeletionMixin[_M], FormMixin[_FormT], BaseDetailView[_M], Generic[_M, _FormT]):
     object: _M
 
-class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView[_M, _ModelFormT], Generic[_M, _ModelFormT]):
+class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView[_M, _FormT], Generic[_M, _FormT]):
     object: _M
     template_name_suffix: str

--- a/tests/assert_type/views/test_generic.py
+++ b/tests/assert_type/views/test_generic.py
@@ -1,5 +1,7 @@
+from django import forms
 from django.db import models
 from django.views.generic.detail import SingleObjectMixin
+from django.views.generic.edit import DeleteView
 from django.views.generic.list import ListView
 from typing_extensions import assert_type
 
@@ -26,3 +28,14 @@ assert_type(list_view.queryset, models.QuerySet[MyModel, MyModel] | None)
 assert_type(list_view.get_context_object_name(models.QuerySet[MyModel]()), str)
 assert_type(list_view.get_context_object_name(MyModel()), str | None)
 assert_type(list_view.get_context_object_name(1), str | None)
+
+
+class ConfirmForm(forms.Form): ...
+
+
+class MyDeleteView(DeleteView[MyModel, ConfirmForm]): ...
+
+
+delete_view = MyDeleteView()
+assert_type(delete_view.get_form_class(), type[ConfirmForm])
+assert_type(delete_view.get_form(), ConfirmForm)

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -96,27 +96,3 @@
 
                 class Article(models.Model):
                     pass
-
--   case: delete_view_with_plain_form
-    main: |
-        from typing_extensions import reveal_type
-        from django.views.generic.edit import DeleteView
-        from django import forms
-        from myapp.models import Article
-
-        class ConfirmForm(forms.Form):
-            pass
-
-        class MyDeleteView(DeleteView[Article, ConfirmForm]):
-            def some(self) -> None:
-                reveal_type(self.get_form_class())  # N: Revealed type is "type[main.ConfirmForm]"
-    installed_apps:
-        - myapp
-    files:
-        -   path: myapp/__init__.py
-        -   path: myapp/models.py
-            content: |
-                from django.db import models
-
-                class Article(models.Model):
-                    pass

--- a/tests/typecheck/views/generic/test_edit.yml
+++ b/tests/typecheck/views/generic/test_edit.yml
@@ -96,3 +96,27 @@
 
                 class Article(models.Model):
                     pass
+
+-   case: delete_view_with_plain_form
+    main: |
+        from typing_extensions import reveal_type
+        from django.views.generic.edit import DeleteView
+        from django import forms
+        from myapp.models import Article
+
+        class ConfirmForm(forms.Form):
+            pass
+
+        class MyDeleteView(DeleteView[Article, ConfirmForm]):
+            def some(self) -> None:
+                reveal_type(self.get_form_class())  # N: Revealed type is "type[main.ConfirmForm]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Article(models.Model):
+                    pass


### PR DESCRIPTION
## PR Summary
`DeleteView` and `BaseDeleteView` were incorrectly typed to only accept `ModelForm` subclasses. Django's actual implementation sets `form_class = Form` by default (since Django 4.0) because delete views use forms for confirmation, not for saving model data. This change relaxes the type parameter from `_ModelFormT` to `_FormT`, matching Django's documented behavior while remaining backward compatible with ModelForm usage.

Closes #2777.