### PR TITLE
Django 6.0: update deprecation module

### DIFF
--- a/django-stubs/utils/deprecation.pyi
+++ b/django-stubs/utils/deprecation.pyi
@@ -1,14 +1,18 @@
-from collections.abc import Awaitable, Callable
-from typing import Any, ClassVar, Protocol, TypeAlias, type_check_only
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, ClassVar, Protocol, TypeAlias, TypeVar, type_check_only
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
-class RemovedInDjango60Warning(DeprecationWarning): ...
-class RemovedInDjango61Warning(PendingDeprecationWarning): ...
+_C = TypeVar("_C", bound=Callable[..., Any])
 
-RemovedInNextVersionWarning: TypeAlias = RemovedInDjango60Warning
-RemovedAfterNextVersionWarning: TypeAlias = RemovedInDjango61Warning
+def django_file_prefixes() -> tuple[str, ...]: ...
+
+class RemovedInDjango61Warning(DeprecationWarning): ...
+class RemovedInDjango70Warning(PendingDeprecationWarning): ...
+
+RemovedInNextVersionWarning: TypeAlias = RemovedInDjango61Warning
+RemovedAfterNextVersionWarning: TypeAlias = RemovedInDjango70Warning
 
 class warn_about_renamed_method:
     class_name: str
@@ -24,6 +28,7 @@ class RenameMethodsBase(type):
     renamed_methods: Any
     def __new__(cls, name: Any, bases: Any, attrs: Any) -> type: ...
 
+def deprecate_posargs(deprecation_warning: type[Warning], remappable_names: Sequence[str], /) -> Callable[[_C], _C]: ...
 @type_check_only
 class _GetResponseCallable(Protocol):
     def __call__(self, request: HttpRequest, /) -> HttpResponseBase: ...

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -140,10 +140,6 @@ django.test.selenium.SeleniumTestCase.get_browser_logs
 django.test.testcases._AssertTemplateUsedContext.rendered_template_names
 django.utils.copy
 django.utils.datastructures.DeferredSubDict
-django.utils.deprecation.RemovedInDjango60Warning
-django.utils.deprecation.RemovedInDjango70Warning
-django.utils.deprecation.deprecate_posargs
-django.utils.deprecation.django_file_prefixes
 django.utils.http.MAX_HEADER_LENGTH
 django.utils.http.parse_header_parameters
 django.utils.inspect.is_module_level_function


### PR DESCRIPTION
## PR Summary
This PR syncs the deprecation module with Django 6.0. The `RemovedInDjango60Warning` class was removed and replaced with `RemovedInDjango61Warning` (now a `DeprecationWarning`) and `RemovedInDjango70Warning`. Also adds the new `deprecate_posargs` decorator for deprecating positional arguments and the `django_file_prefixes` helper function.