### PR TITLE
Bump pyright target from Python 3.8 to 3.10

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -18,6 +18,6 @@
     // Stubs are allowed to use private variables
     "reportPrivateUsage": "none",
     "stubPath": ".",
-    "pythonVersion": "3.8",
+    "pythonVersion": "3.10",
     "pythonPlatform": "All",
 }


### PR DESCRIPTION
### PR Summary
I know the project doesn't fully support pyright right now (the stubs check runs with `continue-on-error: true`), but `pyrightconfig.json` was targeting Python 3.8 while the project minimum is 3.10. This caused ~2,400 false positives from pyright not understanding `TypeAlias`, `X | Y` union syntax, builtin generic subscripts etc. Bumping to 3.10 drops pyright errors from 7,240 to 4,777, eliminating the noise so the remaining errors are actually meaningful when we eventually enforce pyright.