### PR TITLE
docs: Document system dependencies and clarify tool usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,30 @@ As a first step you will need to fork this repository and clone your fork locall
 In order to be able to continuously sync your fork with the origin repository's master branch, you will need to set up an upstream master.
 To do so follow this [official github guide](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
 
+### System Dependencies
+
+The test suite requires some system libraries that Django itself treats as optional.
+This project depends on `mysqlclient`, which needs MySQL/MariaDB C client libraries to build.
+Install them for your platform following the
+[mysqlclient install guide](https://github.com/PyMySQL/mysqlclient#install).
+For Debian/Ubuntu, the [django-docker-box packages list](https://github.com/django/django-docker-box/blob/main/packages.txt)
+is also a useful reference.
+
+**GDAL and GEOS** are needed to pass all tests (2 GIS-related tests require them).
+See the Django documentation on
+[installing geospatial libraries](https://docs.djangoproject.com/en/stable/ref/contrib/gis/install/geolibs/).
+If you're not working on GIS-related stubs, you can skip GDAL/GEOS —
+the 2 failing tests won't affect other contributions.
+
+> **macOS Note:** Homebrew installs GDAL/GEOS to `/opt/homebrew` (Apple Silicon) or `/usr/local` (Intel),
+> which are not in the default library search path. The GIS tests may fail unless you create symlinks:
+>
+> ```bash
+> sudo mkdir -p /usr/local/lib
+> sudo ln -s /opt/homebrew/opt/gdal/lib/libgdal.dylib /usr/local/lib/libgdal.dylib
+> sudo ln -s /opt/homebrew/opt/geos/lib/libgeos_c.dylib /usr/local/lib/libgeos_c.dylib
+> ```
+
 ### Dependency Setup
 
 We use [uv](https://github.com/astral-sh/uv) to manage our dev dependencies.


### PR DESCRIPTION
## Summary

Documents system dependencies required to run the test suite, which are currently undocumented and can cause confusing build failures for new contributors.

## Changes

- **New "System Dependencies" section** covering:
  - MySQL/MariaDB client libraries (required for `mysqlclient` to build)
  - GDAL and GEOS (optional, for `django.contrib.gis` tests)
  - Platform-specific instructions for Ubuntu/Debian, Fedora/RHEL, and macOS (Homebrew)
  - Note about macOS library path issues and workaround for GIS tests

- **Pre-commit clarification**: Added note that pre-commit must be installed separately, with link to installation options and mention of `uvx` alternative.

- **`uv run pytest`**: Changed from `pytest -n auto` to `uv run pytest -n auto` for consistency with uv-based workflow (works regardless of venv activation).

## Motivation

When setting up the dev environment on macOS, `uv sync` fails with a cryptic `mysqlclient` build error unless you have MariaDB/MySQL client libraries installed. Similarly, 2 GIS tests fail without GDAL/GEOS.
These dependencies aren't mentioned anywhere in the docs.

This PR documents what I learned while setting up the project for the first time.

## Test plan

- [x] `pre-commit run --files CONTRIBUTING.md` passes
- [x] Verified instructions work on macOS with Homebrew
