### PR TITLE
Fix crash in order_by validation for abstract models

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -912,13 +912,14 @@ def _validate_order_by_lookup(ctx: MethodContext, model_cls: type[Model], parts:
     if len(parts) == 1 and parts[0] == "?":
         return
 
+    # Abstract models don't have a pk field, skip validation
+    if model_cls._meta.abstract:
+        return
+
     try:
         _, final_field, _, remainder = Query(model_cls).names_to_path(parts, model_cls._meta)
     except FieldError as exc:
         ctx.api.fail(exc.args[0], ctx.context)
-        return
-    except AttributeError:
-        # Can happen when model._meta.pk is None (e.g. abstract models)
         return
 
     if remainder:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -917,6 +917,9 @@ def _validate_order_by_lookup(ctx: MethodContext, model_cls: type[Model], parts:
     except FieldError as exc:
         ctx.api.fail(exc.args[0], ctx.context)
         return
+    except AttributeError:
+        # Can happen when model._meta.pk is None (e.g. abstract models)
+        return
 
     if remainder:
         # Check if the trailing part is a valid transform (e.g. __year, __month) on the field.

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -138,6 +138,31 @@
                     published = models.BooleanField(default=False)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name="article")
 
+# Regression test for https://github.com/typeddjango/django-stubs/issues/3184
+# Abstract models have _meta.pk = None, which caused an AttributeError crash
+# in Django's Query.names_to_path() when validating order_by lookups.
+-   case: order_by_abstract_model_no_crash
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import AbstractModel
+        from django.db.models import QuerySet
+
+        def test(qs: QuerySet[AbstractModel]) -> None:
+            qs.order_by("pk")
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class AbstractModel(models.Model):
+                    class Meta:
+                        abstract = True
+
+                class ConcreteModel(AbstractModel):
+                    pass
+
 -   case: order_by_with_field_transforms
     installed_apps:
         - myapp


### PR DESCRIPTION
Fixes #3184 

<details><summary>Test failure before the fix</summary>
<p>

```
======================================================================================================= test session starts ========================================================================================================
platform linux -- Python 3.13.1, pytest-9.0.2, pluggy-1.6.0 -- /home/thibaut/workspace/django-stubs/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/thibaut/workspace/django-stubs
configfile: pytest.ini
testpaths: ./tests, ./ext/tests
plugins: xdist-3.8.0, mypy-plugins-4.0.0, shard-0.1.2
collected 508 items / 507 deselected / 1 selected                                                                                                                                                                                  
Running 1 items in this shard: tests/typecheck/managers/querysets/test_order_by.yml::order_by_abstract_model_no_crash

tests/typecheck/managers/querysets/test_order_by.yml::order_by_abstract_model_no_crash Traceback (most recent call last):
  File "mypy/checkexpr.py", line 6046, in accept
  File "mypy/checkexpr.py", line 508, in visit_call_expr
  File "mypy/checkexpr.py", line 645, in visit_call_expr_inner
  File "mypy/checkexpr.py", line 1496, in check_call_expr_with_callee_type
  File "mypy/checkexpr.py", line 1589, in check_call
  File "mypy/checkexpr.py", line 1832, in check_callable_call
  File "mypy/checkexpr.py", line 1287, in apply_function_plugin
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/querysets.py", line 948, in validate_order_by
    _validate_order_by_lookup(ctx, django_model.cls, parts)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/querysets.py", line 916, in _validate_order_by_lookup
    _, final_field, _, remainder = Query(model_cls).names_to_path(parts, model_cls._meta)
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django-stubs/.venv/lib/python3.13/site-packages/django/db/models/sql/query.py", line 1789, in names_to_path
    name = opts.pk.name
           ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
/tmp/pytest-mypy-4ic6ftou/main.py:5: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 1.19.1
/tmp/pytest-mypy-4ic6ftou/main.py:5: : note: use --pdb to drop into pdb

FAILED
```

</p>
</details> 