### PR TITLE
Loosen ListFilter.choices() return type to allow custom filter templates

### DIFF
--- a/django-stubs/contrib/admin/filters.pyi
+++ b/django-stubs/contrib/admin/filters.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from datetime import date, datetime
 from typing import Any, ClassVar
 
@@ -14,7 +14,7 @@ from django.http.request import HttpRequest
 from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _StrOrPromise
 from django.utils.safestring import SafeString
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, override
 
 class _ListFilterChoices(TypedDict):
     selected: bool
@@ -30,7 +30,7 @@ class ListFilter:
         self, request: HttpRequest, params: dict[str, str], model: type[Model], model_admin: ModelAdmin
     ) -> None: ...
     def has_output(self) -> bool: ...
-    def choices(self, changelist: ChangeList) -> Iterator[_ListFilterChoices]: ...
+    def choices(self, changelist: ChangeList) -> Iterator[Mapping[str, object]]: ...
     def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet | None: ...
     def expected_parameters(self) -> list[str | None]: ...
 
@@ -43,6 +43,8 @@ class SimpleListFilter(FacetsMixin, ListFilter):
     lookup_choices: list[tuple[str, _StrOrPromise]]
     def value(self) -> str | None: ...
     def lookups(self, request: HttpRequest, model_admin: ModelAdmin) -> Iterable[tuple[str, _StrOrPromise]] | None: ...
+    @override
+    def choices(self, changelist: ChangeList) -> Iterator[_ListFilterChoices]: ...
 
 class FieldListFilter(FacetsMixin, ListFilter):
     list_separator: ClassVar[str]
@@ -71,6 +73,8 @@ class FieldListFilter(FacetsMixin, ListFilter):
         model_admin: ModelAdmin,
         field_path: str,
     ) -> FieldListFilter: ...
+    @override
+    def choices(self, changelist: ChangeList) -> Iterator[_ListFilterChoices]: ...
 
 class RelatedFieldListFilter(FieldListFilter):
     lookup_kwarg: str

--- a/tests/assert_type/contrib/admin/test_filters.py
+++ b/tests/assert_type/contrib/admin/test_filters.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING
 
 from django.contrib.admin.filters import FieldListFilter, ListFilter, SimpleListFilter, _ListFilterChoices
-from typing_extensions import assert_type
+from typing_extensions import assert_type, override
 
 if TYPE_CHECKING:
     from django.contrib.admin.views.main import ChangeList
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 # This can be useful for user who customized the builtin admin template (`admin/filter.html`) with something
 # expecting a different type
 class MyListFilter(ListFilter):
+    @override
     def choices(self, changelist: ChangeList) -> Iterator[Mapping[str, object]]:
         yield {"label": "All items", "icon": "star", "count": 42, "active": True}
 

--- a/tests/assert_type/contrib/admin/test_filters.py
+++ b/tests/assert_type/contrib/admin/test_filters.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING
+
+from django.contrib.admin.filters import FieldListFilter, ListFilter, SimpleListFilter, _ListFilterChoices
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.contrib.admin.views.main import ChangeList
+
+
+# Custom ListFilter subclass with a completely different choices() schema.
+# The loosened base return type (Mapping[str, object]) allows this.
+# This can be useful for user who customized the builtin admin template (`admin/filter.html`) with something
+# expecting a different type
+class MyListFilter(ListFilter):
+    def choices(self, changelist: ChangeList) -> Iterator[Mapping[str, object]]:
+        yield {"label": "All items", "icon": "star", "count": 42, "active": True}
+
+
+def test_choices(
+    changelist: ChangeList,
+    base_filter: ListFilter,
+    simple_filter: SimpleListFilter,
+    field_filter: FieldListFilter,
+    custom_filter: MyListFilter,
+) -> None:
+    # Base ListFilter.choices() returns the loosened type: Iterator[Mapping[str, object]]
+    assert_type(base_filter.choices(changelist), Iterator[Mapping[str, object]])
+
+    # SimpleListFilter and FieldListFilter narrow the return type via @override
+    assert_type(simple_filter.choices(changelist), Iterator[_ListFilterChoices])
+    assert_type(field_filter.choices(changelist), Iterator[_ListFilterChoices])
+
+    # Custom subclass with a completely different schema works without type errors
+    assert_type(custom_filter.choices(changelist), Iterator[Mapping[str, object]])


### PR DESCRIPTION
Fix `ListFilter.choice()` to return a more generic type, since the specific content is supposed to be customised and used by subclasses.

Instead, I pushed down to subclasses the more restrictive type, since those actually expect those fields to be there.

Previously AI generated PR description:

> ## Summary
> 
> - Change `ListFilter.choices()` return type from `Iterator[_ListFilterChoices]` to `Iterator[Mapping[str, object]]` since the base class imposes no structure on the returned dicts
> - Add explicit `choices()` declarations on `SimpleListFilter` and `FieldListFilter` with the specific `Iterator[_ListFilterChoices]` return type, where Django actually enforces the dict shape
> - Fixes spurious mypy `[override]` errors for `ListFilter` subclasses that use custom templates with different dict keys (e.g. multi-select filters yielding `{"selected": bool, "value": str, "display": str}` without `query_string`)
> 
> ## Why `Mapping[str, object]` instead of `dict[str, Any]`?
> 
> Neither mypy nor pyright consider `TypedDict` a structural subtype of `dict` (even `dict[str, Any]`), so using `dict[str, ...]` as the base return type prevents subclasses from narrowing to a `TypedDict` without triggering `[override]` errors.
> 
> `TypedDict` IS recognized as a subtype of `Mapping` by both type checkers, so `Iterator[Mapping[str, object]]` allows the base class to accept any dict-like return while letting subclasses narrow to `Iterator[_ListFilterChoices]`.
> 
> ## Motivation
> 
> `ListFilter` is the base class and its `choices()` method raises `NotImplementedError` — it's meant to be overridden. The consuming code in Django (`admin_list_filter` template tag) just passes `list(spec.choices(cl))` to the template context without enforcing any specific shape. Subclasses with custom templates can return dicts with entirely different keys, but the current stub forces the `_ListFilterChoices` TypedDict shape on all subclasses, causing spurious `[override]` errors.
> 
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)