### PR TITLE
Add stub for register_combinable_fields in expressions

### DIFF
--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -120,6 +120,13 @@ class Expression(_Deconstructible, BaseExpression, Combinable):
     @cached_property
     def identity(self) -> tuple[Any, ...]: ...
 
+def register_combinable_fields(
+    lhs: type[Field],
+    connector: str,
+    rhs: type[Field],
+    result: type[Field],
+) -> None: ...
+
 class CombinedExpression(SQLiteNumericMixin, Expression):
     @cached_property
     @override
@@ -395,10 +402,3 @@ class RowRange(WindowFrame):
 
 class ValueRange(WindowFrame):
     frame_type: str
-
-def register_combinable_fields(
-    lhs: type[Field],
-    connector: str,
-    rhs: type[Field],
-    result: type[Field],
-) -> None: ...

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -395,3 +395,10 @@ class RowRange(WindowFrame):
 
 class ValueRange(WindowFrame):
     frame_type: str
+
+def register_combinable_fields(
+    lhs: type[Field],
+    connector: str,
+    rhs: type[Field],
+    result: type[Field],
+) -> None: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -121,7 +121,6 @@ django.db.models.Field.description
 django.db.models.expressions.connector
 django.db.models.expressions.d
 django.db.models.expressions.field_types
-django.db.models.expressions.register_combinable_fields
 django.db.models.fields.CharField.description
 django.db.models.fields.Field.description
 django.db.models.fields.json.CaseInsensitiveMixin.process_lhs


### PR DESCRIPTION
## Summary

Add missing stub for `register_combinable_fields` function in `django.db.models.expressions`.

## Changes

- Added type stub for `register_combinable_fields(lhs, connector, rhs, result)` in `expressions.pyi`
- Removed `django.db.models.expressions.register_combinable_fields` from `allowlist_todo.txt`

## Details

`register_combinable_fields` is a public API function that registers combinable field types for ORM expressions (e.g., `DateField - DateField = DurationField`).


