### PR TITLE
5.2: Add `ForeignKey.cast_db_type` method

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -3,6 +3,7 @@ from typing import Any, Generic, Literal, TypeVar, overload
 from uuid import UUID
 
 from django.core import validators  # due to weird mypy.stubtest error
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable, Expression
 from django.db.models.fields import NOT_PROVIDED, Field, _AllLimitChoicesTo, _ErrorMessagesMapping, _LimitChoicesTo
@@ -187,6 +188,7 @@ class ForeignKey(ForeignObject[_ST, _GT]):
         error_messages: _ErrorMessagesMapping | None = ...,
         db_comment: str | None = ...,
     ) -> None: ...
+    def cast_db_type(self, connection: BaseDatabaseWrapper) -> str | None: ...
 
 class OneToOneField(ForeignKey[_ST, _GT]):
     _pyi_private_set_type: Any | Combinable

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -2,12 +2,9 @@
 
 # Created for 5.2 update:
 django.contrib.gis.db.backends.mysql.schema.MySQLGISSchemaEditor.__init__
-django.contrib.gis.db.models.ForeignKey.cast_db_type
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
 django.db.backends.oracle.base.DatabaseWrapper.ops
-django.db.models.ForeignKey.cast_db_type
 django.db.models.Q.identity
-django.db.models.fields.related.ForeignKey.cast_db_type


### PR DESCRIPTION
# I have made things!
Add `cast_db_type()` method override stub to `ForeignKey`.

- [x] `django.db.models.fields.related.ForeignKey.cast_db_type`
  - [x] `ForeignKey.cast_db_type(connection)` was added, delegates to `self.target_field.cast_db_type()`

## Related issues

Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream commit
- https://github.com/django/django/commit/de0c7744be