### PR TITLE
Django 6.0: update conf settings stubs

### DIFF
--- a/django-stubs/conf/__init__.pyi
+++ b/django-stubs/conf/__init__.pyi
@@ -10,9 +10,6 @@ ENVIRONMENT_VARIABLE: Literal["DJANGO_SETTINGS_MODULE"]
 DEFAULT_STORAGE_ALIAS: Literal["default"]
 STATICFILES_STORAGE_ALIAS: Literal["staticfiles"]
 
-# RemovedInDjango60Warning.
-FORMS_URLFIELD_ASSUME_HTTPS_DEPRECATED_MSG: str
-
 # required for plugin to be able to distinguish this specific instance of LazySettings from others
 @type_check_only
 class _DjangoConfLazyObject(LazyObject):

--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -1,14 +1,15 @@
 from collections.abc import Collection, Mapping, Sequence
 from re import Pattern
-
-# This is defined here as a do-nothing function because we can't import
-# django.utils.translation -- that module depends on the settings.
 from typing import Any, Literal, Protocol, TypeAlias, TypedDict, type_check_only
 
 from django.utils.functional import _StrOrPromise
 from typing_extensions import NotRequired
 
 from django_stubs_ext.settings import TemplatesSetting
+
+# This is defined here as a do-nothing function because we can't import
+# django.utils.translation -- that module depends on the settings.
+def gettext_noop(s: str) -> str: ...
 
 # Note: the tuple element format for ADMINS or MANAGERS is deprecated. Use a
 # list of strings instead.
@@ -131,11 +132,6 @@ TEMPLATES: list[TemplatesSetting]
 
 # Default form rendering class.
 FORM_RENDERER: str
-
-# RemovedInDjango60Warning: It's a transitional setting helpful in early
-# adoption of "https" as the new default value of forms.URLField.assume_scheme.
-# Set to True to assume "https" during the Django 5.x release cycle.
-FORMS_URLFIELD_ASSUME_HTTPS: bool
 
 # Default email address to use for various automated correspondence from
 # the site managers.
@@ -549,6 +545,11 @@ SECURE_SSL_REDIRECT: bool
 ##################
 SECURE_CSP: Mapping[str, Collection[str] | str]
 SECURE_CSP_REPORT_ONLY: Mapping[str, Collection[str] | str]
+
+# RemovedInDjango70Warning: A transitional setting helpful in early adoption of
+# HTTPS as the default protocol in urlize and urlizetrunc when no protocol is
+# provided. Set to True to assume HTTPS during the Django 6.x release cycle.
+URLIZE_ASSUME_HTTPS: bool
 
 #########
 # TASKS #

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -2,7 +2,6 @@
 # Unsorted: there are real problems and things we can really ignore.
 
 django.__main__
-django.conf.global_settings.gettext_noop
 django.contrib.admin.FieldListFilter.title
 django.contrib.admin.filters.FieldListFilter.title
 django.contrib.admin.helpers.AdminForm.fields

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,6 +1,3 @@
-django.conf.FORMS_URLFIELD_ASSUME_HTTPS_DEPRECATED_MSG
-django.conf.global_settings.FORMS_URLFIELD_ASSUME_HTTPS
-django.conf.global_settings.URLIZE_ASSUME_HTTPS
 django.contrib.admin.AdminSite.password_change_form
 django.contrib.admin.ModelAdmin.log_deletion
 django.contrib.admin.models.LogEntryManager.log_action


### PR DESCRIPTION
## PR summary
This PR removes `FORMS_URLFIELD_ASSUME_HTTPS` and its deprecation message constant that were dropped in Django 6.0, adds the new `URLIZE_ASSUME_HTTPS` transitional setting, and adds the missing `gettext_noop` function. 

Ref #2944.