### PR TITLE
Django 6.0: add support for AnyValue aggregate

### DIFF
--- a/django-stubs/db/models/__init__.pyi
+++ b/django-stubs/db/models/__init__.pyi
@@ -3,6 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist as ObjectDoesNotExist
 from . import lookups as lookups
 from . import signals as signals
 from .aggregates import Aggregate as Aggregate
+from .aggregates import AnyValue as AnyValue
 from .aggregates import Avg as Avg
 from .aggregates import Count as Count
 from .aggregates import Max as Max
@@ -115,6 +116,7 @@ __all__ = [
     "SET_DEFAULT",
     "SET_NULL",
     "Aggregate",
+    "AnyValue",
     "AutoField",
     "Avg",
     "BaseConstraint",

--- a/django-stubs/db/models/aggregates.pyi
+++ b/django-stubs/db/models/aggregates.pyi
@@ -1,10 +1,12 @@
 from collections.abc import Sequence
 from typing import Any, ClassVar
 
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.expressions import Combinable, Func
 from django.db.models.fields import IntegerField
 from django.db.models.functions.mixins import FixDurationInputMixin, NumericOutputFieldMixin
 from django.db.models.query import _OrderByFieldName
+from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 
 class Aggregate(Func):
     filter_template: str
@@ -21,6 +23,11 @@ class Aggregate(Func):
         order_by: Sequence[_OrderByFieldName] | None = None,
         **extra: Any,
     ) -> None: ...
+
+class AnyValue(Aggregate):
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
 
 class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate): ...
 

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -21,7 +21,6 @@ django.contrib.contenttypes.fields.GenericForeignKey.get_prefetch_queryset
 django.contrib.contenttypes.management.get_contenttypes_and_models
 django.contrib.gis.admin.AdminSite.password_change_form
 django.contrib.gis.admin.ModelAdmin.log_deletion
-django.contrib.gis.db.models.AnyValue
 django.contrib.gis.db.models.BaseConstraint.__init__
 django.contrib.gis.db.models.BaseConstraint.check
 django.contrib.gis.db.models.CheckConstraint.__init__
@@ -125,7 +124,6 @@ django.db.migrations.operations.base.Operation.__replace__
 django.db.migrations.serializer.DeconstructableSerializer
 django.db.migrations.serializer.DeconstructibleSerializer
 django.db.migrations.serializer.ZoneInfoSerializer
-django.db.models.AnyValue
 django.db.models.BaseConstraint.__init__
 django.db.models.BaseConstraint.check
 django.db.models.CheckConstraint.__init__
@@ -136,10 +134,8 @@ django.db.models.Index.check
 django.db.models.Model._do_update
 django.db.models.Prefetch.get_current_queryset
 django.db.models.UniqueConstraint.check
-django.db.models.__all__
 django.db.models.StringAgg.as_mysql
 django.db.models.StringAgg.as_oracle
-django.db.models.aggregates.AnyValue
 django.db.models.aggregates.StringAgg.as_mysql
 django.db.models.aggregates.StringAgg.as_oracle
 django.db.models.aggregates.__all__


### PR DESCRIPTION
From the Django 6.0 release notes:

> The new [AnyValue](https://docs.djangoproject.com/en/dev/ref/models/querysets/#django.db.models.AnyValue) aggregate returns an arbitrary value from the non-null input values. This is supported on SQLite, MySQL, Oracle, and PostgreSQL 16+.

See https://docs.djangoproject.com/en/dev/releases/6.0/#models