### PR TITLE
Add types for BaseBinaryDumper in postgis base

### DIFF
--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -1,6 +1,12 @@
 from typing import Any
 
 from django.db.backends.postgresql.base import DatabaseWrapper as Psycopg2DatabaseWrapper
+from psycopg.adapt import Dumper
+from psycopg.pq import Format
+
+class BaseBinaryDumper(Dumper):
+    format: Format
+    def dump(self, obj: Any) -> bytes: ...
 
 class DatabaseWrapper(Psycopg2DatabaseWrapper):
     SchemaEditorClass: Any

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,10 +1,16 @@
+<<<<<<< HEAD
 django.contrib.gis.db.backends.postgis.base.BaseBinaryDumper
+=======
+>>>>>>> df91dbc2 (Remove BaseBinaryDumper from allowlist)
 django.contrib.gis.db.backends.postgis.base.BaseTextDumper
 django.contrib.gis.db.backends.postgis.base.DatabaseWrapper.register_geometry_adapters
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType
 django.contrib.gis.db.backends.postgis.base.RasterType
 django.contrib.gis.db.backends.postgis.base.postgis_adapters
+<<<<<<< HEAD
 django.contrib.gis.db.models.Model._do_update
 django.db.models.Model._do_update
 django.db.models.base.Model._do_update
+=======
+>>>>>>> df91dbc2 (Remove BaseBinaryDumper from allowlist)

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,16 +1,9 @@
-<<<<<<< HEAD
-django.contrib.gis.db.backends.postgis.base.BaseBinaryDumper
-=======
->>>>>>> df91dbc2 (Remove BaseBinaryDumper from allowlist)
 django.contrib.gis.db.backends.postgis.base.BaseTextDumper
 django.contrib.gis.db.backends.postgis.base.DatabaseWrapper.register_geometry_adapters
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType
 django.contrib.gis.db.backends.postgis.base.RasterType
 django.contrib.gis.db.backends.postgis.base.postgis_adapters
-<<<<<<< HEAD
 django.contrib.gis.db.models.Model._do_update
 django.db.models.Model._do_update
 django.db.models.base.Model._do_update
-=======
->>>>>>> df91dbc2 (Remove BaseBinaryDumper from allowlist)


### PR DESCRIPTION
This PR adds missing type stubs for BaseBinaryDumper class 
in django/contrib/gis/db/backends/postgis/base.py

- Added BaseBinaryDumper with format and dump method types