### PR TITLE
Django 6.0: Add plugin support for `NotUpdated` exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ The supported settings are:
 
 - `strict_model_abstract_attrs`, a boolean, default `true`.
 
-  Set to `false` if you want to keep `.objects`, `.DoesNotExist`,
-  and `.MultipleObjectsReturned` attributes on `models.Model` type.
+  Set to `false` if you want to keep `.objects`, `.DoesNotExist`, `.NotUpdated`, and
+  `.MultipleObjectsReturned` attributes on `models.Model` type.
   [See here why](https://github.com/typeddjango/django-stubs?tab=readme-ov-file#how-to-use-typemodel-annotation-with-objects-attribute)
   this is dangerous to do by default.
 
@@ -380,9 +380,9 @@ def assert_zero_count(model_type: type[models.Model]) -> None:
     assert model_type._default_manager.count() == 0
 ```
 
-Configurable with `strict_model_abstract_attrs = false`
-to skip removing `.objects`, `.DoesNotExist`, and `.MultipleObjectsReturned`
-attributes from `model.Model` if you are using our mypy plugin.
+Configurable with `strict_model_abstract_attrs = false` to skip removing `.objects`,
+`.DoesNotExist`, `.NotUpdated`, and `.MultipleObjectsReturned` attributes from `model.Model` if
+you are using our mypy plugin.
 
 Use this setting on your own risk, because it can hide valid errors.
 

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -39,8 +39,8 @@ class Model(metaclass=ModelBase):
     # Our mypy plugin aligns with this behaviour and will remove the 2 attributes below
     # and re-add them to correct concrete subclasses of 'Model'
     DoesNotExist: Final[type[ObjectDoesNotExist]]
-    MultipleObjectsReturned: Final[type[BaseMultipleObjectsReturned]]
     NotUpdated: Final[type[ObjectNotUpdated]]
+    MultipleObjectsReturned: Final[type[BaseMultipleObjectsReturned]]
     # This 'objects' attribute will be deleted, via the plugin, in favor of managing it
     # to only exist on subclasses it exists on during runtime.
     objects: ClassVar[Manager[Self]]

--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -61,6 +61,7 @@ TYPED_MODEL_META_FULLNAME = "django_stubs_ext.db.models.TypedModelMeta"
 STR_PROMISE_FULLNAME = "django.utils.functional._StrPromise"
 
 OBJECT_DOES_NOT_EXIST = "django.core.exceptions.ObjectDoesNotExist"
+OBJECT_NOT_UPDATED = "django.core.exceptions.ObjectNotUpdated"
 MULTIPLE_OBJECTS_RETURNED = "django.core.exceptions.MultipleObjectsReturned"
 
 DJANGO_ABSTRACT_MODELS = frozenset(

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -58,7 +58,7 @@
     Concrete(parent=Concrete(parent=None))
   out: |
     main:4: error: "type[Recursive]" has no attribute "objects"  [attr-defined]
-    main:5: error: Cannot instantiate abstract class "Recursive" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+    main:5: error: Cannot instantiate abstract class "Recursive" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
     main:5: error: Unexpected attribute "parent" for model "Recursive"  [misc]
   installed_apps:
     - myapp
@@ -83,8 +83,8 @@
       from myapp.models import Abstract, Concrete, LiteralAbstract
       from typing import Generic, TypeVar, overload
 
-      Abstract()  # E: Cannot instantiate abstract class "Abstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
-      LiteralAbstract()  # E: Cannot instantiate abstract class "LiteralAbstract" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+      Abstract()  # E: Cannot instantiate abstract class "Abstract" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
+      LiteralAbstract()  # E: Cannot instantiate abstract class "LiteralAbstract" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
 
       def f(klass: type[Abstract]) -> None:
           return None
@@ -175,7 +175,7 @@
     create_animal_generic(Cat, "Grumpy")
     create_animal_generic(Animal, "Animal")  # E: Only concrete class can be given where "type[Animal]" is expected  [type-abstract]
 
-    Animal()  # E: Cannot instantiate abstract class "Animal" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+    Animal()  # E: Cannot instantiate abstract class "Animal" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
     ExplicitConcrete()
   installed_apps:
     - myapp

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -171,7 +171,7 @@
         AbstractModel._default_manager.create()
 
         # Errors:
-        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attributes "DoesNotExist" and "MultipleObjectsReturned"  [abstract]
+        AbstractModel()  # E: Cannot instantiate abstract class "AbstractModel" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
         AbstractModel.objects.create()  # E: "type[AbstractModel]" has no attribute "objects"  [attr-defined]
     installed_apps:
         - myapp

--- a/tests/typecheck/models/test_metaclass.yml
+++ b/tests/typecheck/models/test_metaclass.yml
@@ -5,12 +5,18 @@
         from django.db import models
 
         models.Model.DoesNotExist  # E: "type[Model]" has no attribute "DoesNotExist"  [attr-defined]
+        models.Model.NotUpdated  # E: "type[Model]" has no attribute "NotUpdated"  [attr-defined]
         models.Model.MultipleObjectsReturned  # E: "type[Model]" has no attribute "MultipleObjectsReturned"  [attr-defined]
 
         reveal_type(Abstract1.DoesNotExist)  # N: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
         reveal_type(Abstract2.DoesNotExist)  # N: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
         reveal_type(Concrete1.DoesNotExist)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete1.DoesNotExist"
         reveal_type(Concrete2.DoesNotExist)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete2.DoesNotExist"
+
+        reveal_type(Abstract1.NotUpdated)  # N: Revealed type is "type[django.core.exceptions.ObjectNotUpdated]"
+        reveal_type(Abstract2.NotUpdated)  # N: Revealed type is "type[django.core.exceptions.ObjectNotUpdated]"
+        reveal_type(Concrete1.NotUpdated)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete1.NotUpdated"
+        reveal_type(Concrete2.NotUpdated)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete2.NotUpdated"
 
         reveal_type(Abstract1.MultipleObjectsReturned)  # N: Revealed type is "type[django.core.exceptions.MultipleObjectsReturned]"
         reveal_type(Abstract2.MultipleObjectsReturned)  # N: Revealed type is "type[django.core.exceptions.MultipleObjectsReturned]"
@@ -19,6 +25,9 @@
 
         reveal_type(super(Concrete1, Concrete1()).DoesNotExist())  # N: Revealed type is "django.core.exceptions.ObjectDoesNotExist"
         reveal_type(super(Concrete2, Concrete2()).DoesNotExist())  # N: Revealed type is "myapp.models.Concrete1.DoesNotExist"
+
+        reveal_type(super(Concrete1, Concrete1()).NotUpdated())  # N: Revealed type is "django.core.exceptions.ObjectNotUpdated"
+        reveal_type(super(Concrete2, Concrete2()).NotUpdated())  # N: Revealed type is "myapp.models.Concrete1.NotUpdated"
 
         a: type[Concrete1.DoesNotExist]
         a = Concrete1.DoesNotExist
@@ -35,20 +44,35 @@
         c = Concrete2.DoesNotExist  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.DoesNotExist]", variable has type "type[myapp.models.Concrete3.DoesNotExist]")  [assignment]
         c = Concrete3.DoesNotExist
 
-        d: type[Concrete1.MultipleObjectsReturned]
-        d = Concrete1.MultipleObjectsReturned
-        d = Concrete2.MultipleObjectsReturned
-        d = Concrete3.MultipleObjectsReturned
+        d: type[Concrete1.NotUpdated]
+        d = Concrete1.NotUpdated
+        d = Concrete2.NotUpdated
+        d = Concrete3.NotUpdated
 
-        e: type[Concrete2.MultipleObjectsReturned]
-        e = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete2.MultipleObjectsReturned]")  [assignment]
-        e = Concrete2.MultipleObjectsReturned
-        e = Concrete3.MultipleObjectsReturned
+        e: type[Concrete2.NotUpdated]
+        e = Concrete1.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.NotUpdated]", variable has type "type[myapp.models.Concrete2.NotUpdated]")  [assignment]
+        e = Concrete2.NotUpdated
+        e = Concrete3.NotUpdated
 
-        f: type[Concrete3.MultipleObjectsReturned]
-        f = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
-        f = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
-        f = Concrete3.MultipleObjectsReturned
+        f: type[Concrete3.NotUpdated]
+        f = Concrete1.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.NotUpdated]", variable has type "type[myapp.models.Concrete3.NotUpdated]")  [assignment]
+        f = Concrete2.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.NotUpdated]", variable has type "type[myapp.models.Concrete3.NotUpdated]")  [assignment]
+        f = Concrete3.NotUpdated
+
+        g: type[Concrete1.MultipleObjectsReturned]
+        g = Concrete1.MultipleObjectsReturned
+        g = Concrete2.MultipleObjectsReturned
+        g = Concrete3.MultipleObjectsReturned
+
+        h: type[Concrete2.MultipleObjectsReturned]
+        h = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete2.MultipleObjectsReturned]")  [assignment]
+        h = Concrete2.MultipleObjectsReturned
+        h = Concrete3.MultipleObjectsReturned
+
+        i: type[Concrete3.MultipleObjectsReturned]
+        i = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
+        i = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
+        i = Concrete3.MultipleObjectsReturned
     installed_apps:
         - myapp
     files:
@@ -85,6 +109,7 @@
         from django.db import models
 
         reveal_type(models.Model.DoesNotExist)  # N: Revealed type is "type[django.core.exceptions.ObjectDoesNotExist]"
+        reveal_type(models.Model.NotUpdated)  # N: Revealed type is "type[django.core.exceptions.ObjectNotUpdated]"
         reveal_type(models.Model.MultipleObjectsReturned)  # N: Revealed type is "type[django.core.exceptions.MultipleObjectsReturned]"
         reveal_type(models.Model.objects)  # N: Revealed type is "django.db.models.manager.Manager[django.db.models.base.Model]"
 
@@ -93,6 +118,11 @@
         reveal_type(Concrete1.DoesNotExist)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete1.DoesNotExist"
         reveal_type(Concrete2.DoesNotExist)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete2.DoesNotExist"
 
+        reveal_type(Abstract1.NotUpdated)  # N: Revealed type is "type[django.core.exceptions.ObjectNotUpdated]"
+        reveal_type(Abstract2.NotUpdated)  # N: Revealed type is "type[django.core.exceptions.ObjectNotUpdated]"
+        reveal_type(Concrete1.NotUpdated)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete1.NotUpdated"
+        reveal_type(Concrete2.NotUpdated)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete2.NotUpdated"
+
         reveal_type(Abstract1.MultipleObjectsReturned)  # N: Revealed type is "type[django.core.exceptions.MultipleObjectsReturned]"
         reveal_type(Abstract2.MultipleObjectsReturned)  # N: Revealed type is "type[django.core.exceptions.MultipleObjectsReturned]"
         reveal_type(Concrete1.MultipleObjectsReturned)  # N: Revealed type is "def (*args: builtins.object) -> myapp.models.Concrete1.MultipleObjectsReturned"
@@ -100,6 +130,9 @@
 
         reveal_type(super(Concrete1, Concrete1()).DoesNotExist())  # N: Revealed type is "django.core.exceptions.ObjectDoesNotExist"
         reveal_type(super(Concrete2, Concrete2()).DoesNotExist())  # N: Revealed type is "myapp.models.Concrete1.DoesNotExist"
+
+        reveal_type(super(Concrete1, Concrete1()).NotUpdated())  # N: Revealed type is "django.core.exceptions.ObjectNotUpdated"
+        reveal_type(super(Concrete2, Concrete2()).NotUpdated())  # N: Revealed type is "myapp.models.Concrete1.NotUpdated"
 
         a: type[Concrete1.DoesNotExist]
         a = Concrete1.DoesNotExist
@@ -116,20 +149,35 @@
         c = Concrete2.DoesNotExist  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.DoesNotExist]", variable has type "type[myapp.models.Concrete3.DoesNotExist]")  [assignment]
         c = Concrete3.DoesNotExist
 
-        d: type[Concrete1.MultipleObjectsReturned]
-        d = Concrete1.MultipleObjectsReturned
-        d = Concrete2.MultipleObjectsReturned
-        d = Concrete3.MultipleObjectsReturned
+        d: type[Concrete1.NotUpdated]
+        d = Concrete1.NotUpdated
+        d = Concrete2.NotUpdated
+        d = Concrete3.NotUpdated
 
-        e: type[Concrete2.MultipleObjectsReturned]
-        e = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete2.MultipleObjectsReturned]")  [assignment]
-        e = Concrete2.MultipleObjectsReturned
-        e = Concrete3.MultipleObjectsReturned
+        e: type[Concrete2.NotUpdated]
+        e = Concrete1.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.NotUpdated]", variable has type "type[myapp.models.Concrete2.NotUpdated]")  [assignment]
+        e = Concrete2.NotUpdated
+        e = Concrete3.NotUpdated
 
-        f: type[Concrete3.MultipleObjectsReturned]
-        f = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
-        f = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
-        f = Concrete3.MultipleObjectsReturned
+        f: type[Concrete3.NotUpdated]
+        f = Concrete1.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.NotUpdated]", variable has type "type[myapp.models.Concrete3.NotUpdated]")  [assignment]
+        f = Concrete2.NotUpdated  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.NotUpdated]", variable has type "type[myapp.models.Concrete3.NotUpdated]")  [assignment]
+        f = Concrete3.NotUpdated
+
+        g: type[Concrete1.MultipleObjectsReturned]
+        g = Concrete1.MultipleObjectsReturned
+        g = Concrete2.MultipleObjectsReturned
+        g = Concrete3.MultipleObjectsReturned
+
+        h: type[Concrete2.MultipleObjectsReturned]
+        h = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete2.MultipleObjectsReturned]")  [assignment]
+        h = Concrete2.MultipleObjectsReturned
+        h = Concrete3.MultipleObjectsReturned
+
+        i: type[Concrete3.MultipleObjectsReturned]
+        i = Concrete1.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete1.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
+        i = Concrete2.MultipleObjectsReturned  # E: Incompatible types in assignment (expression has type "type[myapp.models.Concrete2.MultipleObjectsReturned]", variable has type "type[myapp.models.Concrete3.MultipleObjectsReturned]")  [assignment]
+        i = Concrete3.MultipleObjectsReturned
     installed_apps:
         - myapp
     files:


### PR DESCRIPTION
# I have made things!

`NotUpdated` was added in Django 6.0 and should work the same as `DoesNotExist` and `MultipleObjectsReturned`.

## Related issues

- Refs https://github.com/typeddjango/django-stubs/pull/2940