### PR TITLE
added raster type stubs and postgis_adapters stubs in postgis base.pyi

### DIFF
--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -5,14 +5,14 @@ from psycopg import BaseConnection
 from psycopg.adapt import Dumper
 from psycopg.pq import Format
 
+class RasterType: ...
+
 class BaseBinaryDumper(Dumper):
     format: Format
     def dump(self, obj: Any) -> bytes: ...
 
 class BaseTextDumper(Dumper):
     def dump(self, obj: Any) -> bytes: ...
-
-class RsterType: ...
 
 class DatabaseWrapper(Psycopg2DatabaseWrapper):
     SchemaEditorClass: Any

--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -12,6 +12,8 @@ class BaseBinaryDumper(Dumper):
 class BaseTextDumper(Dumper):
     def dump(self, obj: Any) -> bytes: ...
 
+class RsterType: ...
+
 class DatabaseWrapper(Psycopg2DatabaseWrapper):
     SchemaEditorClass: Any
     features: Any

--- a/django-stubs/contrib/gis/db/backends/postgis/base.pyi
+++ b/django-stubs/contrib/gis/db/backends/postgis/base.pyi
@@ -1,11 +1,10 @@
+from functools import lru_cache
 from typing import Any
 
 from django.db.backends.postgresql.base import DatabaseWrapper as Psycopg2DatabaseWrapper
 from psycopg import BaseConnection
 from psycopg.adapt import Dumper
 from psycopg.pq import Format
-
-class RasterType: ...
 
 class BaseBinaryDumper(Dumper):
     format: Format
@@ -22,3 +21,12 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def prepare_database(self) -> None: ...
     def register_geometry_adapters(self, pg_connection: BaseConnection[bytes], clear_caches: bool = False) -> None: ...
+
+class RasterType: ...
+
+@lru_cache
+def postgis_adapters(
+    geo_oid: int | None,
+    geog_oid: int | None,
+    raster_oid: int | None,
+) -> tuple[type[Dumper], type[Dumper]]: ...

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,3 +1,2 @@
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType
-django.contrib.gis.db.backends.postgis.base.postgis_adapters

--- a/scripts/stubtest/allowlist_todo_django60.txt
+++ b/scripts/stubtest/allowlist_todo_django60.txt
@@ -1,4 +1,3 @@
 django.contrib.gis.db.backends.postgis.base.GeographyType
 django.contrib.gis.db.backends.postgis.base.GeometryType
-django.contrib.gis.db.backends.postgis.base.RasterType
 django.contrib.gis.db.backends.postgis.base.postgis_adapters


### PR DESCRIPTION
# Changes I had made

- added the Rastertype in` postgis.base.pyi`
- removed `django.contrib.gis.db.backends.postgis.base.RasterType` from the todo list.
- added `postgis_adapters` in `postgis.base.pyi`
- removed `django.contrib.gis.db.backends.postgis.base.postgis_adapters` from the todo list.
