### PR TITLE
Type the view parameter of conf.urls.static.static

### DIFF
--- a/django-stubs/conf/urls/static.pyi
+++ b/django-stubs/conf/urls/static.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from django.http.response import HttpResponseBase
 from django.urls.resolvers import URLPattern
 
-def static(prefix: str, view: Callable = ..., **kwargs: Any) -> list[URLPattern]: ...
+def static(prefix: str, view: Callable[..., HttpResponseBase] = ..., **kwargs: Any) -> list[URLPattern]: ...

--- a/tests/assert_type/urls/test_conf.py
+++ b/tests/assert_type/urls/test_conf.py
@@ -1,4 +1,5 @@
 from django.conf.urls.i18n import urlpatterns as i18n_urlpatterns
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth.views import LoginView
 from django.contrib.flatpages import urls as flatpages_urls
@@ -45,3 +46,13 @@ assert_type(path("i18n/", include((i18n_urlpatterns, "i18n"))), URLResolver)
 assert_type(path("admindocs/", include("django.contrib.admindocs.urls")), URLResolver)
 assert_type(path("admindocs/", include(("django.contrib.admindocs.urls", "i18n"))), URLResolver)
 assert_type(path("", include(staticfiles_urlpatterns(prefix="static/"))), URLResolver)
+
+# Test 'static'
+assert_type(static("/media/"), list[URLPattern])
+assert_type(static("/media/", document_root="/tmp/media"), list[URLPattern])
+
+
+def custom_serve(request: object, path: str) -> HttpResponse: ...
+
+
+assert_type(static("/media/", view=custom_serve), list[URLPattern])


### PR DESCRIPTION
## Summary
- Change `view: Callable` to `view: Callable[..., HttpResponseBase]` in `django.conf.urls.static.static`, eliminating the "partially unknown" type warning from strict type checkers (e.g. basedpyright)
- This is consistent with `re_path`'s existing `view` parameter type
- Add `assert_type` test coverage for `static()`

## Test plan
- [x] `uv run pytest -n auto` — 497 passed
- [x] `uv run mypy .` — no issues in 788 source files
- [x] `uvx pre-commit run` — all checks passed
- [x] `./scripts/stubtest.sh` — no new errors (module not affected)
