### PR TITLE
stubs for LogEntry  fields

### DIFF
--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Literal, overload
+from typing import Any, ClassVar, Literal, overload
 from uuid import UUID
 
 from django.contrib.auth.models import User
@@ -48,7 +48,7 @@ class LogEntry(models.Model):
     object_repr: DeferredAttribute | models.CharField[str, str]
     action_flag: DeferredAttribute | models.PositiveSmallIntegerField[int, int]
     change_message: DeferredAttribute | models.TextField[str, str]
-    objects: LogEntryManager  # type: ignore[assignment]
+    objects: ClassVar[LogEntryManager]
     def is_addition(self) -> bool: ...
     def is_change(self) -> bool: ...
     def is_deletion(self) -> bool: ...

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -1,7 +1,10 @@
 from collections.abc import Iterable
-from typing import Any, ClassVar, Literal, overload
+from datetime import datetime
+from typing import Any, Literal, overload
 from uuid import UUID
 
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
 
@@ -33,14 +36,14 @@ class LogEntryManager(models.Manager[LogEntry]):
     ) -> list[LogEntry]: ...
 
 class LogEntry(models.Model):
-    action_time: models.DateTimeField
-    user: models.ForeignKey
-    content_type: models.ForeignKey
-    object_id: models.TextField
-    object_repr: models.CharField
-    action_flag: models.PositiveSmallIntegerField
-    change_message: models.TextField
-    objects: ClassVar[LogEntryManager]
+    action_time: models.DateTimeField[datetime, datetime]
+    user: models.ForeignKey[User, User]
+    content_type: models.ForeignKey[ContentType, ContentType]
+    object_id: models.TextField[str, str]
+    object_repr: models.CharField[str, str]
+    action_flag: models.PositiveSmallIntegerField[int, int]
+    change_message: models.TextField[str, str]
+    objects: LogEntryManager  # type: ignore[assignment]
     def is_addition(self) -> bool: ...
     def is_change(self) -> bool: ...
     def is_deletion(self) -> bool: ...

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -7,6 +7,8 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
+from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
+from django.db.models.query_utils import DeferredAttribute
 
 ADDITION: int
 CHANGE: int
@@ -36,13 +38,16 @@ class LogEntryManager(models.Manager[LogEntry]):
     ) -> list[LogEntry]: ...
 
 class LogEntry(models.Model):
-    action_time: models.DateTimeField[datetime, datetime]
-    user: models.ForeignKey[User, User]
-    content_type: models.ForeignKey[ContentType, ContentType]
-    object_id: models.TextField[str, str]
-    object_repr: models.CharField[str, str]
-    action_flag: models.PositiveSmallIntegerField[int, int]
-    change_message: models.TextField[str, str]
+    action_time: DeferredAttribute | models.DateTimeField[datetime, datetime]
+    user: ForwardManyToOneDescriptor[models.ForeignKey[User, User]] | models.ForeignKey[User, User]
+    content_type: (
+        ForwardManyToOneDescriptor[models.ForeignKey[ContentType, ContentType]]
+        | models.ForeignKey[ContentType, ContentType]
+    )
+    object_id: DeferredAttribute | models.TextField[str, str]
+    object_repr: DeferredAttribute | models.CharField[str, str]
+    action_flag: DeferredAttribute | models.PositiveSmallIntegerField[int, int]
+    change_message: DeferredAttribute | models.TextField[str, str]
     objects: LogEntryManager  # type: ignore[assignment]
     def is_addition(self) -> bool: ...
     def is_change(self) -> bool: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -7,7 +7,6 @@ django.contrib.admin.models.LogEntry.get_action_flag_display
 django.contrib.admin.models.LogEntry.get_next_by_action_time
 django.contrib.admin.models.LogEntry.get_previous_by_action_time
 django.contrib.admin.models.LogEntry.id
-django.contrib.admin.models.LogEntry.object_id
 django.contrib.admin.models.LogEntry.user_id
 django.contrib.admin.site
 django.contrib.admin.sites.site

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -2,18 +2,12 @@
 # Unsorted: there are real problems and things we can really ignore.
 
 django.__main__
-django.contrib.admin.models.LogEntry.action_flag
-django.contrib.admin.models.LogEntry.action_time
-django.contrib.admin.models.LogEntry.change_message
-django.contrib.admin.models.LogEntry.content_type
 django.contrib.admin.models.LogEntry.content_type_id
 django.contrib.admin.models.LogEntry.get_action_flag_display
 django.contrib.admin.models.LogEntry.get_next_by_action_time
 django.contrib.admin.models.LogEntry.get_previous_by_action_time
 django.contrib.admin.models.LogEntry.id
 django.contrib.admin.models.LogEntry.object_id
-django.contrib.admin.models.LogEntry.object_repr
-django.contrib.admin.models.LogEntry.user
 django.contrib.admin.models.LogEntry.user_id
 django.contrib.admin.site
 django.contrib.admin.sites.site


### PR DESCRIPTION
Fix stubs for LogEntry fields in `contrib.admin.models.LogEntry`

 - `action_time` updated to `DateTimeField[datetime, datetime]`
 -  `user and content_type` updated to use explicit `ForeignKey` generics with related models.
 -  `object_id`, `object_repr` and `change_msg` updated to `[str, str]`.
 -  `action_flag` updated to `[int, int]`.  
 -  removed the above from `allowlist_todo.txt`
 
I don't think we need to add any stubs for the rest LogEntry fields as i couldn't find any reference to them in django.