### PR TITLE
Fix lower bound for `response_gone_class`

### DIFF
--- a/django-stubs/contrib/redirects/middleware.pyi
+++ b/django-stubs/contrib/redirects/middleware.pyi
@@ -1,10 +1,10 @@
 from typing import ClassVar
 
 from django.http.request import HttpRequest
-from django.http.response import HttpResponse, HttpResponseBase, HttpResponseRedirectBase
+from django.http.response import HttpResponse, HttpResponseRedirectBase
 from django.utils.deprecation import MiddlewareMixin
 
 class RedirectFallbackMiddleware(MiddlewareMixin):
-    response_gone_class: ClassVar[type[HttpResponseBase]]
+    response_gone_class: ClassVar[type[HttpResponse]]
     response_redirect_class: ClassVar[type[HttpResponseRedirectBase]]
     def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse: ...

--- a/tests/assert_type/middleware/test_middleware.py
+++ b/tests/assert_type/middleware/test_middleware.py
@@ -1,4 +1,5 @@
 from django.contrib.redirects.middleware import RedirectFallbackMiddleware
+from django.http.request import HttpRequest
 from django.http.response import (
     FileResponse,
     HttpResponse,
@@ -40,3 +41,8 @@ class CustomRedirectFallbackMiddleware2(RedirectFallbackMiddleware):
 class BrokenCustomRedirectFallbackMiddleware(RedirectFallbackMiddleware):
     response_redirect_class = HttpResponse  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]  # pyrefly: ignore[bad-assignment]
     response_gone_class = 12  # type:ignore[assignment]  # pyright: ignore[reportAssignmentType]  # pyrefly: ignore[bad-assignment]
+
+
+class ResponseGoneFallbackMiddleware(RedirectFallbackMiddleware):
+    def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
+        return self.response_gone_class()


### PR DESCRIPTION
# I have made things!

The test showcase well the issue, it was failing previously because the bound was too low and incompatible with the return type of `process_response` 

