### PR TITLE
adding warnings for __isnull (#3033)

### DIFF
--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -33,7 +33,7 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
             except LookupsAreUnsupported:
                 pass
             else:
-                if field.null is False:
+                if getattr(field, "null", None) is False:
                     ctx.api.fail(
                         f'Field "{field.name}" does not allow NULL;'
                         f'using "__isnull=True" will always return an empty queryset.',

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -33,7 +33,7 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
             except LookupsAreUnsupported:
                 pass
             else:
-                if getattr(field, "null", None) is False:
+                if field is not None and getattr(field, "null", None) is False:
                     ctx.api.fail(
                         f'Field "{field.name}" does not allow NULL;'
                         f'using "__isnull=True" will always return an empty queryset.',

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -1,8 +1,8 @@
 from mypy.plugin import MethodContext
-from mypy.types import AnyType, Instance, ProperType, TypeOfAny, get_proper_type
+from mypy.types import AnyType, Instance, LiteralType, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext
+from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
 
@@ -11,6 +11,7 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
     django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
     if django_model is None:
         return ctx.default_return_type
+    model_cls = django_model.cls
 
     # Expected formal arguments for filter methods are `*args` and `**kwargs`. We'll only typecheck
     # `**kwargs`, which means that `arg_names[1]` is what we're interested in.
@@ -21,6 +22,24 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
         if lookup_kwarg is None:
             continue
         provided_type = get_proper_type(provided_type)
+
+        if lookup_kwarg.endswith("__isnull"):
+            is_true_literal = isinstance(provided_type, LiteralType)
+
+            if is_true_literal:
+                lookup = lookup_kwarg[:-8]
+
+                try:
+                    field, _ = django_context.resolve_lookup_into_field(model_cls, lookup)
+                except (LookupsAreUnsupported, Exception):
+                    field = None
+
+                if field is not None and not getattr(field, "null", False):
+                    ctx.api.fail(
+                        f'Filed "{field.name}" does not allow NULL;'
+                        f'using "__isnull=True" will always return an empty queryset.',
+                        ctx.context,
+                    )
         if isinstance(provided_type, Instance) and provided_type.type.has_base(
             fullnames.COMBINABLE_EXPRESSION_FULLNAME
         ):

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -3,9 +3,20 @@ from mypy.plugin import MethodContext
 from mypy.types import AnyType, Instance, LiteralType, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
+from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
+
+
+def _extract_literal_bool(provided_type: ProperType) -> bool | None:
+    literal: LiteralType | None = None
+    if isinstance(provided_type, LiteralType):
+        literal = provided_type
+    elif isinstance(provided_type, Instance) and provided_type.last_known_value is not None:
+        literal = provided_type.last_known_value
+    if literal is not None and isinstance(literal.value, bool):
+        return literal.value
+    return None
 
 
 def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
@@ -25,20 +36,40 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
         provided_type = get_proper_type(provided_type)
 
         lookup_path, _, lookup_name = lookup_kwarg.rpartition(LOOKUP_SEP)
-        is_true_literal = isinstance(provided_type, LiteralType) and provided_type.value is True
 
-        if lookup_name == "isnull" and is_true_literal:
-            try:
-                field, _ = django_context.resolve_lookup_into_field(model_cls, lookup_path)
-            except LookupsAreUnsupported:
-                pass
-            else:
+        if lookup_name == "isnull" and isinstance(provided_type, LiteralType):
+            isnull_value = _extract_literal_bool(provided_type)
+
+            if isnull_value is not None and lookup_path:
+                field = None
+
+                try:
+                    real_model_cls = django_context.get_model_class_by_fullname(model_cls.fullname)
+                    if real_model_cls is not None:
+                        path_parts = lookup_path.split(LOOKUP_SEP)
+                        current_model = real_model_cls
+
+                        for part in path_parts:
+                            field = current_model._meta.get_fidld(part)
+
+                            if hasattr(field, "related_model") and field.related_model is not None:
+                                current_model = field.related_model
+                except Exception:
+                    field = None
+
                 if field is not None and getattr(field, "null", None) is False:
-                    ctx.api.fail(
-                        f'Field "{field.name}" does not allow NULL;'
-                        f'using "__isnull=True" will always return an empty queryset.',
-                        ctx.context,
-                    )
+                    if isnull_value is True:
+                        ctx.api.fail(
+                            f'Field "{field.name}" does not allow NULL;'
+                            f'using "__isnull=True" will always return an empty queryset.',
+                            ctx.context,
+                        )
+                    elif isnull_value is False:
+                        ctx.api.fail(
+                            f'Field "{field.name}" does not allow NULL;'
+                            f'using "__isnull=False" is a no-op and can be removed',
+                            ctx.context,
+                        )
 
         if isinstance(provided_type, Instance) and provided_type.type.has_base(
             fullnames.COMBINABLE_EXPRESSION_FULLNAME

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -1,3 +1,4 @@
+from django.db.models.constants import LOOKUP_SEP
 from mypy.plugin import MethodContext
 from mypy.types import AnyType, Instance, LiteralType, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
@@ -23,23 +24,22 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
             continue
         provided_type = get_proper_type(provided_type)
 
-        if lookup_kwarg.endswith("__isnull"):
-            is_true_literal = isinstance(provided_type, LiteralType)
+        lookup_path, _, lookup_name = lookup_kwarg.rpartition(LOOKUP_SEP)
+        is_true_literal = isinstance(provided_type, LiteralType) and provided_type.value is True
 
-            if is_true_literal:
-                lookup = lookup_kwarg[:-8]
-
-                try:
-                    field, _ = django_context.resolve_lookup_into_field(model_cls, lookup)
-                except (LookupsAreUnsupported, Exception):
-                    field = None
-
-                if field is not None and not getattr(field, "null", False):
+        if lookup_name == "isnull" and is_true_literal:
+            try:
+                field, _ = django_context.resolve_lookup_into_field(model_cls, lookup_path)
+            except LookupsAreUnsupported:
+                pass
+            else:
+                if field.null is False:
                     ctx.api.fail(
-                        f'Filed "{field.name}" does not allow NULL;'
+                        f'Field "{field.name}" does not allow NULL;'
                         f'using "__isnull=True" will always return an empty queryset.',
                         ctx.context,
                     )
+
         if isinstance(provided_type, Instance) and provided_type.type.has_base(
             fullnames.COMBINABLE_EXPRESSION_FULLNAME
         ):

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -23,7 +23,6 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
     django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
     if django_model is None:
         return ctx.default_return_type
-    model_cls = django_model.cls
 
     # Expected formal arguments for filter methods are `*args` and `**kwargs`. We'll only typecheck
     # `**kwargs`, which means that `arg_names[1]` is what we're interested in.
@@ -44,13 +43,13 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
                 field = None
 
                 try:
-                    real_model_cls = django_context.get_model_class_by_fullname(model_cls.fullname)
+                    real_model_cls = django_context.get_model_class_by_fullname(django_model.cls.fullname)
                     if real_model_cls is not None:
                         path_parts = lookup_path.split(LOOKUP_SEP)
                         current_model = real_model_cls
 
                         for part in path_parts:
-                            field = current_model._meta.get_fidld(part)
+                            field = current_model._meta.get_field(part)
 
                             if hasattr(field, "related_model") and field.related_model is not None:
                                 current_model = field.related_model

--- a/tests/typecheck/db/models/test_filter_isnull.yml
+++ b/tests/typecheck/db/models/test_filter_isnull.yml
@@ -8,7 +8,9 @@
       class Book(models.Model):
         author = models.ForeignKey(Author, on_delete=models.CASCADE)
 
-      Book.objects.filter(author__name__isnull==False) # E: Field "name" does not allow NULL
+      Book.objects.filter(author__name__isnull==False)
+  out:  |
+      main:9: error: Field "name" does not allow NULL
 
 - case: filter_isnull_on_non_nullable_field
   main: |

--- a/tests/typecheck/db/models/test_filter_isnull.yml
+++ b/tests/typecheck/db/models/test_filter_isnull.yml
@@ -1,22 +1,192 @@
-- case: filter_isnull_on_related_field
+- case: filter_isnull_true_on_non_nullable_field_is_an_error
   main: |
-      from django.db import models
+    from myapp.models import MyModel
+    MyModel.objects.filter(name__isnull=True)  # E: Field "name" does not allow NULL; using "__isnull=True" will always return an empty queryset.  [misc]
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
 
-      class Author(models.Model):
-        name = models.CharField(null=False)
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100)
 
-      class Book(models.Model):
-        author = models.ForeignKey(Author, on_delete=models.CASCADE)
+            class Meta:
+                app_label = "myapp"
 
-      Book.objects.filter(author__name__isnull==False)
-  out:  |
-      main:9: error: Field "name" does not allow NULL
 
-- case: filter_isnull_on_non_nullable_field
+- case: filter_isnull_false_on_non_nullable_field_is_a_noop_error
   main: |
-      from django.db import models
+    from myapp.models import MyModel
+    MyModel.objects.filter(name__isnull=False)  # E: Field "name" does not allow NULL; using "__isnull=False" is a no-op and can be removed.  [misc]
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
 
-      class User(models.model):
-        username = models.CharField(null=False)
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100)
 
-      User.objects.filter(username__isnull=True) # E: Field "username" does not allow NULL
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_true_on_nullable_field_is_allowed
+  main: |
+    from myapp.models import MyModel
+    MyModel.objects.filter(name__isnull=True)
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100, null=True)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_false_on_nullable_field_is_allowed
+  main: |
+    from myapp.models import MyModel
+    MyModel.objects.filter(name__isnull=False)
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100, null=True)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_with_plain_bool_variable_does_not_raise
+  # A runtime bool variable is not a LiteralType — its value cannot be
+  # statically determined, so no error should be emitted.
+  main: |
+    from myapp.models import MyModel
+    flag: bool
+    MyModel.objects.filter(name__isnull=flag)
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_true_on_related_field_traversal_non_nullable
+  # Traversing a FK: the resolved leaf field "name" is non-nullable → error.
+  main: |
+    from myapp.models import Order
+    Order.objects.filter(customer__name__isnull=True)  # E: Field "name" does not allow NULL; using "__isnull=True" will always return an empty queryset.  [misc]
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class Customer(models.Model):
+            name = models.CharField(max_length=100)
+
+            class Meta:
+                app_label = "myapp"
+
+        class Order(models.Model):
+            customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_true_on_nullable_fk_field_itself_is_allowed
+  # __isnull directly on a nullable FK ("has no related object") must not be flagged.
+  main: |
+    from myapp.models import Order
+    Order.objects.filter(customer__isnull=True)
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class Customer(models.Model):
+            name = models.CharField(max_length=100)
+
+            class Meta:
+                app_label = "myapp"
+
+        class Order(models.Model):
+            customer = models.ForeignKey(Customer, null=True, on_delete=models.SET_NULL)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_mixed_kwargs_only_non_nullable_field_errors
+  # Only the non-nullable field produces an error; the nullable one is silent.
+  main: |
+    from myapp.models import MyModel
+    MyModel.objects.filter(
+        name__isnull=True,  # E: Field "name" does not allow NULL; using "__isnull=True" will always return an empty queryset.  [misc]
+        bio__isnull=True,
+    )
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class MyModel(models.Model):
+            name = models.CharField(max_length=100)
+            bio = models.TextField(null=True)
+
+            class Meta:
+                app_label = "myapp"
+
+
+- case: filter_isnull_on_integer_field_non_nullable
+  # The check is field-type-agnostic: IntegerField with null=False also triggers.
+  main: |
+    from myapp.models import MyModel
+    MyModel.objects.filter(age__isnull=True)  # E: Field "age" does not allow NULL; using "__isnull=True" will always return an empty queryset.  [misc]
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class MyModel(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                app_label = "myapp"

--- a/tests/typecheck/db/models/test_filter_isnull.yml
+++ b/tests/typecheck/db/models/test_filter_isnull.yml
@@ -1,0 +1,20 @@
+- case: filter_isnull_on_related_field
+  main: |
+      from django.db import models
+
+      class Author(models.Model):
+        name = models.CharField(null=False)
+
+      class Book(models.Model):
+        author = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+      Book.objects.filter(author__name__isnull==False) # E: Field "name" does not allow NULL
+
+- case: filter_isnull_on_non_nullable_field
+  main: |
+      from django.db import models
+
+      class User(models.model):
+        username = models.CharField(null=False)
+
+      User.objects.filter(username__isnull=True) # E: Field "username" does not allow NULL


### PR DESCRIPTION
This PR adds the feature to generate warnings while incorrectly using __isnull feature, 
 - Detect lookups ending with `__isnull`
 - Check whether the provided value is `Literal[True]`
 - Remove the `__isnull` suffix to obtain the field lookup path.
 - Resolve the lookup using `django_context.resolve_lookup_into_field`.
 - Inspect the resolved Django `Field.null` attribute.
 - If the field has `null=False`, emit a mypy error.

## Related issues
- Closes #3033