### PR TITLE
Django 6.0: add tasks module stubs

### DIFF
--- a/django-stubs/tasks/__init__.pyi
+++ b/django-stubs/tasks/__init__.pyi
@@ -1,5 +1,3 @@
-from typing import Any, type_check_only
-
 from django.utils.connection import BaseConnectionHandler
 
 from .backends.base import BaseTaskBackend
@@ -26,10 +24,5 @@ __all__ = [
 class TaskBackendHandler(BaseConnectionHandler[BaseTaskBackend]): ...
 
 task_backends: TaskBackendHandler
-
-@type_check_only
-class _default_task_backend(BaseTaskBackend):
-    def enqueue(self, task: Task, args: list[Any], kwargs: dict[str, Any]) -> TaskResult: ...
-
-# Actually ConnectionProxy, but quacks exactly like _default_task_backend, it's not worth distinguishing the two.
-default_task_backend: _default_task_backend
+# Actually ConnectionProxy, but quacks exactly like BaseTaskBackend, it's not worth distinguishing the two.
+default_task_backend: BaseTaskBackend

--- a/django-stubs/tasks/checks.pyi
+++ b/django-stubs/tasks/checks.pyi
@@ -1,0 +1,7 @@
+from collections.abc import Sequence
+from typing import Any
+
+from django.apps.config import AppConfig
+from django.core.checks.messages import CheckMessage
+
+def check_tasks(app_configs: Sequence[AppConfig] | None = ..., **kwargs: Any) -> list[CheckMessage]: ...

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -21,6 +21,9 @@ django.contrib.sites.migrations.*
 # default_storage is actually an instance of DefaultStorage, but it proxies through to a Storage
 django.core.files.storage.default_storage
 
+# default_task_backend is actually an instance of ConnectionProxy, but it proxies through to a BaseTaskBackend
+django.tasks.default_task_backend
+
 # '<Model>_RelatedManager' entries are plugin generated and these subclasses only exist
 # _locally/dynamically_ runtime -- Created via
 # 'django.db.models.fields.related_descriptors.create_reverse_many_to_one_manager'

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -113,5 +113,3 @@ django.db.models.query.Prefetch.get_current_queryset
 django.db.models.sql.compiler.SQLUpdateCompiler.execute_returning_sql
 django.db.models.sql.compiler.SQLUpdateCompiler.returning_fields
 django.db.models.sql.compiler.SQLUpdateCompiler.returning_params
-django.tasks.checks
-django.tasks.default_task_backend

--- a/tests/typecheck/test_import_all.yml
+++ b/tests/typecheck/test_import_all.yml
@@ -565,6 +565,15 @@
         import django.middleware.locale
         import django.middleware.security
         import django.shortcuts
+        import django.tasks
+        import django.tasks.backends
+        import django.tasks.backends.base
+        import django.tasks.backends.dummy
+        import django.tasks.backends.immediate
+        import django.tasks.base
+        import django.tasks.checks
+        import django.tasks.exceptions
+        import django.tasks.signals
         import django.template
         import django.template.backends
         import django.template.backends.base


### PR DESCRIPTION
## PR summary
This PR adds the missing `django.tasks.checks` stub and simplify `default_task_backend` typing to use `BaseTaskBackend` directly (matches how `django.db.connection` and `django.core.cache.cache` handle their `ConnectionProxy` singletons). Also this PR adds the missing `django.tasks` entries to `test_import_all.yml` that were overlooked in #2967. 

Ref #2944