### PR TITLE
Add missing GeoModelAdminMixin and fix GISModelAdmin types

### DIFF
--- a/django-stubs/contrib/gis/admin/options.pyi
+++ b/django-stubs/contrib/gis/admin/options.pyi
@@ -1,8 +1,17 @@
-from typing import Any
+from typing import Any, TypeVar
 
 from django.contrib.admin import ModelAdmin
-from django.contrib.gis.forms import BaseGeometryWidget
+from django.contrib.gis.forms import OSMWidget
+from django.db.models import Model
+from django.db.models.fields import Field
+from django.forms.fields import Field as FormField
+from django.http.request import HttpRequest
 
-class GISModelAdmin(ModelAdmin):
-    gis_widget: BaseGeometryWidget
+_ModelT = TypeVar("_ModelT", bound=Model)
+
+class GeoModelAdminMixin:
+    gis_widget: type[OSMWidget]
     gis_widget_kwargs: dict[str, Any]
+    def formfield_for_dbfield(self, db_field: Field, request: HttpRequest, **kwargs: Any) -> FormField | None: ...
+
+class GISModelAdmin(GeoModelAdminMixin, ModelAdmin[_ModelT]): ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -80,9 +80,6 @@ django.contrib.flatpages.models.FlatPage.sites
 django.contrib.flatpages.models.FlatPage.template_name
 django.contrib.flatpages.models.FlatPage.title
 django.contrib.flatpages.models.FlatPage.url
-django.contrib.gis.admin.GISModelAdmin.gis_widget
-django.contrib.gis.admin.options.GISModelAdmin.gis_widget
-django.contrib.gis.admin.options.GeoModelAdminMixin
 django.contrib.gis.admin.site
 django.contrib.gis.db.backends.oracle.features.DatabaseFeatures.django_test_skips
 django.contrib.gis.db.backends.postgis.operations.PostGISOperations.convert_extent


### PR DESCRIPTION
### PR Summary
The `GISModelAdmin` stub was missing its `GeoModelAdminMixin` base class and had `gis_widget` typed as an instance rather than a class reference. This PR adds the mixin with `formfield_for_dbfield` properly typed to match `ModelAdmin`, fixes `gis_widget` to `type[OSMWidget]`, and makes `GISModelAdmin` generic.