### PR TITLE
5.2: Add `BaseDatabaseFeatures.supports_tuple_lookups`

### DIFF
--- a/django-stubs/db/backends/base/features.pyi
+++ b/django-stubs/db/backends/base/features.pyi
@@ -145,6 +145,7 @@ class BaseDatabaseFeatures:
     supports_unlimited_charfield: bool
     supports_tuple_comparison_against_subquery: bool
     rounds_to_even: bool
+    supports_tuple_lookups: bool
     test_collations: dict[str, str | None]
     test_now_utc_template: str | None
     insert_test_table_with_defaults: str | None

--- a/django-stubs/db/backends/oracle/features.pyi
+++ b/django-stubs/db/backends/oracle/features.pyi
@@ -68,4 +68,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def bare_select_suffix(self) -> str: ...  # type: ignore[override]
     @cached_property
-    def supports_tuple_lookups(self) -> bool: ...
+    def supports_tuple_lookups(self) -> bool: ...  # type: ignore[override]

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -5,7 +5,6 @@ django.contrib.gis.db.backends.mysql.schema.MySQLGISSchemaEditor.__init__
 django.contrib.gis.db.models.ForeignKey.cast_db_type
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
-django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
 django.db.backends.oracle.base.DatabaseWrapper.ops
 django.db.models.ForeignKey.cast_db_type


### PR DESCRIPTION
# I have made things!
Add `supports_tuple_lookups` to `BaseDatabaseFeatures` 

- [x] `django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups`
  - [x] `supports_tuple_lookups: bool` was added (default `True`)
- [x] `django.db.backends.oracle.features.DatabaseFeatures.supports_tuple_lookups`
  - [x] Overridden as `@cached_property` (Oracle >= 23.4)

## Related issues

Refs
- https://github.com/typeddjango/django-stubs/issues/1493