### PR TITLE
Update docs.djangoproject.com links to current stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This happens because these Django classes do not support [`__class_getitem__`](h
    You can add extra types to patch with `django_stubs_ext.monkeypatch(extra_classes=[YourDesiredType])`
 
    **If you use generic symbols in `django.contrib.auth.forms`**, you will have to do the monkeypatching
-   manually in your first [`AppConfig.ready`](https://docs.djangoproject.com/en/5.2/ref/applications/#django.apps.AppConfig.ready).
+   manually in your first [`AppConfig.ready`](https://docs.djangoproject.com/en/stable/ref/applications/#django.apps.AppConfig.ready).
    This is currently required because `django.contrib.auth.forms` cannot be imported until django is initialized.
 
     ```python
@@ -208,7 +208,7 @@ This happens because these Django classes do not support [`__class_getitem__`](h
 
 ### How can I create a HttpRequest that's guaranteed to have an authenticated user?
 
-Django's built in [`HttpRequest`](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpRequest) has the attribute `user` that resolves to the type
+Django's built in [`HttpRequest`](https://docs.djangoproject.com/en/stable/ref/request-response/#django.http.HttpRequest) has the attribute `user` that resolves to the type
 
 ```python
 Union[User, AnonymousUser]
@@ -300,7 +300,7 @@ func(MyModel.objects.annotate(bar=Value("")).get(id=1))  # Error
 
 The lazy translation functions of Django (such as `gettext_lazy`) return a `Promise` instead of `str`. These two types [cannot be used interchangeably](https://github.com/typeddjango/django-stubs/pull/1139#issuecomment-1232167698). The return type of these functions was therefore [changed](https://github.com/typeddjango/django-stubs/pull/689) to reflect that.
 
-If you encounter this error in your own code, you can either cast the `Promise` to `str` (causing the translation to be evaluated), or use the `StrPromise` or `StrOrPromise` types from `django-stubs-ext` in type hints. Which solution to choose depends depends on the particular case. See [working with lazy translation objects](https://docs.djangoproject.com/en/5.2/topics/i18n/translation/#working-with-lazy-translation-objects) in the Django documentation for more information.
+If you encounter this error in your own code, you can either cast the `Promise` to `str` (causing the translation to be evaluated), or use the `StrPromise` or `StrOrPromise` types from `django-stubs-ext` in type hints. Which solution to choose depends depends on the particular case. See [working with lazy translation objects](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#working-with-lazy-translation-objects) in the Django documentation for more information.
 
 If this is reported on Django code, please report an issue or open a pull request to fix the type hints.
 
@@ -370,7 +370,7 @@ error: "type[Model]" has no attribute "objects"  [attr-defined]
 ```
 
 It is a common problem: some `type[models.Model]` types won't have `.objects` available.
-Notable example: [abstract models](https://docs.djangoproject.com/en/5.2/topics/db/models/#abstract-base-classes).
+Notable example: [abstract models](https://docs.djangoproject.com/en/stable/topics/db/models/#abstract-base-classes).
 See [the reasoning here](https://github.com/typeddjango/django-stubs/issues/1684).
 
 So, instead for the general case you should write:

--- a/django-stubs/conf/global_settings.pyi
+++ b/django-stubs/conf/global_settings.pyi
@@ -251,34 +251,34 @@ FILE_UPLOAD_DIRECTORY_PERMISSIONS: int | None
 FORMAT_MODULE_PATH: str | None
 
 # Default formatting for date objects. See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 DATE_FORMAT: str
 
 # Default formatting for datetime objects. See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 DATETIME_FORMAT: str
 
 # Default formatting for time objects. See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 TIME_FORMAT: str
 
 # Default formatting for date objects when only the year and month are relevant.
 # See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 YEAR_MONTH_FORMAT: str
 
 # Default formatting for date objects when only the month and day are relevant.
 # See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 MONTH_DAY_FORMAT: str
 
 # Default short formatting for date objects. See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 SHORT_DATE_FORMAT: str
 
 # Default short formatting for datetime objects.
 # See all available format strings here:
-# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+# https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 SHORT_DATETIME_FORMAT: str
 
 # Default formats to be used when parsing dates from input boxes, in order

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -296,7 +296,7 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
     """
     Extract proper return type for QuerySet.values(*fields, **expressions) method calls.
 
-    See https://docs.djangoproject.com/en/5.2/ref/models/querysets/#values
+    See https://docs.djangoproject.com/en/stable/ref/models/querysets/#values
     """
     django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
     if django_model is None or django_model.is_annotated:
@@ -603,7 +603,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     """
     Extract annotated attributes via `prefetch_related(Prefetch(..., to_attr=...))`
 
-    See https://docs.djangoproject.com/en/5.2/ref/models/querysets/#prefetch-objects
+    See https://docs.djangoproject.com/en/stable/ref/models/querysets/#prefetch-objects
     """
     api = helpers.get_typechecker_api(ctx)
 

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -242,7 +242,7 @@ django.contrib.auth.views.UserModel
 django.db.migrations.operations.base.OperationCategory.__new__
 
 # These are dynamically added when using `save(commit=False)`
-# See https://docs.djangoproject.com/en/5.2/topics/forms/modelforms/#the-save-method
+# See https://docs.djangoproject.com/en/stable/topics/forms/modelforms/#the-save-method
 django.forms.BaseModelForm.save_m2m
 django.forms.BaseModelFormSet.save_m2m
 django.forms.models.BaseModelForm.save_m2m

--- a/tests/assert_type/conf/settings.py
+++ b/tests/assert_type/conf/settings.py
@@ -5,7 +5,7 @@ from django_stubs_ext.settings import TemplatesSetting
 BASE_DIR = Path(__file__).resolve().parent
 
 # Example taken from various doc pages
-# https://docs.djangoproject.com/en/5.2/ref/settings/#templates
+# https://docs.djangoproject.com/en/stable/ref/settings/#templates
 TEMPLATES: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -13,7 +13,7 @@ TEMPLATES: list[TemplatesSetting] = [
     },
 ]
 
-# https://docs.djangoproject.com/en/5.2/ref/templates/api/#the-dirs-option
+# https://docs.djangoproject.com/en/stable/ref/templates/api/#the-dirs-option
 TEMPLATES_2: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -24,7 +24,7 @@ TEMPLATES_2: list[TemplatesSetting] = [
     },
 ]
 
-# https://docs.djangoproject.com/en/5.2/ref/templates/api/#template-loaders
+# https://docs.djangoproject.com/en/stable/ref/templates/api/#template-loaders
 TEMPLATES_3: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -44,7 +44,7 @@ TEMPLATES_4: list[TemplatesSetting] = [
         },
     }
 ]
-# https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
+# https://docs.djangoproject.com/en/stable/ref/templates/api/#django.template.loaders.cached.Loader
 TEMPLATES_5: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -63,7 +63,7 @@ TEMPLATES_5: list[TemplatesSetting] = [
         },
     }
 ]
-# https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.loaders.cached.Loader
+# https://docs.djangoproject.com/en/stable/ref/templates/api/#django.template.loaders.cached.Loader
 TEMPLATES_6: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -79,7 +79,7 @@ TEMPLATES_6: list[TemplatesSetting] = [
         },
     }
 ]
-# https://docs.djangoproject.com/en/5.2/topics/templates/#configuration
+# https://docs.djangoproject.com/en/stable/topics/templates/#configuration
 TEMPLATES_7: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -90,7 +90,7 @@ TEMPLATES_7: list[TemplatesSetting] = [
         },
     },
 ]
-# https://docs.djangoproject.com/en/5.2/topics/templates/#django.template.backends.base.Template.render
+# https://docs.djangoproject.com/en/stable/topics/templates/#django.template.backends.base.Template.render
 TEMPLATES_8: list[TemplatesSetting] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",

--- a/tests/typecheck/managers/querysets/test_basic_methods.yml
+++ b/tests/typecheck/managers/querysets/test_basic_methods.yml
@@ -109,7 +109,7 @@
         reveal_type(foos_dict.difference(bars_dict)) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.MyModel1, TypedDict({'name': builtins.str})]"
 
         # `values()` QuerySet -- One field, different name, the first one takes precedence.
-        # cf https://docs.djangoproject.com/en/5.2/ref/models/querysets/#django.db.models.query.QuerySet.union
+        # cf https://docs.djangoproject.com/en/stable/ref/models/querysets/#django.db.models.query.QuerySet.union
         foos_dict2 = MyModel1.objects.all().values("name")
         bars_dict2 = MyModel2.objects.all().values("id")
 


### PR DESCRIPTION
Preparing for 6.0.0 release.

Prevent links from going out of date.
