### PR TITLE
Add missing `Meta` class stubs for auth and session models

### DIFF
--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -17,6 +17,9 @@ class BaseUserManager(models.Manager[_T]):
 class AbstractBaseUser(models.Model):
     REQUIRED_FIELDS: ClassVar[list[str]]
 
+    class Meta:
+        abstract: ClassVar[bool]
+
     password = models.CharField(max_length=128)
     last_login = models.DateTimeField(blank=True, null=True)
     is_active: bool | BooleanField[bool | Combinable, bool]

--- a/django-stubs/contrib/auth/forms.pyi
+++ b/django-stubs/contrib/auth/forms.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from logging import Logger
-from typing import Any, Generic
+from typing import Any, ClassVar, Generic
 
 from django import forms
 from django.contrib.auth.models import _User, _UserModel, _UserType
@@ -68,6 +68,12 @@ class BaseUserCreationForm(forms.ModelForm[_UserType], Generic[_UserType]):
     error_messages: _ErrorMessagesDict
     password1: forms.Field
     password2: forms.Field
+
+    class Meta:
+        model: ClassVar[type[_User]]
+        fields: ClassVar[tuple[str, ...]]
+        field_classes: ClassVar[dict[str, type[forms.Field]]]
+
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     @override
     def save(self, commit: bool = ...) -> _UserType: ...
@@ -77,6 +83,12 @@ class UserCreationForm(BaseUserCreationForm[_UserType]):
 
 class UserChangeForm(forms.ModelForm[_UserType]):
     password: forms.Field
+
+    class Meta:
+        model: ClassVar[type[_User]]
+        fields: ClassVar[str]
+        field_classes: ClassVar[dict[str, type[forms.Field]]]
+
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
 class AuthenticationForm(forms.Form):

--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -79,6 +79,9 @@ class PermissionsMixin(models.Model):
     groups = models.ManyToManyField(Group)
     user_permissions = models.ManyToManyField(Permission)
 
+    class Meta:
+        abstract: ClassVar[bool]
+
     def get_user_permissions(self, obj: Model | None = ...) -> set[str]: ...
     async def aget_user_permissions(self, obj: Model | None = ...) -> set[str]: ...
     def get_group_permissions(self, obj: Model | None = ...) -> set[str]: ...
@@ -94,6 +97,11 @@ class PermissionsMixin(models.Model):
 
 class AbstractUser(AbstractBaseUser, PermissionsMixin):
     username_validator: UnicodeUsernameValidator
+
+    class Meta:
+        abstract: ClassVar[bool]
+        verbose_name: ClassVar[str]
+        verbose_name_plural: ClassVar[str]
 
     username = models.CharField(max_length=150)
     first_name = models.CharField(max_length=30, blank=True)

--- a/django-stubs/contrib/flatpages/forms.pyi
+++ b/django-stubs/contrib/flatpages/forms.pyi
@@ -1,7 +1,13 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from django import forms
+from django.contrib.flatpages.models import FlatPage
 
-class FlatpageForm(forms.ModelForm):
+class FlatpageForm(forms.ModelForm[FlatPage]):
     url: Any
+
+    class Meta:
+        model: ClassVar[type[FlatPage]]
+        fields: ClassVar[str]
+
     def clean_url(self) -> str: ...

--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -17,6 +17,11 @@ class AbstractBaseSession(models.Model):
     expire_date = models.DateTimeField()
     objects: ClassVar[BaseSessionManager[Self]]
 
+    class Meta:
+        abstract: ClassVar[bool]
+        verbose_name: ClassVar[str]
+        verbose_name_plural: ClassVar[str]
+
     @classmethod
     def get_session_store_class(cls) -> type[SessionBase] | None: ...
     def get_decoded(self) -> dict[str, Any]: ...

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -169,16 +169,6 @@ django.utils.functional.cached_property.__class_getitem__
 django.utils.functional.cached_property.__set__
 django.utils.functional.cached_property.name
 
-# Ignore missing inner `Meta` class, see PR #2000 for the related discussion
-django.contrib.auth.base_user.AbstractBaseUser.Meta
-django.contrib.auth.forms.BaseUserCreationForm.Meta
-django.contrib.auth.forms.UserChangeForm.Meta
-django.contrib.auth.models.AbstractBaseUser.Meta
-django.contrib.auth.models.AbstractUser.Meta
-django.contrib.auth.models.PermissionsMixin.Meta
-django.contrib.flatpages.forms.FlatpageForm.Meta
-django.contrib.sessions.base_session.AbstractBaseSession.Meta
-
 # Custom __str__ that we don't want to overcomplicate:
 django.forms.utils.RenderableMixin.__str__
 django.forms.utils.RenderableMixin.__html__

--- a/tests/typecheck/contrib/auth/test_auth.yml
+++ b/tests/typecheck/contrib/auth/test_auth.yml
@@ -93,3 +93,27 @@
 
               class MyUser(models.Model):
                   ...
+
+-   case: test_abstract_user_meta_inheritance
+    main: |
+        from django.contrib.auth.models import AbstractUser
+
+        class CustomUser(AbstractUser):
+            class Meta(AbstractUser.Meta):
+                pass
+    custom_settings: |
+        INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth")
+
+-   case: test_auth_form_meta_inheritance
+    main: |
+        from django.contrib.auth.forms import BaseUserCreationForm, UserChangeForm
+
+        class CustomUserCreationForm(BaseUserCreationForm):
+            class Meta(BaseUserCreationForm.Meta):
+                pass
+
+        class CustomUserChangeForm(UserChangeForm):
+            class Meta(UserChangeForm.Meta):
+                pass
+    custom_settings: |
+        INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth")


### PR DESCRIPTION
### PR Summary
This PR adds inner `Meta` class stubs to `AbstractBaseUser`, `PermissionsMixin`, `AbstractUser`, `AbstractBaseSession`, `BaseUserCreationForm`, `UserChangeForm`, and `FlatpageForm`. This enables the common Django pattern of inheriting from `AbstractUser.Meta` when creating custom user models. 

Continues the work of #2168
Fixes #2112 
Ref #2000 