### PR TITLE
Add `django-modern-rest` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ See mypy section on [generic classes subclasses](https://mypy.readthedocs.io/en/
 - [`djangorestframework-stubs`](https://github.com/typeddjango/djangorestframework-stubs) - Stubs for Django REST Framework.
 - [`pytest-mypy-plugins`](https://github.com/typeddjango/pytest-mypy-plugins) - `pytest` plugin that we use for testing `mypy` stubs and plugins.
 - [`wemake-django-template`](https://github.com/wemake-services/wemake-django-template) - Create new typed Django projects in seconds.
+- [`django-modern-rest`](https://github.com/wemake-services/django-modern-rest) - Modern REST framework for Django with everything properly typed.
 
 ## Contributing
 


### PR DESCRIPTION
I worked on this project for the last 4 months: https://github.com/wemake-services/django-modern-rest

It uses a lot of typing and makes heavy use of `django-stubs`.

CC @intgr @UnknownPlatypus @ngnpope @flaeppe @emmanuel-ferdman 
Check it out :)

The official release will be tomorrow.
