### PR TITLE
Fix stubtest: annotate leaked loop variables in django.db.models.expressions

### DIFF
--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -127,6 +127,16 @@ def register_combinable_fields(
     result: type[Field],
 ) -> None: ...
 
+# These are leaked loop variables from the module-level loop that registers
+# combinable field types (`for d in _connector_combinations`). They are not
+# part of the public API but are visible as module attributes at runtime.
+d: dict[str, list[tuple[type[Field[Any, Any]], type[Field[Any, Any]], type[Field[Any, Any]]]]]
+connector: str
+field_types: list[tuple[type[Field[Any, Any]], type[Field[Any, Any]], type[Field[Any, Any]]]]
+lhs: type[Field[Any, Any]]
+rhs: type[Field[Any, Any]]
+result: type[Field[Any, Any]]
+
 class CombinedExpression(SQLiteNumericMixin, Expression):
     @cached_property
     @override

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -117,9 +117,6 @@ django.db.migrations.recorder.MigrationRecorder.Migration.get_previous_by_applie
 django.db.migrations.recorder.MigrationRecorder.Migration.id
 django.db.models.CharField.description
 django.db.models.Field.description
-django.db.models.expressions.connector
-django.db.models.expressions.d
-django.db.models.expressions.field_types
 django.db.models.fields.CharField.description
 django.db.models.fields.Field.description
 django.db.models.fields.json.CaseInsensitiveMixin.process_lhs
@@ -127,11 +124,6 @@ django.forms.inlineformset_factory
 django.forms.modelformset_factory
 django.forms.models.inlineformset_factory
 django.forms.models.modelformset_factory
-
-# mypy 1.9.0 new issues:
-django.db.models.expressions.rhs
-django.db.models.expressions.result
-django.db.models.expressions.lhs
 
 # Django 6.0.3 security fix new APIs:
 django.utils._os.makedirs


### PR DESCRIPTION
## Problem
stubtest reported 6 unresolved variables in `django.db.models.expressions`:
`connector`, `d`, `field_types`, `lhs`, `rhs`, `result`.

These are leaked loop variables from the module-level loop in Django's
`expressions.py` that registers combinable field types:

    for d in _connector_combinations:
        for connector, field_types in d.items():
            for lhs, rhs, result in field_types:

## Fix
Add proper type annotations for these variables in the stub file instead
of silencing them in `allowlist_todo.txt`.
