### PR TITLE
Update min/max/step parameters of IntegerField to accept Callables

### DIFF
--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Collection, Iterator, Sequence
 from decimal import Decimal
 from re import Pattern
-from typing import Any, ClassVar, Protocol, TypeAlias, type_check_only
+from typing import Any, Callable, ClassVar, Protocol, TypeAlias, type_check_only
 from uuid import UUID
 
 from django.core.files import File

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -1,8 +1,8 @@
 import datetime
-from collections.abc import Collection, Iterator, Sequence
+from collections.abc import Callable, Collection, Iterator, Sequence
 from decimal import Decimal
 from re import Pattern
-from typing import Any, Callable, ClassVar, Protocol, TypeAlias, type_check_only
+from typing import Any, ClassVar, Protocol, TypeAlias, type_check_only
 from uuid import UUID
 
 from django.core.files import File

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -96,16 +96,16 @@ class CharField(Field):
     def widget_attrs(self, widget: Widget) -> dict[str, Any]: ...
 
 class IntegerField(Field):
-    max_value: int | None
-    min_value: int | None
-    step_size: int | None
+    max_value: int | Callable[[], int] | None
+    min_value: int | Callable[[], int] | None
+    step_size: int | Callable[[], int] | None
     re_decimal: Any
     def __init__(
         self,
         *,
-        max_value: int | None = None,
-        min_value: int | None = None,
-        step_size: int | None = None,
+        max_value: int | Callable[[], int] | None = None,
+        min_value: int | Callable[[], int] | None = None,
+        step_size: int | Callable[[], int] | None = None,
         required: bool = ...,
         widget: Widget | type[Widget] | None = ...,
         label: _StrOrPromise | None = ...,


### PR DESCRIPTION

## Related issues

No related issue

## Description

Update min/max/step parameters of `IntegerField` to accept Callables

These can be Callables that return int,
because they are passed to MaxValueValidator/MinValueValidator/StepValueValidator which all accepts callables:

* https://docs.djangoproject.com/en/dev/ref/forms/fields/#integerfield
* https://docs.djangoproject.com/en/dev/ref/validators/#django.core.validators.MaxValueValidator
* https://docs.djangoproject.com/en/dev/ref/validators/#django.core.validators.MinValueValidator
* https://docs.djangoproject.com/en/dev/ref/validators/#django.core.validators.StepValueValidator
* https://github.com/django/django/blob/fb3a11071aae27ef869d2b029289b9f59cc41128/django/forms/fields.py#L318-L332

