### PR TITLE
5.2: Add `BaseDatabaseFeatures.rounds_to_even`

### DIFF
--- a/django-stubs/db/backends/base/features.pyi
+++ b/django-stubs/db/backends/base/features.pyi
@@ -144,6 +144,7 @@ class BaseDatabaseFeatures:
     prohibits_null_characters_in_text_exception: tuple[ValueError | DataError] | None
     supports_unlimited_charfield: bool
     supports_tuple_comparison_against_subquery: bool
+    rounds_to_even: bool
     test_collations: dict[str, str | None]
     test_now_utc_template: str | None
     insert_test_table_with_defaults: str | None

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -8,7 +8,6 @@ django.contrib.gis.db.models.Field.has_db_default
 django.contrib.gis.db.models.ForeignKey.cast_db_type
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
-django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
 django.db.backends.mysql.features.DatabaseFeatures.allows_group_by_selected_pks


### PR DESCRIPTION
# I have made things!
Add `rounds_to_even` attribute to `BaseDatabaseFeatures`.

- [x] `django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even`
  - [x] `rounds_to_even: bool` was added (default `False`)

## Related issues

Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/18948