### PR TITLE
Fix edge case with `Prefetch` + `to_attr` and multiple levels

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -653,6 +653,12 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
         if to_attr and check_valid_attr_value(
             ctx, django_context, qs_model, to_attr, new_attr_names=set(new_attrs.keys())
         ):
+            # When traversing multiple relations (e.g. "groups__user_set"), the to_attr is set
+            # on the last item of the chain (e.g. Group), not on the root model (e.g. User).
+            # We can't annotate an intermediate model from here, so skip adding the annotation
+            # to the root model to avoid incorrectly attributing to_attr to it.
+            if lookup and "__" in lookup:
+                continue
             new_attrs[to_attr] = api.named_generic_type(
                 "builtins.list",
                 [elem_model if elem_model is not None else AnyType(TypeOfAny.special_form)],

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -343,3 +343,29 @@
 
                 class Book(models.Model):
                     author = models.ForeignKey(Person, on_delete=models.CASCADE)
+
+-   case: prefetch_related_traversing_multiple_relations
+    main: |
+        from typing_extensions import reveal_type
+        from django.db.models import Prefetch, F
+        from django.contrib.auth.models import User, Group
+
+        # When prefetching a relation that is traversing multiple relations
+        # The `to_attr` arg is set on the last item of the chain, not the initial one.
+        # We should NOT annotate the root model (User) with the to_attr.
+        user = (
+            User.objects
+            .prefetch_related(Prefetch("groups__user_set", User.objects.all(), to_attr="users"))
+            .get()
+        )
+        reveal_type(user) # N: Revealed type is "django.contrib.auth.models.User"
+        reveal_type(user.groups) # N: Revealed type is "django.contrib.auth.models.Group_ManyRelatedManager[django.contrib.auth.models.User_groups]"
+        last_group = user.groups.get()
+        reveal_type(last_group) # N: Revealed type is "django.contrib.auth.models.Group"
+
+        # Ideally we would like the type to be inferred as list[User] here
+        last_group.users # E: "Group" has no attribute "users"; maybe "user_set"?  [attr-defined]
+
+    installed_apps:
+        - django.contrib.auth
+        - django.contrib.contenttypes


### PR DESCRIPTION
# I have made things!
Fixes an edge case where a `Prefetch` with `to_attr` that traverses multiple relations was annotating the attribute on the initial model instead of the intermediate one it actually ends up on at runtime.

```python
from django.db.models import Prefetch
from django.contrib.auth.models import User

user = (
    User.objects
    .prefetch_related(Prefetch("groups__user_set", User.objects.all(), to_attr="users"))
    .get()
)
user.users  # Revealed type was "list[User]" but is an `AttributeError` at runtime
user.groups.last().users # Mypy attribute error but it's actually present at runtime
```
In this example, `to_attr="users"` is stored on the `Group` instances you get when doing `user.groups.all()` (the intermediate model), not on `User` (the queryset's root model). Previously, the plugin incorrectly annotated it on User.