### PR TITLE
Fix order_by false positive with values() expression aliases

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -921,11 +921,16 @@ def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> Mypy
     if (django_model := helpers.get_model_info_from_qs_ctx(ctx, django_context)) is None:
         return ctx.default_return_type
 
+    selected_fields = _get_selected_fields_from_queryset_type(ctx.type) if isinstance(ctx.type, Instance) else None
+
     for lookup_value in _extract_field_names_from_varargs(ctx):
         parts = lookup_value.removeprefix("-").split(LOOKUP_SEP)
 
         if django_model.typ.extra_attrs and parts[0] in django_model.typ.extra_attrs.attrs:
             # Skip validation for annotated fields
+            continue
+        if selected_fields is not None and parts[0] in selected_fields:
+            # Skip validation for fields selected via values()/values_list()
             continue
         _validate_order_by_lookup(ctx, django_model.cls, parts)
 

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -57,6 +57,9 @@
         # values() / values_list() then order_by
         Article.objects.values("title").order_by("title")
         Article.objects.values_list("title", flat=True).order_by("title")
+
+        # values() with annotation then order_by
+        Article.objects.values(name=F("author__name")).order_by("name")
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py


### PR DESCRIPTION
Skip order_by validation for fields that were introduced as keyword arguments in values()/values_list() calls (e.g. `values(name=F(...))`).

Should take care of https://github.com/typeddjango/django-stubs/issues/3184#issuecomment-4050402587