### PR TITLE
Allow UserAdmin with custom user models

### DIFF
--- a/django-stubs/contrib/auth/admin.pyi
+++ b/django-stubs/contrib/auth/admin.pyi
@@ -1,15 +1,13 @@
-from typing import Any, TypeVar
+from typing import Any
 
 from django.contrib import admin
-from django.contrib.auth.models import AbstractUser, Group
+from django.contrib.auth.models import Group, _UserType
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 
-_AbstractUserT = TypeVar("_AbstractUserT", bound=AbstractUser)
-
 class GroupAdmin(admin.ModelAdmin[Group]): ...
 
-class UserAdmin(admin.ModelAdmin[_AbstractUserT]):
+class UserAdmin(admin.ModelAdmin[_UserType]):
     change_user_password_template: Any
     add_fieldsets: Any
     add_form: Any


### PR DESCRIPTION
## PR Summary
`UserAdmin`'s `TypeVar` was bound to `AbstractUser`, but Django [docs](https://docs.djangoproject.com/en/6.0/topics/auth/customizing/#custom-users-and-django-contrib-admin) say you can use `UserAdmin` with any `AbstractBaseUser` subclass if you override the fieldsets. This PR changes to reuse the existing `_UserType` from `models.pyi` which has the correct bound. 

Fixes #2878