### PR TITLE
Django 6.0: update Oracle utils stubs

### DIFF
--- a/django-stubs/db/backends/oracle/utils.pyi
+++ b/django-stubs/db/backends/oracle/utils.pyi
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any
 
-class InsertVar:
+class BoundVar:
     types: Any
     db_type: Any
     bound_param: Any
@@ -16,9 +16,11 @@ class Oracle_datetime(datetime.datetime):
 
 class BulkInsertMapper:
     BLOB: str
-    CLOB: str
     DATE: str
     INTERVAL: str
+    NCLOB: str
     NUMBER: str
     TIMESTAMP: str
     types: Any
+
+def dsn(settings_dict: dict[str, Any]) -> str: ...

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -52,8 +52,6 @@ django.db.backends.oracle.features.DatabaseFeatures.supports_primitives_in_json_
 django.db.backends.oracle.features.DatabaseFeatures.supports_tuple_lookups
 django.db.backends.oracle.features.DatabaseFeatures.test_collations
 django.db.backends.oracle.introspection.TableInfo
-django.db.backends.oracle.utils.BulkInsertMapper.NCLOB
-django.db.backends.oracle.utils.dsn
 django.db.backends.postgresql.base.DatabaseWrapper.close_pool
 django.db.backends.postgresql.base.DatabaseWrapper.pool
 django.db.backends.postgresql.compiler

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -25,8 +25,6 @@ django.db.backends.oracle.operations.DatabaseOperations.fetch_returned_rows
 django.db.backends.oracle.operations.DatabaseOperations.field_cast_sql
 django.db.backends.oracle.operations.DatabaseOperations.return_insert_columns
 django.db.backends.oracle.operations.DatabaseOperations.returning_columns
-django.db.backends.oracle.utils.BoundVar
-django.db.backends.oracle.utils.InsertVar
 django.db.backends.postgresql.base.CursorDebugWrapper.copy
 django.db.backends.postgresql.base.CursorDebugWrapper.copy_expert
 django.db.backends.postgresql.base.CursorDebugWrapper.copy_to


### PR DESCRIPTION
## PR Summary
This PR updates the Oracle database backend utils stubs to match Django 6.0.

Ref #2944.