### PR TITLE
Fix `django.utils.inspect` stubtest errors on Python 3.14+

### DIFF
--- a/django-stubs/utils/inspect.pyi
+++ b/django-stubs/utils/inspect.pyi
@@ -1,10 +1,17 @@
+import functools
+import sys
+import threading
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from inspect import _ParameterKind
+from inspect import Signature, _ParameterKind
 from types import FunctionType
 from typing import Any, TypeGuard
 
 ARG_KINDS: frozenset[_ParameterKind]
+
+if sys.version_info >= (3, 14):
+    lock: threading.Lock
+    safe_signature_from_callable: functools.partial[Signature]
 
 def get_func_args(func: Callable[..., Any]) -> list[str]: ...
 def get_func_full_args(func: Callable[..., Any]) -> list[tuple[str, str] | tuple[str]]: ...


### PR DESCRIPTION
# I have made things!

The following errors are only present when running stubtest on Python 3.14+ due to some things added conditionally:

```
error: django.utils.inspect.lock is not present in stub
Stub: in file /home/nick/Sources/_external/django-stubs/django-stubs/utils/inspect.pyi
MISSING
Runtime:
<unlocked _thread.lock object at 0x7f44a774d490>

error: django.utils.inspect.safe_signature_from_callable is not present in stub
Stub: in file /home/nick/Sources/_external/django-stubs/django-stubs/utils/inspect.pyi
MISSING
Runtime:
def (obj, *, follow_wrapper_chains=True, skip_bound_arg=True, globals=None, locals=None, eval_str...
```