### PR TITLE
Fix MySQL backend feature stubs

### DIFF
--- a/django-stubs/db/backends/mysql/features.pyi
+++ b/django-stubs/db/backends/mysql/features.pyi
@@ -7,43 +7,37 @@ from django.utils.functional import cached_property
 class DatabaseFeatures(BaseDatabaseFeatures):
     connection: DatabaseWrapper
     empty_fetchmany_value: Any
-    allows_group_by_pk: bool
     related_fields_match_type: bool
     allow_sliced_subqueries_with_in: bool
     has_select_for_update: bool
+    has_select_for_update_nowait: bool
+    has_select_for_update_skip_locked: bool
     supports_forward_references: bool
     supports_regex_backreferencing: bool
     supports_date_lookup_using_string: bool
-    can_introspect_autofield: bool
-    can_introspect_binary_field: bool
-    can_introspect_duration_field: bool
-    can_introspect_small_integer_field: bool
-    can_introspect_positive_integer_field: bool
-    introspected_boolean_field_type: str
     supports_timezones: bool
     requires_explicit_null_ordering_when_grouping: bool
-    can_release_savepoints: bool
     atomic_transactions: bool
     can_clone_databases: bool
     supports_temporal_subtraction: bool
-    supports_select_intersection: bool
-    supports_select_difference: bool
     supports_slicing_ordering_in_compound: bool
     supports_index_on_text_field: bool
-    has_case_insensitive_like: bool
+    supports_over_clause: bool
+    supports_frame_range_fixed_distance: bool
     create_test_procedure_without_params_sql: str
     create_test_procedure_with_int_param_sql: str
-    db_functions_convert_bytes_to_str: bool
     supports_partial_indexes: bool
     supports_order_by_nulls_modifier: bool
     order_by_nulls_first: bool
     supports_aggregate_order_by_clause: bool
     supports_json_negative_indexing: bool
 
-    # fake properties (until `property` is generic)
-    supports_frame_range_fixed_distance: bool
-    supports_table_check_constraints: bool
-    can_return_rows_from_bulk_insert: bool
+    @cached_property
+    def minimum_database_version(self) -> tuple[int, ...]: ...  # type: ignore[override]
+    @cached_property
+    def test_collations(self) -> dict[str, str]: ...  # type: ignore[override]
+    @cached_property
+    def django_test_skips(self) -> dict[str, set[str]]: ...  # type: ignore[override]
     @cached_property
     def allows_auto_pk_0(self) -> bool: ...  # type: ignore[override]
     @cached_property
@@ -54,20 +48,18 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def introspected_field_types(self) -> dict[str, str]: ...  # type: ignore[override]
     @cached_property
     def can_return_columns_from_insert(self) -> bool: ...  # type: ignore[override]
+    @property
+    def can_return_rows_from_bulk_insert(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def has_zoneinfo_database(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def is_sql_auto_is_null_enabled(self) -> bool: ...
     @cached_property
-    def supports_over_clause(self) -> bool: ...  # type: ignore[override]
-    @cached_property
     def supports_column_check_constraints(self) -> bool: ...  # type: ignore[override]
+    @property
+    def supports_table_check_constraints(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def can_introspect_check_constraints(self) -> bool: ...  # type: ignore[override]
-    @cached_property
-    def has_select_for_update_skip_locked(self) -> bool: ...  # type: ignore[override]
-    @cached_property
-    def has_select_for_update_nowait(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def has_select_for_update_of(self) -> bool: ...  # type: ignore[override]
     @cached_property
@@ -88,5 +80,15 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def supports_index_column_ordering(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def supports_expression_indexes(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def supports_select_intersection(self) -> bool: ...  # type: ignore[override]
+    @property
+    def supports_select_difference(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def supports_expression_defaults(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def has_native_uuid_field(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def allows_group_by_selected_pks(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def supports_any_value(self) -> bool: ...  # type: ignore[override]

--- a/django-stubs/db/backends/mysql/schema.pyi
+++ b/django-stubs/db/backends/mysql/schema.pyi
@@ -19,6 +19,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_pk: str
     sql_delete_pk: str
     sql_create_index: str
+    sql_alter_column_comment: None  # type: ignore[assignment]
     @property
     def sql_delete_check(self) -> str: ...  # type: ignore[override]
     @property

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -247,14 +247,6 @@ django.contrib.staticfiles.storage.staticfiles_storage
 django.core.cache.cache
 django.db.backends.ddl_references.Expressions
 django.db.backends.mysql.base.DatabaseWrapper.ops
-django.db.backends.mysql.features.DatabaseFeatures.can_return_rows_from_bulk_insert
-django.db.backends.mysql.features.DatabaseFeatures.django_test_skips
-django.db.backends.mysql.features.DatabaseFeatures.minimum_database_version
-django.db.backends.mysql.features.DatabaseFeatures.supports_select_difference
-django.db.backends.mysql.features.DatabaseFeatures.supports_select_intersection
-django.db.backends.mysql.features.DatabaseFeatures.supports_table_check_constraints
-django.db.backends.mysql.features.DatabaseFeatures.test_collations
-django.db.backends.mysql.schema.DatabaseSchemaEditor.sql_alter_column_comment
 django.db.backends.oracle.features.DatabaseFeatures.django_test_skips
 django.db.backends.oracle.features.DatabaseFeatures.introspected_field_types
 django.db.backends.oracle.features.DatabaseFeatures.supports_collation_on_charfield

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -11,9 +11,6 @@ django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
-django.db.backends.mysql.features.DatabaseFeatures.allows_group_by_selected_pks
-django.db.backends.mysql.features.DatabaseFeatures.has_native_uuid_field
-django.db.backends.mysql.features.DatabaseFeatures.supports_expression_defaults
 django.db.backends.oracle.base.DatabaseWrapper.close_pool
 django.db.backends.oracle.base.DatabaseWrapper.is_pool
 django.db.backends.oracle.base.DatabaseWrapper.ops


### PR DESCRIPTION
### PR Summary
This PR fixes the MySQL backend stubs to match runtime. It converts plain `bool` attributes to `@cached_property` or `@property` where Django uses descriptors (like `minimum_database_version`, `allows_group_by_selected_pks`, `supports_select_intersection`). It removes phantom attributes that were in the stubs but never existed at runtime (`allows_group_by_pk`, `can_introspect_autofield`, `can_introspect_duration_field`, etc.) and adds `sql_alter_column_comment: None` to the schema stub. This follows the same pattern already used for sqlite3 and postgresql backends.