### PR TITLE
Add overloads to Library.inclusion_tag for proper type inference

### DIFF
--- a/django-stubs/template/library.pyi
+++ b/django-stubs/template/library.pyi
@@ -35,10 +35,19 @@ class Library:
     def simple_tag(
         self, func: None = None, takes_context: bool | None = None, name: str | None = None
     ) -> Callable[[_C], _C]: ...
+    @overload
     def inclusion_tag(
         self,
         filename: Template | str,
-        func: Callable | None = None,
+        func: _C,
+        takes_context: bool | None = None,
+        name: str | None = None,
+    ) -> _C: ...
+    @overload
+    def inclusion_tag(
+        self,
+        filename: Template | str,
+        func: None = None,
         takes_context: bool | None = None,
         name: str | None = None,
     ) -> Callable[[_C], _C]: ...

--- a/tests/typecheck/template/test_library.yml
+++ b/tests/typecheck/template/test_library.yml
@@ -135,3 +135,27 @@
             return ', '.join(results)
 
         reveal_type(format_results) # N: Revealed type is "def (results: builtins.list[builtins.str]) -> builtins.str"
+
+-   case: register_inclusion_tag_takes_context
+    main: |
+        from typing_extensions import reveal_type
+        from typing import Any
+        from django import template
+        register = template.Library()
+
+        @register.inclusion_tag('results.html', takes_context=True)
+        def format_results(context: dict[str, Any], results: list[str]) -> str:
+            return ', '.join(results)
+
+        reveal_type(format_results) # N: Revealed type is "def (context: builtins.dict[builtins.str, Any], results: builtins.list[builtins.str]) -> builtins.str"
+
+-   case: register_inclusion_tag_via_call
+    main: |
+        from typing_extensions import reveal_type
+        from django import template
+        register = template.Library()
+
+        def format_results(results: list[str]) -> str:
+            return ', '.join(results)
+
+        reveal_type(register.inclusion_tag('results.html', format_results)) # N: Revealed type is "def (results: builtins.list[builtins.str]) -> builtins.str"


### PR DESCRIPTION
## Summary

Add proper overloads to `Library.inclusion_tag` to match the pattern used by `simple_tag` and `simple_block_tag`.

## Problem

The `inclusion_tag` method was missing overloads, causing type checkers (particularly pyright) to report `reportUnknownMemberType` errors when using the decorator:

```python
@register.inclusion_tag("template.html")  # pyright: ignore [reportUnknownMemberType]
def my_tag() -> dict[str, str]:
    return {"key": "value"}
```

Solution

Add overloads matching the pattern already used by simple_tag and simple_block_tag:

1. When func is provided directly → return _C (preserves function type)
2. When func is None (decorator usage) → return Callable[[_C], _C]

Test plan

- Added test case for takes_context=True pattern
- Added test case for direct call pattern
- All 496 tests pass
