### PR TITLE
Fix `value_to_string` return types for JSONField and RangeField

### DIFF
--- a/django-stubs/contrib/postgres/fields/ranges.pyi
+++ b/django-stubs/contrib/postgres/fields/ranges.pyi
@@ -39,6 +39,8 @@ class RangeField(CheckPostgresInstalledMixin, models.Field[Any, _RangeT]):
     @override
     def to_python(self, value: Any) -> Any: ...
     @override
+    def value_to_string(self, obj: models.Model) -> str | None: ...  # type: ignore[override]
+    @override
     def formfield(self, **kwargs: Any) -> Any: ...  # type: ignore[override]
 
 class ContinuousRangeField(RangeField[_RangeT]):

--- a/django-stubs/db/models/fields/json.pyi
+++ b/django-stubs/db/models/fields/json.pyi
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar, TypeVar
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import lookups
+from django.db.models import Model, lookups
 from django.db.models.expressions import Expression
 from django.db.models.fields import TextField
 from django.db.models.lookups import FieldGetDbPrepValueMixin, PostgresOperatorLookup, Transform
@@ -33,6 +33,8 @@ class JSONField(CheckFieldDefaultMixin, Field[_ST, _GT]):
     def from_db_value(self, value: str | None, expression: Expression, connection: BaseDatabaseWrapper) -> Any: ...
     @override
     def get_transform(self, name: str) -> type[Transform] | KeyTransformFactory: ...  # type: ignore[override]
+    @override
+    def value_to_string(self, obj: Model) -> Any: ...
     @override
     def formfield(self, **kwargs: Any) -> Any: ...  # type: ignore[override]
 


### PR DESCRIPTION
### PR Summary
`JSONField.value_to_string` returns raw JSON data at runtime, not `str`. `RangeField.value_to_string` can return `None`. This PR adds the missing overrides with correct return types.

Fixes #2729