### PR TITLE
Fix order_by false positives with field transforms

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -12,6 +12,7 @@ from django.db.models.fields.related_descriptors import (
     ReverseOneToOneDescriptor,
 )
 from django.db.models.fields.reverse_related import ForeignObjectRel
+from django.db.models.lookups import Transform
 from django.db.models.sql.query import Query
 from mypy.checker import TypeChecker
 from mypy.errorcodes import NO_REDEF
@@ -912,9 +913,18 @@ def _validate_order_by_lookup(ctx: MethodContext, model_cls: type[Model], parts:
         return
 
     try:
-        Query(model_cls).names_to_path(parts, model_cls._meta, fail_on_missing=True)
+        _, final_field, _, remainder = Query(model_cls).names_to_path(parts, model_cls._meta)
     except FieldError as exc:
         ctx.api.fail(exc.args[0], ctx.context)
+        return
+
+    if remainder:
+        # Check if the trailing part is a valid transform (e.g. __year, __month) on the field.
+        # Transforms are allowed in order_by, but lookups (e.g. __exact) are not.
+        lookup_cls = final_field.get_lookups().get(remainder[0])
+        if lookup_cls is None or not issubclass(lookup_cls, Transform):
+            msg = f"Cannot resolve keyword '{remainder[0]}' into field or transform on '{final_field.name}'."
+            ctx.api.fail(msg, ctx.context)
 
 
 def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> MypyType:

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -85,7 +85,7 @@
         Article.objects.order_by("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: author, author_id, content, id, published, title  [misc]
 
         # Invalid chained lookup
-        Article.objects.order_by("author__nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: article, email, id, name  [misc]
+        Article.objects.order_by("author__nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field or transform on 'author'.  [misc]
 
         # Descending invalid
         Article.objects.order_by("-nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: author, author_id, content, id, published, title  [misc]
@@ -100,7 +100,7 @@
 
         # Literal typed invalid FK traversal
         field3: Literal["author__nonexistent"] = "author__nonexistent"
-        Article.objects.order_by(field3)  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: article, email, id, name  [misc]
+        Article.objects.order_by(field3)  # E: Cannot resolve keyword 'nonexistent' into field or transform on 'author'.  [misc]
 
         # earliest / latest with invalid fields
         Article.objects.earliest("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: author, author_id, content, id, published, title  [misc]
@@ -112,10 +112,10 @@
             await Article.objects.alatest("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: author, author_id, content, id, published, title  [misc]
 
         # Lookup suffix on a valid field — __exact is a lookup, not a traversal
-        Article.objects.order_by("title__exact")  # E: Cannot resolve keyword 'exact' into field. Join on 'title' not permitted.  [misc]
+        Article.objects.order_by("title__exact")  # E: Cannot resolve keyword 'exact' into field or transform on 'title'.  [misc]
 
         # Invalid field at depth > 2
-        Article.objects.order_by("author__name__nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Join on 'name' not permitted.  [misc]
+        Article.objects.order_by("author__name__nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field or transform on 'name'.  [misc]
 
         # values() then order_by with invalid field
         Article.objects.values("title").order_by("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: author, author_id, content, id, published, title  [misc]
@@ -134,3 +134,26 @@
                     content = models.TextField()
                     published = models.BooleanField(default=False)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name="article")
+
+-   case: order_by_with_field_transforms
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article
+
+        Article.objects.order_by("created__year", "created__month")
+        Article.objects.order_by("-created__year")
+        Article.objects.order_by("author__created__year")
+        Article.objects.values("created__month", "created__year").order_by("created__year")
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Author(models.Model):
+                    created = models.DateTimeField(auto_now_add=True)
+
+                class Article(models.Model):
+                    created = models.DateTimeField(auto_now_add=True)
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)


### PR DESCRIPTION
The new `order_by` validation introduced in https://github.com/typeddjango/django-stubs/pull/3158 generated some false-positives in my project due to the use of field transforms.

I'm hesitant to add a new dependency on the Django runtime by querying the field lookups, but let me know if it makes sense in this case.

*Full disclosure:* this PR was partly written with AI, though read carefully after that.