### PR TITLE
Django 6.0: update compiler stubs

### DIFF
--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -725,10 +725,6 @@ django.db.models.query_utils.logger
 django.db.models.query_utils.select_related_descend
 django.db.models.sql.AggregateQuery.__init__
 django.db.models.sql.InsertQuery.__init__
-django.db.models.sql.compiler.SQLCompiler.__init__
-django.db.models.sql.compiler.SQLCompiler.get_default_columns
-django.db.models.sql.compiler.SQLCompiler.get_qualify_sql
-django.db.models.sql.compiler.SQLCompiler.get_related_selections
 django.db.models.sql.datastructures.BaseTable.identity
 django.db.models.sql.datastructures.Join.identity
 django.db.models.sql.subqueries.AggregateQuery.__init__

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -33,10 +33,6 @@ django.contrib.gis.management.commands.ogrinspect
 django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
-django.db.backends.mysql.compiler.SQLCompiler.__init__
-django.db.backends.mysql.compiler.SQLCompiler.get_default_columns
-django.db.backends.mysql.compiler.SQLCompiler.get_qualify_sql
-django.db.backends.mysql.compiler.SQLCompiler.get_related_selections
 django.db.backends.mysql.features.DatabaseFeatures.allows_group_by_selected_pks
 django.db.backends.mysql.features.DatabaseFeatures.has_native_uuid_field
 django.db.backends.mysql.features.DatabaseFeatures.supports_expression_defaults

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -9,9 +9,6 @@ django.contrib.gis.db.models.ForeignObjectRel.get_joining_columns
 django.contrib.gis.db.models.GeneratedField.referenced_fields
 django.contrib.gis.db.models.Model._do_update
 django.contrib.gis.db.models.Prefetch.get_current_queryset
-django.db.backends.postgresql.compiler.SQLUpdateCompiler.execute_returning_sql
-django.db.backends.postgresql.compiler.SQLUpdateCompiler.returning_fields
-django.db.backends.postgresql.compiler.SQLUpdateCompiler.returning_params
 django.db.models.ForeignObjectRel.get_joining_columns
 django.db.models.GeneratedField.referenced_fields
 django.db.models.Model._do_update
@@ -30,6 +27,3 @@ django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor.get_prefe
 django.db.models.fields.related_descriptors.ReverseOneToOneDescriptor.get_prefetch_queryset
 django.db.models.fields.reverse_related.ForeignObjectRel.get_joining_columns
 django.db.models.query.Prefetch.get_current_queryset
-django.db.models.sql.compiler.SQLUpdateCompiler.execute_returning_sql
-django.db.models.sql.compiler.SQLUpdateCompiler.returning_fields
-django.db.models.sql.compiler.SQLUpdateCompiler.returning_params


### PR DESCRIPTION
## PR Summary
This PR updates the SQL compiler stubs. Adds `select_mask` parameter to `get_default_columns` and `get_related_selections`, adds `elide_empty` to `__init__`, and adds the missing `get_qualify_sql` method. Also adds `execute_returning_sql` and related attributes to `SQLUpdateCompiler`.

Ref #2944.