### PR TITLE
5.2: Add `BaseDatabaseSchemaEditor.sql_pk_constraint`

### DIFF
--- a/django-stubs/db/backends/base/schema.pyi
+++ b/django-stubs/db/backends/base/schema.pyi
@@ -51,6 +51,7 @@ class BaseDatabaseSchemaEditor(AbstractContextManager[Any]):
     sql_delete_index: str
     sql_create_pk: str
     sql_delete_pk: str
+    sql_pk_constraint: str
     sql_delete_procedure: str
     sql_alter_table_comment: str
     sql_alter_column_comment: str

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -4,6 +4,5 @@
 django.contrib.gis.db.backends.mysql.schema.MySQLGISSchemaEditor.__init__
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
-django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
 django.db.backends.oracle.base.DatabaseWrapper.ops
 django.db.models.Q.identity

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -5,6 +5,5 @@ django.contrib.gis.db.backends.mysql.schema.MySQLGISSchemaEditor.__init__
 django.contrib.gis.db.models.Q.identity
 django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
-django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
 django.db.backends.oracle.base.DatabaseWrapper.ops
 django.db.models.Q.identity


### PR DESCRIPTION
# I have made things!
Add `sql_pk_constraint` attribute to `BaseDatabaseSchemaEditor`.

- [x] `django.dgitb.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint`
  - [x] `sql_pk_constraint: str` was added (used for CompositePrimaryKey)

## Related issues

Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream PR
- https://github.com/django/django/pull/18056