### PR TITLE
Cleanup: remove unused stubs allowlist entries

### DIFF
--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -150,8 +150,3 @@ django.forms.widgets.ChoiceWidget.template_name
 django.db.models.expressions.rhs
 django.db.models.expressions.result
 django.db.models.expressions.lhs
-
-# Django 6.0.3 security fix new APIs:
-django.utils._os.makedirs
-django.utils._os.safe_makedirs
-django.utils.inspect.signature


### PR DESCRIPTION
While running `stubtest` on the latest master, I identified several unused entries in the allowlist. This PR removes them to keep the configuration clean and ensure these areas are properly checked.

**Removed entries:**
- `django.utils._os.makedirs`
- `django.utils._os.safe_makedirs`
- `django.utils.inspect.signature`