### PR TITLE
Add configurable `resolve_manager_on_typevars` option for .objects on type[T]

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ The supported settings are:
   [See here why](https://github.com/typeddjango/django-stubs?tab=readme-ov-file#how-to-use-typemodel-annotation-with-objects-attribute)
   this is dangerous to do by default.
 
+- `resolve_manager_on_typevars`, a boolean, default `false`.
+
+  Set to `true` to allow `.objects` to resolve on `type[T]` where `T` is a
+  `TypeVar` bounded by a Django `Model` subclass. This is useful for generic
+  model utilities, factory patterns, and plugin architectures where the concrete
+  model type isn't known at the call site but is guaranteed to be a `Model`
+  subclass. Without this setting, only `._default_manager` and `._base_manager`
+  are available on `type[T]`; with it, `.objects` resolves to `Manager[T]` as
+  well.
+
 
 ## FAQ
 
@@ -385,6 +395,12 @@ to skip removing `.objects`, `.DoesNotExist`, and `.MultipleObjectsReturned`
 attributes from `model.Model` if you are using our mypy plugin.
 
 Use this setting on your own risk, because it can hide valid errors.
+
+Alternatively, if you need `.objects` to work on `type[T]` where `T` is a
+`TypeVar` bounded by a `Model` subclass (e.g. generic model utilities or factory
+patterns), you can set `resolve_manager_on_typevars = true`. This keeps strict
+checking on direct `models.Model` access while enabling `.objects` on type
+variables bounded by model subclasses.
 
 ### How to type a custom `models.Field`?
 

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -31,6 +31,11 @@ class ModelBase(type):
     def _default_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
     @property
     def _base_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
+    # This metaclass property is the fallback for 'objects' when accessed on type[T]
+    # where T is a TypeVar bounded by a Model subclass. It is removed by the plugin
+    # unless resolve_manager_on_typevars is enabled.
+    @property
+    def objects(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc,unused-ignore]
 
 class Model(metaclass=ModelBase):
     # Note: these two metaclass generated attributes don't really exist on the 'Model'

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -17,6 +17,7 @@ TEMPLATE = """
 django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 strict_model_abstract_attrs = bool (default: true)
+resolve_manager_on_typevars = bool (default: false)
 ...
 (django-stubs) mypy: error: {}
 """
@@ -28,6 +29,7 @@ TEMPLATE_TOML = """
 django_settings_module = str (default: `os.getenv("DJANGO_SETTINGS_MODULE")`)
 strict_settings = bool (default: true)
 strict_model_abstract_attrs = bool (default: true)
+resolve_manager_on_typevars = bool (default: false)
 ...
 (django-stubs) mypy: error: {}
 """
@@ -78,6 +80,15 @@ def write_to_file(file_contents: str, suffix: str | None = None) -> Generator[st
             ],
             "invalid 'strict_model_abstract_attrs': the setting must be a boolean",
             id="invalid-strict_model_abstract_attrs",
+        ),
+        pytest.param(
+            [
+                "[mypy.plugins.django-stubs]",
+                "django_settings_module = some.module",
+                "resolve_manager_on_typevars = bad",
+            ],
+            "invalid 'resolve_manager_on_typevars': the setting must be a boolean",
+            id="invalid-resolve_manager_on_typevars",
         ),
     ],
 )
@@ -160,6 +171,15 @@ def test_handles_filename(capsys: Any, filename: str) -> None:
             """,
             "invalid 'strict_model_abstract_attrs': the setting must be a boolean",
             id="invalid strict_model_abstract_attrs type",
+        ),
+        pytest.param(
+            """
+            [tool.django-stubs]
+            django_settings_module = "some.module"
+            resolve_manager_on_typevars = "a"
+            """,
+            "invalid 'resolve_manager_on_typevars': the setting must be a boolean",
+            id="invalid resolve_manager_on_typevars type",
         ),
     ],
 )

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -838,3 +838,122 @@
                 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
                 class UserProfile(AbstractBaseUser, PermissionsMixin):
                     pass
+
+-   case: test_objects_on_typevar_bounded_model_with_config
+    mypy_config: |
+        [mypy.plugins.django-stubs]
+        django_settings_module = mysettings
+        resolve_manager_on_typevars = true
+    main: |
+        from typing import TypeVar
+        from typing_extensions import reveal_type
+        from myapp.models import MyBaseModel, MyConcreteModel, Base
+        from django.db import models
+
+        # Generic class pattern: type[T] as class attribute
+        base_instance = Base(MyConcreteModel)
+        reveal_type(base_instance.model_cls.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyConcreteModel]"
+        reveal_type(base_instance.model_cls._default_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyConcreteModel]"
+
+        # Concrete model access still works
+        reveal_type(MyConcreteModel.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyConcreteModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import Generic, TypeVar
+                from typing_extensions import reveal_type
+                from django.db import models
+
+                class MyBaseModel(models.Model):
+                    class Meta:
+                        abstract = True
+
+                class MyConcreteModel(MyBaseModel):
+                    pass
+
+                _T = TypeVar('_T', bound=models.Model)
+                class Base(Generic[_T]):
+                    def __init__(self, model_cls: type[_T]) -> None:
+                        self.model_cls = model_cls
+                        reveal_type(self.model_cls.objects)  # N: Revealed type is "django.db.models.manager.Manager[_T`1]"
+
+                class ChildBase(Base[MyConcreteModel]):
+                    def method(self) -> None:
+                        reveal_type(self.model_cls.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyConcreteModel]"
+
+-   case: test_objects_on_typevar_bounded_model_default_config
+    main: |
+        from typing import Generic, TypeVar
+        from django.db import models
+
+        _T = TypeVar('_T', bound=models.Model)
+        class Base(Generic[_T]):
+            def __init__(self, model_cls: type[_T]) -> None:
+                self.model_cls = model_cls
+                self.model_cls.objects  # E: "type[_T]" has no attribute "objects"  [attr-defined]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    pass
+
+-   case: test_default_manager_on_typevar_still_works_regardless_of_config
+    main: |
+        from typing import Generic, TypeVar
+        from typing_extensions import reveal_type
+        from myapp.models import Base, MyModel
+        from django.db import models
+
+        # _default_manager always works because it is on the ModelBase metaclass
+        base_instance = Base(MyModel)
+        reveal_type(base_instance.model_cls._default_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
+        reveal_type(base_instance.model_cls._base_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import Generic, TypeVar
+                from typing_extensions import reveal_type
+                from django.db import models
+
+                _T = TypeVar('_T', bound=models.Model)
+                class Base(Generic[_T]):
+                    def __init__(self, model_cls: type[_T]) -> None:
+                        self.model_cls = model_cls
+                        reveal_type(self.model_cls._default_manager)  # N: Revealed type is "django.db.models.manager.Manager[_T`1]"
+                        reveal_type(self.model_cls._base_manager)  # N: Revealed type is "django.db.models.manager.Manager[_T`1]"
+
+                class MyModel(models.Model):
+                    pass
+
+-   case: test_custom_manager_concrete_model_not_regressed_with_typevar_config
+    mypy_config: |
+        [mypy.plugins.django-stubs]
+        django_settings_module = mysettings
+        resolve_manager_on_typevars = true
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.CustomManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.CustomManager[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class CustomManager(models.Manager):
+                    pass
+                class MyModel(models.Model):
+                    objects = CustomManager()


### PR DESCRIPTION
## Summary

- Adds `objects` as a property on the `ModelBase` metaclass (consistent with `_default_manager` and `_base_manager`)
- Introduces a new `resolve_manager_on_typevars` config option (default: `false`) that controls whether the metaclass property is kept or removed
- When enabled, `type[T].objects` resolves to `Manager[T]` where `T` is a `TypeVar` bounded by a `Model` subclass
- When disabled (default), current behavior is fully preserved

## Motivation

When using `type[T]` where `T` is a `TypeVar` bounded by a Django Model subclass, accessing `.objects` on the result reports:

```
error: "type[T]" has no attribute "objects"  [attr-defined]
```

This pattern is common in generic model utilities, factory patterns, and plugin architectures where the concrete model type isn't known at the call site but is guaranteed to be a Model subclass. Meanwhile, `._default_manager` and `._base_manager` already work in this context because they are defined as properties on the `ModelBase` metaclass.

## Changes

| File | Change |
|------|--------|
| `django-stubs/db/models/base.pyi` | Add `objects` property to `ModelBase` metaclass |
| `mypy_django_plugin/config.py` | Add `resolve_manager_on_typevars` boolean config (default: `false`) |
| `mypy_django_plugin/transformers/models.py` | Guard metaclass property removal based on config |
| `tests/typecheck/managers/test_managers.yml` | 4 new test cases covering both config states |
| `tests/test_error_handling.py` | Config validation tests for INI and TOML |
| `README.md` | Document the new config option |

## Test plan

- [x] New tests: opt-in resolves `type[T].objects` to `Manager[T]`
- [x] New tests: default config preserves the existing error
- [x] New tests: `_default_manager`/`_base_manager` unaffected regardless of config
- [x] New tests: concrete models with custom managers not regressed
- [x] Existing manager tests pass (31/31)
- [x] Existing metaclass tests pass (3/3)
- [x] Error handling tests pass with updated usage strings
- [x] Ruff lint + format checks pass

Made with [Cursor](https://cursor.com)