### PR TITLE
Django 6.0: Add types BaseTextDumper in postgis base 

### DIFF
--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -8,9 +8,6 @@ class BaseBinaryDumper(Dumper):
     format: Format
     def dump(self, obj: Any) -> bytes: ...
 
-class BaseTextDumper(Dumper):
-    def dump(self, obj: Any) -> bytes: ...
-
 class DatabaseWrapper(Psycopg2DatabaseWrapper):
     SchemaEditorClass: Any
     features: Any

--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -8,6 +8,9 @@ class BaseBinaryDumper(Dumper):
     format: Format
     def dump(self, obj: Any) -> bytes: ...
 
+class BaseTextDumper(Dumper):
+    def dump(self, obj: Any) -> bytes: ...
+
 class DatabaseWrapper(Psycopg2DatabaseWrapper):
     SchemaEditorClass: Any
     features: Any

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,4 +1,4 @@
-django.contrib.gis.db.backends.postgis.base.BaseTextDumper
+django.contrib.gis.db.backends.postgis.base.BaseBinaryDumper
 django.contrib.gis.db.backends.postgis.base.DatabaseWrapper.register_geometry_adapters
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,4 +1,3 @@
-django.contrib.gis.db.backends.postgis.base.BaseBinaryDumper
 django.contrib.gis.db.backends.postgis.base.DatabaseWrapper.register_geometry_adapters
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType


### PR DESCRIPTION
This PR adds missing type stubs for BaseTextDumper in
django.contrib.gis.db.backends.postgis.base.

Changes:

Added `dump(obj: Any) -> bytes` method signature

Removed `BaseTextDumper` entry from TODO/allowlist 