### PR TITLE
5.2: Update MySQL `DatabaseFeatures cached_property overrides`

### DIFF
--- a/django-stubs/db/backends/mysql/features.pyi
+++ b/django-stubs/db/backends/mysql/features.pyi
@@ -90,3 +90,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def supports_expression_indexes(self) -> bool: ...  # type: ignore[override]
     @cached_property
     def supports_any_value(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def supports_expression_defaults(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def has_native_uuid_field(self) -> bool: ...  # type: ignore[override]
+    @cached_property
+    def allows_group_by_selected_pks(self) -> bool: ...  # type: ignore[override]

--- a/scripts/stubtest/allowlist_todo_django52.txt
+++ b/scripts/stubtest/allowlist_todo_django52.txt
@@ -11,9 +11,6 @@ django.contrib.gis.geos.prototypes.io.DEFAULT_TRIM_VALUE
 django.db.backends.base.features.BaseDatabaseFeatures.rounds_to_even
 django.db.backends.base.features.BaseDatabaseFeatures.supports_tuple_lookups
 django.db.backends.base.schema.BaseDatabaseSchemaEditor.sql_pk_constraint
-django.db.backends.mysql.features.DatabaseFeatures.allows_group_by_selected_pks
-django.db.backends.mysql.features.DatabaseFeatures.has_native_uuid_field
-django.db.backends.mysql.features.DatabaseFeatures.supports_expression_defaults
 django.db.backends.oracle.base.DatabaseWrapper.close_pool
 django.db.backends.oracle.base.DatabaseWrapper.is_pool
 django.db.backends.oracle.base.DatabaseWrapper.ops


### PR DESCRIPTION
# I have made things!
Add `@cached_property` overrides for MySQL `DatabaseFeatures`.

These attributes were changed from plain class attributes to `@cached_property` in Django because they depend on runtime MySQL/MariaDB version checks.

- [x] `django.db.backends.mysql.features.DatabaseFeatures`
  - [x] `allows_group_by_selected_pks` changed to `@cached_property`
  - [x] `has_native_uuid_field` changed to `@cached_property`
  - [x] `supports_expression_defaults` changed to `@cached_property`

## Related issues

Refs
- https://github.com/typeddjango/django-stubs/issues/1493

Upstream commits
- https://github.com/django/django/commit/0257426fe1fe9d146fd5813f09d909917ff59360
- https://github.com/django/django/commit/7cd187a5ba58d7769039f487faeb9a5a2ff05540
- https://github.com/django/django/commit/7414704e88d73dafbcfbb85f9bc54cb6111439d3