### PR TITLE
Use newer syntax and enable more mypy configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,7 @@ This happens because these Django classes do not support [`__class_getitem__`](h
 
 ### How can I create a HttpRequest that's guaranteed to have an authenticated user?
 
-Django's built in [`HttpRequest`](https://docs.djangoproject.com/en/stable/ref/request-response/#django.http.HttpRequest) has the attribute `user` that resolves to the type
-
-```python
-Union[User, AnonymousUser]
-```
-
-where `User` is the user model specified by the `AUTH_USER_MODEL` setting.
+Django's built in [`HttpRequest`](https://docs.djangoproject.com/en/stable/ref/request-response/#django.http.HttpRequest) has the attribute `user` that resolves to the type `User | AnonymousUser` where `User` is the user model specified by the `AUTH_USER_MODEL` setting.
 
 If you want a `HttpRequest` that you can type-annotate with where you know that the user is authenticated you can subclass the normal `HttpRequest` class like so:
 

--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -66,12 +66,12 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
 
     .. code:: python
 
-        from typing import Generic, Union
+        from typing import Generic
 
         class Model(object):
             ...
 
-        _SetType = Union[int, float]  # You can assign ints and floats
+        _SetType = int | float  # You can assign ints and floats
         _GetType = int  # access type is always `int`
 
         class IntField(object):
@@ -100,7 +100,7 @@ class Field(RegisterLookupMixin, Generic[_ST, _GT]):
         example.count = 1.5  # ok
         example.count = 'a'
         # Incompatible types in assignment
-        # (expression has type "str", variable has type "Union[int, float]")
+        # (expression has type "str", variable has type "int | float")
 
     Notice, that this is not magic. This is how descriptors work with ``mypy``.
 

--- a/django-stubs/forms/fields.pyi
+++ b/django-stubs/forms/fields.pyi
@@ -18,7 +18,7 @@ from typing_extensions import Self, override
 
 # Problem: attribute `widget` is always of type `Widget` after field instantiation.
 # However, on class level it can be set to `Type[Widget]` too.
-# If we annotate it as `Union[Widget, Type[Widget]]`, every code that uses field
+# If we annotate it as `Widget | Type[Widget]`, every code that uses field
 # instances will not typecheck.
 # If we annotate it as `Widget`, any widget subclasses that do e.g.
 # `widget = Select` will not typecheck.

--- a/django-stubs/utils/formats.pyi
+++ b/django-stubs/utils/formats.pyi
@@ -31,7 +31,7 @@ def number_format(
 _T = TypeVar("_T")
 
 # Mypy considers this invalid (overlapping signatures), but thanks to implementation
-# details it works as expected (all values from Union are `localize`d to str,
+# details it works as expected (all values from the union are `localize`d to str,
 # while type of others is preserved)
 @overload
 def localize(value: builtin_datetime | date | time | Decimal | float | str, use_l10n: bool | None = None) -> str: ...

--- a/django-stubs/utils/functional.pyi
+++ b/django-stubs/utils/functional.pyi
@@ -108,7 +108,7 @@ class _Getter(Protocol[_Get]):  # noqa: PYI046
     """
     Type fake to declare some read-only properties (until `property` builtin is generic).
 
-    We can use something like `Union[_Getter[str], str]` in base class to avoid errors
+    We can use something like `_Getter[str] | str` in base class to avoid errors
     when redefining attribute with property or property with attribute.
     """
 

--- a/ext/django_stubs_ext/__init__.py
+++ b/ext/django_stubs_ext/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .aliases import FieldOpts as FieldOpts
 from .aliases import FieldsetSpec as FieldsetSpec
 from .aliases import QuerySetAny as QuerySetAny

--- a/ext/django_stubs_ext/aliases.py
+++ b/ext/django_stubs_ext/aliases.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 if typing.TYPE_CHECKING:

--- a/ext/django_stubs_ext/annotations.py
+++ b/ext/django_stubs_ext/annotations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Annotated, Any, Generic, TypeVar
 

--- a/ext/django_stubs_ext/db/models/__init__.py
+++ b/ext/django_stubs_ext/db/models/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/ext/django_stubs_ext/db/models/manager.py
+++ b/ext/django_stubs_ext/db/models/manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 # Re-export stubs-only classes RelatedManger and ManyRelatedManager.

--- a/ext/django_stubs_ext/db/router.py
+++ b/ext/django_stubs_ext/db/router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import builtins
 import logging
-from collections.abc import Iterable
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from django import VERSION
 from django.contrib.admin import ModelAdmin
@@ -32,6 +33,9 @@ from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 __all__ = ["monkeypatch"]
 

--- a/ext/django_stubs_ext/settings.py
+++ b/ext/django_stubs_ext/settings.py
@@ -1,7 +1,11 @@
-from pathlib import Path
-from typing import Any, TypedDict, type_check_only
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypedDict, type_check_only
 
 from typing_extensions import NotRequired
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @type_check_only

--- a/ext/django_stubs_ext/types.py
+++ b/ext/django_stubs_ext/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Protocol
 
 from typing_extensions import override

--- a/ext/tests/test_aliases.py
+++ b/ext/tests/test_aliases.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django_stubs_ext import ValuesQuerySet

--- a/ext/tests/test_monkeypatching.py
+++ b/ext/tests/test_monkeypatching.py
@@ -1,17 +1,22 @@
+from __future__ import annotations
+
 import builtins
-from collections.abc import Iterable
 from contextlib import suppress
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import pytest
-from _pytest.fixtures import FixtureRequest
-from _pytest.monkeypatch import MonkeyPatch
 from django.db.models import Model
 from django.forms.models import ModelForm
 
 import django_stubs_ext
 from django_stubs_ext import patch
 from django_stubs_ext.patch import _need_generic, _VersionSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from _pytest.fixtures import FixtureRequest
+    from _pytest.monkeypatch import MonkeyPatch
 
 
 class _MakeGenericClasses(Protocol):

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ incremental = true
 disallow_any_generics = false
 strict = true
 local_partial_types = true
+strict_equality_for_none = true
 warn_unreachable = true
 
 disable_error_code = empty-body

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ incremental = true
 # TODO: add type args to all generics
 disallow_any_generics = false
 strict = true
+allow_redefinition_new = true
 local_partial_types = true
 strict_equality_for_none = true
 warn_unreachable = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,6 +27,7 @@ enable_error_code =
     unimported-reveal,
     unused-awaitable,
 
+fixed_format_cache = true
 show_traceback = true
 
 plugins =

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import os
 import sys

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
@@ -10,15 +11,11 @@ from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 from django.db.models.base import Model
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import Expression
 from django.db.models.fields import AutoField, CharField, Field
 from django.db.models.fields.related import ForeignKey, RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.db.models.lookups import Exact
 from django.db.models.sql.query import Query
-from mypy.checker import TypeChecker
-from mypy.nodes import TypeInfo
-from mypy.plugin import MethodContext
 from mypy.typeanal import make_optional_type
 from mypy.types import AnyType, Instance, ProperType, TypeOfAny, UnionType, get_proper_type
 from mypy.types import Type as MypyType
@@ -36,9 +33,15 @@ except ImportError:
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
+
     from django.apps.registry import Apps
     from django.conf import LazySettings
+    from django.db.models.expressions import Expression
     from django.db.models.options import _AnyField
+    from mypy.checker import TypeChecker
+    from mypy.nodes import TypeInfo
+    from mypy.plugin import MethodContext
 
 
 @contextmanager
@@ -52,7 +55,7 @@ def temp_environ() -> Iterator[None]:
         os.environ.update(environ)
 
 
-def initialize_django(settings_module: str) -> tuple["Apps", "LazySettings"]:
+def initialize_django(settings_module: str) -> tuple[Apps, LazySettings]:
     with temp_environ():
         os.environ["DJANGO_SETTINGS_MODULE"] = settings_module
 
@@ -133,17 +136,17 @@ class DjangoContext:
         module, _, model_cls_name = fullname.rpartition(".")
         return self.model_modules.get(module, {}).get(model_cls_name)
 
-    def get_model_fields(self, model_cls: type[Model]) -> Iterator["Field[Any, Any]"]:
+    def get_model_fields(self, model_cls: type[Model]) -> Iterator[Field[Any, Any]]:
         for field in model_cls._meta.get_fields():
             if isinstance(field, Field):
                 yield field
 
-    def get_model_foreign_keys(self, model_cls: type[Model]) -> Iterator["ForeignKey[Any, Any]"]:
+    def get_model_foreign_keys(self, model_cls: type[Model]) -> Iterator[ForeignKey[Any, Any]]:
         for field in model_cls._meta.get_fields():
             if isinstance(field, ForeignKey):
                 yield field
 
-    def get_model_related_fields(self, model_cls: type[Model]) -> Iterator["RelatedField[Any, Any]"]:
+    def get_model_related_fields(self, model_cls: type[Model]) -> Iterator[RelatedField[Any, Any]]:
         """Get model forward relations"""
         for field in model_cls._meta.get_fields():
             if isinstance(field, RelatedField):
@@ -155,7 +158,7 @@ class DjangoContext:
             if isinstance(field, ForeignObjectRel):
                 yield field
 
-    def get_field_lookup_exact_type(self, api: TypeChecker, field: "Field[Any, Any] | ForeignObjectRel") -> MypyType:
+    def get_field_lookup_exact_type(self, api: TypeChecker, field: Field[Any, Any] | ForeignObjectRel) -> MypyType:
         if isinstance(field, RelatedField | ForeignObjectRel):
             related_model_cls = self.get_field_related_model_cls(field)
             rel_model_info = helpers.lookup_class_typeinfo(api, related_model_cls)
@@ -174,8 +177,8 @@ class DjangoContext:
         return helpers.get_private_descriptor_type(field_info, "_pyi_lookup_exact_type", is_nullable=field.null)
 
     def get_related_target_field(
-        self, related_model_cls: type[Model], field: "ForeignKey[Any, Any]"
-    ) -> "Field[Any, Any] | None":
+        self, related_model_cls: type[Model], field: ForeignKey[Any, Any]
+    ) -> Field[Any, Any] | None:
         # ForeignKey only supports one `to_fields` item (ForeignObject supports many)
         assert len(field.to_fields) == 1
         to_field_name = field.to_fields[0]
@@ -186,7 +189,7 @@ class DjangoContext:
             return rel_field
         return self.get_primary_key_field(related_model_cls)
 
-    def get_primary_key_field(self, model_cls: type[Model]) -> "Field[Any, Any]":
+    def get_primary_key_field(self, model_cls: type[Model]) -> Field[Any, Any]:
         for field in model_cls._meta.get_fields():
             if isinstance(field, Field):
                 if field.primary_key:
@@ -287,7 +290,7 @@ class DjangoContext:
             if klass is not models.Model
         }
 
-    def get_field_nullability(self, field: "Field[Any, Any] | ForeignObjectRel", method: str | None) -> bool:
+    def get_field_nullability(self, field: Field[Any, Any] | ForeignObjectRel, method: str | None) -> bool:
         if method in ("values", "values_list"):
             return field.null
 
@@ -305,7 +308,7 @@ class DjangoContext:
         return nullable
 
     def get_field_set_type(
-        self, api: TypeChecker, field: "Field[Any, Any] | ForeignObjectRel", *, method: str
+        self, api: TypeChecker, field: Field[Any, Any] | ForeignObjectRel, *, method: str
     ) -> MypyType:
         """Get a type of __set__ for this specific Django field."""
         target_field = field
@@ -333,7 +336,7 @@ class DjangoContext:
         self,
         api: TypeChecker,
         model_info: TypeInfo | None,
-        field: "Field[Any, Any] | ForeignObjectRel",
+        field: Field[Any, Any] | ForeignObjectRel,
         *,
         method: str,
     ) -> MypyType:
@@ -363,7 +366,7 @@ class DjangoContext:
             return Instance(model_info, [])
         return helpers.get_private_descriptor_type(field_info, "_pyi_private_get_type", is_nullable=is_nullable)
 
-    def get_field_related_model_cls(self, field: "RelatedField[Any, Any] | ForeignObjectRel") -> type[Model]:
+    def get_field_related_model_cls(self, field: RelatedField[Any, Any] | ForeignObjectRel) -> type[Model]:
         if isinstance(field, RelatedField):
             related_model_cls = field.remote_field.model
         else:
@@ -392,7 +395,7 @@ class DjangoContext:
 
     def _resolve_field_from_parts(
         self, field_parts: Iterable[str], model_cls: type[Model]
-    ) -> tuple["Field[Any, Any] | ForeignObjectRel", type[Model]]:
+    ) -> tuple[Field[Any, Any] | ForeignObjectRel, type[Model]]:
         currently_observed_model = model_cls
         field: _AnyField | None = None
         for field_part in field_parts:
@@ -450,7 +453,7 @@ class DjangoContext:
 
     def resolve_lookup_into_field(
         self, model_cls: type[Model], lookup: str
-    ) -> tuple["Field[Any, Any] | ForeignObjectRel | None", type[Model]]:
+    ) -> tuple[Field[Any, Any] | ForeignObjectRel | None, type[Model]]:
         solved_lookup = self.solve_lookup_type(model_cls, lookup)
         if solved_lookup is None:
             return None, model_cls
@@ -460,7 +463,7 @@ class DjangoContext:
         return self._resolve_field_from_parts(field_parts, model_cls)
 
     def _resolve_lookup_type_from_lookup_class(
-        self, ctx: MethodContext, lookup_cls: type, field: "Field[Any, Any] | ForeignObjectRel | None" = None
+        self, ctx: MethodContext, lookup_cls: type, field: Field[Any, Any] | ForeignObjectRel | None = None
     ) -> MypyType | None:
         """Resolve the expected type for a lookup class (used both for regular fields and annotated fields)
 

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
@@ -155,9 +155,7 @@ class DjangoContext:
             if isinstance(field, ForeignObjectRel):
                 yield field
 
-    def get_field_lookup_exact_type(
-        self, api: TypeChecker, field: Union["Field[Any, Any]", ForeignObjectRel]
-    ) -> MypyType:
+    def get_field_lookup_exact_type(self, api: TypeChecker, field: "Field[Any, Any] | ForeignObjectRel") -> MypyType:
         if isinstance(field, RelatedField | ForeignObjectRel):
             related_model_cls = self.get_field_related_model_cls(field)
             rel_model_info = helpers.lookup_class_typeinfo(api, related_model_cls)
@@ -289,7 +287,7 @@ class DjangoContext:
             if klass is not models.Model
         }
 
-    def get_field_nullability(self, field: Union["Field[Any, Any]", ForeignObjectRel], method: str | None) -> bool:
+    def get_field_nullability(self, field: "Field[Any, Any] | ForeignObjectRel", method: str | None) -> bool:
         if method in ("values", "values_list"):
             return field.null
 
@@ -307,7 +305,7 @@ class DjangoContext:
         return nullable
 
     def get_field_set_type(
-        self, api: TypeChecker, field: Union["Field[Any, Any]", ForeignObjectRel], *, method: str
+        self, api: TypeChecker, field: "Field[Any, Any] | ForeignObjectRel", *, method: str
     ) -> MypyType:
         """Get a type of __set__ for this specific Django field."""
         target_field = field
@@ -335,7 +333,7 @@ class DjangoContext:
         self,
         api: TypeChecker,
         model_info: TypeInfo | None,
-        field: Union["Field[Any, Any]", ForeignObjectRel],
+        field: "Field[Any, Any] | ForeignObjectRel",
         *,
         method: str,
     ) -> MypyType:
@@ -365,7 +363,7 @@ class DjangoContext:
             return Instance(model_info, [])
         return helpers.get_private_descriptor_type(field_info, "_pyi_private_get_type", is_nullable=is_nullable)
 
-    def get_field_related_model_cls(self, field: Union["RelatedField[Any, Any]", ForeignObjectRel]) -> type[Model]:
+    def get_field_related_model_cls(self, field: "RelatedField[Any, Any] | ForeignObjectRel") -> type[Model]:
         if isinstance(field, RelatedField):
             related_model_cls = field.remote_field.model
         else:
@@ -394,7 +392,7 @@ class DjangoContext:
 
     def _resolve_field_from_parts(
         self, field_parts: Iterable[str], model_cls: type[Model]
-    ) -> tuple[Union["Field[Any, Any]", ForeignObjectRel], type[Model]]:
+    ) -> tuple["Field[Any, Any] | ForeignObjectRel", type[Model]]:
         currently_observed_model = model_cls
         field: _AnyField | None = None
         for field_part in field_parts:
@@ -452,7 +450,7 @@ class DjangoContext:
 
     def resolve_lookup_into_field(
         self, model_cls: type[Model], lookup: str
-    ) -> tuple[Union["Field[Any, Any]", ForeignObjectRel, None], type[Model]]:
+    ) -> tuple["Field[Any, Any] | ForeignObjectRel | None", type[Model]]:
         solved_lookup = self.solve_lookup_type(model_cls, lookup)
         if solved_lookup is None:
             return None, model_cls
@@ -462,7 +460,7 @@ class DjangoContext:
         return self._resolve_field_from_parts(field_parts, model_cls)
 
     def _resolve_lookup_type_from_lookup_class(
-        self, ctx: MethodContext, lookup_cls: type, field: Union["Field[Any, Any]", ForeignObjectRel] | None = None
+        self, ctx: MethodContext, lookup_cls: type, field: "Field[Any, Any] | ForeignObjectRel | None" = None
     ) -> MypyType | None:
         """Resolve the expected type for a lookup class (used both for regular fields and annotated fields)
 

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -372,7 +372,7 @@ class DjangoContext:
         else:
             related_model_cls = field.field.model
 
-        if related_model_cls is None:
+        if related_model_cls is None:  # type: ignore[comparison-overlap]
             raise UnregisteredModelError
 
         if isinstance(related_model_cls, str):
@@ -421,7 +421,7 @@ class DjangoContext:
         self, model_cls: type[Model], lookup: str
     ) -> tuple[Sequence[str], Sequence[str], Expression | Literal[False]] | None:
         query = Query(model_cls)
-        if (lookup == "pk" or lookup.startswith("pk__")) and query.get_meta().pk is None:
+        if (lookup == "pk" or lookup.startswith("pk__")) and query.get_meta().pk is None:  # type: ignore[comparison-overlap]
             # Primary key lookup when no primary key field is found, model is presumably
             # abstract and we can't say anything about 'pk'.
             return None

--- a/mypy_django_plugin/errorcodes.py
+++ b/mypy_django_plugin/errorcodes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mypy.errorcodes import ErrorCode
 
 MANAGER_MISSING = ErrorCode("django-manager-missing", "Couldn't resolve manager for model", "Django")

--- a/mypy_django_plugin/exceptions.py
+++ b/mypy_django_plugin/exceptions.py
@@ -1,2 +1,5 @@
+from __future__ import annotations
+
+
 class UnregisteredModelError(Exception):
     """The requested model is not registered"""

--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 ABSTRACT_BASE_USER_MODEL_FULLNAME = "django.contrib.auth.base_user.AbstractBaseUser"
 ABSTRACT_USER_MODEL_FULLNAME = "django.contrib.auth.models.AbstractUser"
 PERMISSION_MIXIN_CLASS_FULLNAME = "django.contrib.auth.models.PermissionsMixin"

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterable, Iterator
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
 
-from django.db.models.base import Model
 from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy import checker
@@ -59,6 +59,9 @@ from typing_extensions import Self
 from mypy_django_plugin.lib import fullnames
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from django.db.models.base import Model
     from django.db.models.fields import Field
 
     from mypy_django_plugin.django.context import DjangoContext
@@ -211,7 +214,7 @@ class DjangoModel(NamedTuple):
         return self.typ.type
 
     @classmethod
-    def from_model_type(cls, model_type: Instance, django_context: "DjangoContext") -> Self | None:
+    def from_model_type(cls, model_type: Instance, django_context: DjangoContext) -> Self | None:
         model_info = model_type.type
         is_annotated = is_annotated_model(model_info)
 
@@ -249,7 +252,7 @@ def extract_model_type_from_queryset(queryset_type: Instance, api: TypeChecker) 
 
 def get_model_info_from_qs_ctx(
     ctx: MethodContext,
-    django_context: "DjangoContext",
+    django_context: DjangoContext,
 ) -> DjangoModel | None:
     """
     Extract DjangoModel details from a queryset/manager `MethodContext`
@@ -411,7 +414,7 @@ def get_private_descriptor_type(type_info: TypeInfo, private_field_name: str, is
     return AnyType(TypeOfAny.explicit)
 
 
-def get_field_lookup_exact_type(api: TypeChecker, field: "Field[Any, Any]") -> MypyType:
+def get_field_lookup_exact_type(api: TypeChecker, field: Field[Any, Any]) -> MypyType:
     if isinstance(field, RelatedField | ForeignObjectRel):
         # Not using field.related_model because that may have str value "self"
         lookup_type_class = field.remote_field.model
@@ -487,7 +490,7 @@ def get_current_module(api: TypeChecker) -> MypyFile:
 
 
 def make_oneoff_named_tuple(
-    api: TypeChecker, name: str, fields: "dict[str, MypyType]", extra_bases: list[Instance] | None = None
+    api: TypeChecker, name: str, fields: dict[str, MypyType], extra_bases: list[Instance] | None = None
 ) -> TupleType:
     current_module = get_current_module(api)
     if extra_bases is None:
@@ -498,7 +501,7 @@ def make_oneoff_named_tuple(
     return TupleType(list(fields.values()), fallback=Instance(namedtuple_info, []))
 
 
-def make_tuple(api: "TypeChecker", fields: list[MypyType]) -> TupleType:
+def make_tuple(api: TypeChecker, fields: list[MypyType]) -> TupleType:
     # fallback for tuples is any builtins.tuple instance
     fallback = api.named_generic_type("builtins.tuple", [AnyType(TypeOfAny.special_form)])
     return TupleType(fields, fallback=fallback)
@@ -545,7 +548,7 @@ def make_typeddict(
     )
 
 
-def resolve_string_attribute_value(attr_expr: Expression, django_context: "DjangoContext") -> str | None:
+def resolve_string_attribute_value(attr_expr: Expression, django_context: DjangoContext) -> str | None:
     if isinstance(attr_expr, StrExpr):
         return attr_expr.value
 
@@ -630,7 +633,7 @@ def is_abstract_model(model: TypeInfo) -> bool:
 
 
 def resolve_lazy_reference(
-    reference: str, *, api: TypeChecker | SemanticAnalyzer, django_context: "DjangoContext", ctx: Context
+    reference: str, *, api: TypeChecker | SemanticAnalyzer, django_context: DjangoContext, ctx: Context
 ) -> TypeInfo | None:
     """
     Attempts to resolve a lazy reference(e.g. "<app_label>.<object_name>") to a
@@ -665,7 +668,7 @@ def get_model_from_expression(
     *,
     self_model: TypeInfo,
     api: TypeChecker | SemanticAnalyzer,
-    django_context: "DjangoContext",
+    django_context: DjangoContext,
 ) -> Instance | None:
     """
     Attempts to resolve an expression to a 'TypeInfo' instance. Any lazy reference

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,14 +1,14 @@
+from __future__ import annotations
+
 import importlib.metadata
 import itertools
 import sys
-from collections.abc import Callable
 from functools import cached_property, partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mypy.build import PRI_MED, PRI_MYPY
 from mypy.modulefinder import mypy_path
 from mypy.nodes import MypyFile, TypeInfo
-from mypy.options import Options
 from mypy.plugin import (
     AnalyzeTypeContext,
     AttributeContext,
@@ -19,7 +19,6 @@ from mypy.plugin import (
     Plugin,
     ReportConfigContext,
 )
-from mypy.types import Type as MypyType
 from typing_extensions import override
 
 from mypy_django_plugin.config import DjangoPluginConfig
@@ -54,6 +53,12 @@ from mypy_django_plugin.transformers.models import (
     set_auth_user_model_boolean_fields,
 )
 from mypy_django_plugin.transformers.request import check_querydict_is_mutable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mypy.options import Options
+    from mypy.types import Type as MypyType
 
 
 class NewSemanalDjangoPlugin(Plugin):

--- a/mypy_django_plugin/transformers/auth.py
+++ b/mypy_django_plugin/transformers/auth.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.nodes import TypeInfo
-from mypy.plugin import AnalyzeTypeContext
 from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
 from mypy.types import PlaceholderType, ProperType
 from mypy.types import Type as MypyType
 from mypy.typevars import fill_typevars_with_any
 
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import AnalyzeTypeContext
+
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 def _get_abstract_base_user(api: SemanticAnalyzer) -> ProperType:

--- a/mypy_django_plugin/transformers/choices.py
+++ b/mypy_django_plugin/transformers/choices.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from enum import Enum, auto
+from typing import TYPE_CHECKING
 
 from django.db.models.constants import LOOKUP_SEP
 from mypy.nodes import MemberExpr, NameExpr, SuperExpr, TypeAlias, TypeInfo, Var
-from mypy.plugin import AttributeContext
 from mypy.typeanal import make_optional_type
 from mypy.types import (
     AnyType,
@@ -20,6 +22,9 @@ from mypy.types import (
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.lib import fullnames
+
+if TYPE_CHECKING:
+    from mypy.plugin import AttributeContext
 
 
 # TODO: [mypy 1.14+] Remove this backport of `TypeInfo.enum_members`.
@@ -47,7 +52,7 @@ class _LabelLaziness(Enum):
     MIXED = auto()
 
     @classmethod
-    def make(cls, lazy: bool | None) -> "_LabelLaziness":
+    def make(cls, lazy: bool | None) -> _LabelLaziness:
         return cls.LAZY if lazy else cls.NON_LAZY
 
 

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from django.core.exceptions import FieldDoesNotExist
@@ -5,22 +7,23 @@ from django.db.models.fields import AutoField, Field
 from django.db.models.fields.related import RelatedField
 from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import AssignmentStmt, NameExpr, TypeInfo
-from mypy.plugin import FunctionContext
 from mypy.types import AnyType, Instance, NoneType, ProperType, TypeOfAny, UninhabitedType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.transformers import manytomany
 
 if TYPE_CHECKING:
     from django.db.models.fields.reverse_related import ForeignObjectRel
+    from mypy.plugin import FunctionContext
+
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 def _get_current_field_from_assignment(
     ctx: FunctionContext, django_context: DjangoContext
-) -> "Field[Any, Any] | ForeignObjectRel | None":
+) -> Field[Any, Any] | ForeignObjectRel | None:
     outer_model_info = helpers.get_typechecker_api(ctx).scope.active_class()
     if outer_model_info is None or not helpers.is_model_type(outer_model_info):
         return None

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -1,9 +1,8 @@
-from typing import Any, NamedTuple, Union, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.fields import AutoField, Field
 from django.db.models.fields.related import RelatedField
-from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import AssignmentStmt, NameExpr, TypeInfo
 from mypy.plugin import FunctionContext
@@ -15,10 +14,13 @@ from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
 from mypy_django_plugin.transformers import manytomany
 
+if TYPE_CHECKING:
+    from django.db.models.fields.reverse_related import ForeignObjectRel
+
 
 def _get_current_field_from_assignment(
     ctx: FunctionContext, django_context: DjangoContext
-) -> Union["Field[Any, Any]", ForeignObjectRel] | None:
+) -> "Field[Any, Any] | ForeignObjectRel | None":
     outer_model_info = helpers.get_typechecker_api(ctx).scope.active_class()
     if outer_model_info is None or not helpers.is_model_type(outer_model_info):
         return None

--- a/mypy_django_plugin/transformers/forms.py
+++ b/mypy_django_plugin/transformers/forms.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.nodes import TypeInfo
-from mypy.plugin import ClassDefContext
 
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import ClassDefContext
 
 
 def make_meta_nested_class_inherit_from_any(ctx: ClassDefContext) -> None:

--- a/mypy_django_plugin/transformers/functional.py
+++ b/mypy_django_plugin/transformers/functional.py
@@ -1,14 +1,18 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from mypy.checkmember import analyze_member_access
 from mypy.errorcodes import ATTR_DEFINED
 from mypy.nodes import CallExpr, MemberExpr
-from mypy.plugin import AttributeContext
 from mypy.types import AnyType, Instance, TypeOfAny
 from mypy.types import Type as MypyType
 from mypy.version import __version__ as mypy_version
 
 from mypy_django_plugin.lib import helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import AttributeContext
 
 mypy_version_info = tuple(map(int, mypy_version.partition("+")[0].split(".")))
 

--- a/mypy_django_plugin/transformers/init_create.py
+++ b/mypy_django_plugin/transformers/init_create.py
@@ -1,11 +1,18 @@
-from django.db.models.base import Model
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.errorcodes import CALL_ARG
-from mypy.plugin import FunctionContext, MethodContext
 from mypy.types import Instance, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import helpers
+
+if TYPE_CHECKING:
+    from django.db.models.base import Model
+    from mypy.plugin import FunctionContext, MethodContext
+
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 def get_actual_types(ctx: MethodContext | FunctionContext, expected_keys: list[str]) -> list[tuple[str, MypyType]]:

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -1,6 +1,7 @@
-from typing import Final
+from __future__ import annotations
 
-from mypy.checker import TypeChecker
+from typing import TYPE_CHECKING, Final
+
 from mypy.copytype import copy_type
 from mypy.nodes import (
     GDEF,
@@ -17,9 +18,7 @@ from mypy.nodes import (
     SymbolTableNode,
     TypeInfo,
 )
-from mypy.plugin import AttributeContext, ClassDefContext, DynamicClassDefContext
 from mypy.plugins.common import add_method_to_class
-from mypy.semanal import SemanticAnalyzer
 from mypy.semanal_shared import has_placeholder
 from mypy.subtypes import find_member
 from mypy.types import (
@@ -40,6 +39,11 @@ from mypy.types import Type as MypyType
 from mypy.typevars import fill_typevars
 
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.checker import TypeChecker
+    from mypy.plugin import AttributeContext, ClassDefContext, DynamicClassDefContext
+    from mypy.semanal import SemanticAnalyzer
 
 MANAGER_METHODS_RETURNING_QUERYSET: Final = frozenset(
     (

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -381,7 +381,7 @@ def create_manager_info_from_from_queryset_call(
         return None
 
     base_manager_info, queryset_info = call_expr.callee.expr.node, call_expr.args[0].node
-    if queryset_info.fullname is None:
+    if queryset_info.fullname is None:  # type: ignore[comparison-overlap]
         # In some cases, due to the way the semantic analyzer works, only
         # passed_queryset.name is available. But it should be analyzed again,
         # so this isn't a problem.

--- a/mypy_django_plugin/transformers/manytomany.py
+++ b/mypy_django_plugin/transformers/manytomany.py
@@ -1,12 +1,17 @@
-from typing import NamedTuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
 
 from mypy.nodes import AssignmentStmt, NameExpr, Node, TypeInfo
-from mypy.plugin import FunctionContext, MethodContext
 from mypy.types import Instance, ProperType, UninhabitedType, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import FunctionContext, MethodContext
+
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 class M2MThrough(NamedTuple):

--- a/mypy_django_plugin/transformers/manytoone.py
+++ b/mypy_django_plugin/transformers/manytoone.py
@@ -1,8 +1,14 @@
-from mypy.plugin import MethodContext
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.types import Instance, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import MethodContext
 
 
 def get_model_of_related_manager(ctx: MethodContext) -> Instance | None:

--- a/mypy_django_plugin/transformers/meta.py
+++ b/mypy_django_plugin/transformers/meta.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.core.exceptions import FieldDoesNotExist
-from mypy.plugin import MethodContext
 from mypy.types import AnyType, Instance, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext, get_field_type_from_model_type_info
 from mypy_django_plugin.lib import helpers
 from mypy_django_plugin.lib.helpers import DjangoModel
+
+if TYPE_CHECKING:
+    from mypy.plugin import MethodContext
 
 
 def return_proper_field_type_from_get_field(ctx: MethodContext, django_context: DjangoContext) -> MypyType:

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1,12 +1,11 @@
-from collections import deque
-from collections.abc import Iterable
-from functools import cached_property
-from typing import Any, cast
+from __future__ import annotations
 
-from django.db.models import Manager, Model
+from collections import deque
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, cast
+
 from django.db.models.fields import DateField, DateTimeField, Field
 from django.db.models.fields.reverse_related import ForeignObjectRel, ManyToManyRel, OneToOneRel
-from mypy.checker import TypeChecker
 from mypy.nodes import (
     ARG_STAR2,
     MDEF,
@@ -22,7 +21,6 @@ from mypy.nodes import (
     TypeInfo,
     Var,
 )
-from mypy.plugin import AnalyzeTypeContext, AttributeContext, ClassDefContext
 from mypy.plugins import common
 from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
@@ -31,8 +29,6 @@ from mypy.types import Type as MypyType
 from mypy.typevars import fill_typevars, fill_typevars_with_any
 from typing_extensions import override
 
-from mypy_django_plugin.config import DjangoPluginConfig
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.errorcodes import MANAGER_MISSING
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
@@ -43,6 +39,16 @@ from mypy_django_plugin.transformers.managers import (
     create_manager_info_from_from_queryset_call,
 )
 from mypy_django_plugin.transformers.manytomany import M2MArguments, M2MThrough, M2MTo
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from django.db.models import Manager, Model
+    from mypy.checker import TypeChecker
+    from mypy.plugin import AnalyzeTypeContext, AttributeContext, ClassDefContext
+
+    from mypy_django_plugin.config import DjangoPluginConfig
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 class ModelClassInitializer:
@@ -295,7 +301,7 @@ class AddDefaultPrimaryKey(ModelClassInitializer):
 
     def create_autofield(
         self,
-        auto_field: "Field[Any, Any]",
+        auto_field: Field[Any, Any],
         dest_name: str,
         existing_field: bool,
     ) -> None:
@@ -365,7 +371,7 @@ class AddRelatedModelsId(ModelClassInitializer):
 
 
 class AddManagers(ModelClassInitializer):
-    def lookup_manager(self, fullname: str, manager: "Manager[Any]") -> TypeInfo | None:
+    def lookup_manager(self, fullname: str, manager: Manager[Any]) -> TypeInfo | None:
         manager_info = self.lookup_typeinfo(fullname)
         if manager_info is None:
             manager_info = self.get_dynamic_manager(fullname, manager)
@@ -450,7 +456,7 @@ class AddManagers(ModelClassInitializer):
 
         return None
 
-    def get_dynamic_manager(self, fullname: str, manager: "Manager[Any]") -> TypeInfo | None:
+    def get_dynamic_manager(self, fullname: str, manager: Manager[Any]) -> TypeInfo | None:
         """
         Try to get a dynamically defined manager
         """

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -323,7 +323,7 @@ class AddPrimaryKeyAlias(AddDefaultPrimaryKey):
     def run_with_model_cls(self, model_cls: type[Model]) -> None:
         # We also need to override existing `pk` definition from `stubs`:
         auto_field = model_cls._meta.pk
-        if auto_field is not None:
+        if auto_field is not None:  # type: ignore[comparison-overlap]
             self.create_autofield(
                 auto_field=auto_field,
                 dest_name="pk",

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -1,10 +1,17 @@
-from mypy.plugin import MethodContext
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.types import AnyType, Instance, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.exceptions import UnregisteredModelError
 from mypy_django_plugin.lib import fullnames, helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import MethodContext
+
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext) -> MypyType:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -653,9 +653,11 @@ def check_valid_prefetch_related_lookup(
     for through_attr in lookup.split(LOOKUP_SEP):
         rel_obj_descriptor = getattr(current_model_cls, through_attr, None)
         if rel_obj_descriptor is None:
+            # If current_model_cls is "self", we cannot use `__name__` and want "self".
+            model_name = getattr(current_model_cls, "__name__", current_model_cls)
             ctx.api.fail(
                 (
-                    f'Cannot find "{through_attr}" on "{current_model_cls.__name__}" object, '
+                    f'Cannot find "{through_attr}" on "{model_name}" object, '
                     f'"{lookup}" is an invalid parameter to "prefetch_related()"'
                 ),
                 ctx.context,
@@ -665,8 +667,10 @@ def check_valid_prefetch_related_lookup(
             from django.contrib.contenttypes.fields import GenericForeignKey
 
             if not isinstance(rel_obj_descriptor, GenericForeignKey):
+                # If current_model_cls is "self", we cannot use `__name__` and want "self".
+                model_name = getattr(current_model_cls, "__name__", current_model_cls)
                 ctx.api.fail(
-                    f'"{through_attr}" on "{current_model_cls.__name__}" is not a GenericForeignKey, '
+                    f'"{through_attr}" on "{model_name}" is not a GenericForeignKey, '
                     f"GenericPrefetch can only be used with GenericForeignKey fields",
                     ctx.context,
                 )
@@ -674,10 +678,10 @@ def check_valid_prefetch_related_lookup(
         elif isinstance(rel_obj_descriptor, ForwardManyToOneDescriptor):
             current_model_cls = rel_obj_descriptor.field.remote_field.model
         elif isinstance(rel_obj_descriptor, ReverseOneToOneDescriptor):
-            current_model_cls = rel_obj_descriptor.related.related_model  # type:ignore[assignment] # Can't be 'self' for non abstract models
+            current_model_cls = rel_obj_descriptor.related.related_model
         elif isinstance(rel_obj_descriptor, ManyToManyDescriptor):
             current_model_cls = (
-                rel_obj_descriptor.rel.related_model if rel_obj_descriptor.reverse else rel_obj_descriptor.rel.model  # type:ignore[assignment] # Can't be 'self' for non abstract models
+                rel_obj_descriptor.rel.related_model if rel_obj_descriptor.reverse else rel_obj_descriptor.rel.model
             )
         elif isinstance(rel_obj_descriptor, ReverseManyToOneDescriptor):
             if contenttypes_installed:
@@ -686,7 +690,7 @@ def check_valid_prefetch_related_lookup(
                 if isinstance(rel_obj_descriptor, ReverseGenericManyToOneDescriptor):
                     current_model_cls = rel_obj_descriptor.rel.model
                     continue
-            current_model_cls = rel_obj_descriptor.rel.related_model  # type:ignore[assignment] # Can't be 'self' for non abstract models
+            current_model_cls = rel_obj_descriptor.rel.related_model
         else:
             if contenttypes_installed:
                 from django.contrib.contenttypes.fields import GenericForeignKey

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1,8 +1,8 @@
-from collections.abc import Sequence
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Literal
 
 from django.core.exceptions import FieldDoesNotExist, FieldError
-from django.db.models.base import Model
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import RelatedField
 from django.db.models.fields.related_descriptors import (
@@ -14,7 +14,6 @@ from django.db.models.fields.related_descriptors import (
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.db.models.lookups import Transform
 from django.db.models.sql.query import Query
-from mypy.checker import TypeChecker
 from mypy.errorcodes import NO_REDEF
 from mypy.nodes import (
     ARG_NAMED,
@@ -28,7 +27,6 @@ from mypy.nodes import (
     TupleExpr,
     Var,
 )
-from mypy.plugin import FunctionContext, MethodContext
 from mypy.types import (
     AnyType,
     CallableType,
@@ -44,11 +42,17 @@ from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
 from mypy_django_plugin.lib import fullnames, helpers
-from mypy_django_plugin.lib.helpers import DjangoModel
 from mypy_django_plugin.transformers.models import get_annotated_type
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from django.db.models.base import Model
     from django.db.models.options import _AnyField
+    from mypy.checker import TypeChecker
+    from mypy.plugin import FunctionContext, MethodContext
+
+    from mypy_django_plugin.lib.helpers import DjangoModel
 
 
 def determine_proper_manager_type(ctx: FunctionContext) -> MypyType:
@@ -826,7 +830,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
 
 def _try_get_field(
     ctx: MethodContext, model_cls: type[Model], field_name: str, *, resolve_pk: bool = False
-) -> "_AnyField | None":
+) -> _AnyField | None:
     opts = model_cls._meta
     resolved_name = opts.pk.name if resolve_pk and field_name == "pk" else field_name
     try:
@@ -836,7 +840,7 @@ def _try_get_field(
         return None
 
 
-def _check_field_concrete(ctx: MethodContext, field: "_AnyField", field_name: str, method: str) -> bool:
+def _check_field_concrete(ctx: MethodContext, field: _AnyField, field_name: str, method: str) -> bool:
     if not field.concrete or field.many_to_many:
         ctx.api.fail(f'"{method}()" can only be used with concrete fields. Got "{field_name}"', ctx.context)
         return False
@@ -846,7 +850,7 @@ def _check_field_concrete(ctx: MethodContext, field: "_AnyField", field_name: st
 def _check_field_not_pk(
     ctx: MethodContext,
     model_cls: type[Model],
-    field: "_AnyField",
+    field: _AnyField,
     field_name: str,
     method: str,
     *,

--- a/mypy_django_plugin/transformers/request.py
+++ b/mypy_django_plugin/transformers/request.py
@@ -1,6 +1,12 @@
-from mypy.plugin import MethodContext
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.types import Type as MypyType
 from mypy.types import UninhabitedType, get_proper_type
+
+if TYPE_CHECKING:
+    from mypy.plugin import MethodContext
 
 
 def check_querydict_is_mutable(ctx: MethodContext) -> MypyType:

--- a/mypy_django_plugin/transformers/settings.py
+++ b/mypy_django_plugin/transformers/settings.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mypy.nodes import MemberExpr
-from mypy.plugin import AttributeContext
 from mypy.types import AnyType, TypeOfAny
 from mypy.types import Type as MypyType
 
-from mypy_django_plugin.config import DjangoPluginConfig
-from mypy_django_plugin.django.context import DjangoContext
 from mypy_django_plugin.lib import helpers
+
+if TYPE_CHECKING:
+    from mypy.plugin import AttributeContext
+
+    from mypy_django_plugin.config import DjangoPluginConfig
+    from mypy_django_plugin.django.context import DjangoContext
 
 
 def get_type_of_settings_attribute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,4 +162,5 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["django_stubs_ext", "mypy_django_plugin"]
+required-imports = ["from __future__ import annotations"]
 split-on-trailing-comma = false

--- a/pyrightconfig.testcases.json
+++ b/pyrightconfig.testcases.json
@@ -5,7 +5,6 @@
     ],
     "typeCheckingMode": "strict",
     // Extra strict settings
-    "reportShadowedImports": "error", // Don't accidentally name a file something that shadows stdlib
     "reportImplicitStringConcatenation": "error",
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",

--- a/scripts/django_tests_settings.py
+++ b/scripts/django_tests_settings.py
@@ -1,5 +1,7 @@
 # It is used in `mypy.ini` only.
 # The following installed apps are required for stubtest to run correctly.
+from __future__ import annotations
+
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.admin",

--- a/scripts/tests_extension_hook.py
+++ b/scripts/tests_extension_hook.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pytest_mypy_plugins.collect import File
-from pytest_mypy_plugins.item import YamlTestItem
+
+if TYPE_CHECKING:
+    from pytest_mypy_plugins.item import YamlTestItem
 
 
 def django_plugin_hook(test_item: YamlTestItem) -> None:

--- a/tests/assert_type/apps/test_config.py
+++ b/tests/assert_type/apps/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps.config import AppConfig
 from django.utils.functional import cached_property
 from typing_extensions import assert_type, override

--- a/tests/assert_type/conf/settings.py
+++ b/tests/assert_type/conf/settings.py
@@ -1,6 +1,10 @@
-from pathlib import Path
+from __future__ import annotations
 
-from django_stubs_ext.settings import TemplatesSetting
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django_stubs_ext.settings import TemplatesSetting
 
 BASE_DIR = Path(__file__).resolve().parent
 

--- a/tests/assert_type/contrib/admin/test_utils.py
+++ b/tests/assert_type/contrib/admin/test_utils.py
@@ -62,11 +62,11 @@ person_tuple_admin = PersonTupleAdmin(Person, admin_site)
 person_fieldset_list_admin = PersonFieldsetListAdmin(Person, admin_site)
 person_fieldset_tuple_admin = PersonFieldsetTupleAdmin(Person, admin_site)
 
-# For some reason, pyright cannot see that these are not `None`.
-assert person_list_admin.fields is not None
-assert person_tuple_admin.fields is not None
-assert person_fieldset_list_admin.fieldsets is not None
-assert person_fieldset_tuple_admin.fieldsets is not None
+# For some reason, pyright cannot see that these are not `None` so we need to ignore these for mypy.
+assert person_list_admin.fields is not None  # type: ignore[comparison-overlap]
+assert person_tuple_admin.fields is not None  # type: ignore[comparison-overlap]
+assert person_fieldset_list_admin.fieldsets is not None  # type: ignore[comparison-overlap]
+assert person_fieldset_tuple_admin.fieldsets is not None  # type: ignore[comparison-overlap]
 
 assert_type(flatten(person_list_admin.fields), list[str])  # ty: ignore[no-matching-overload,type-assertion-failure]
 assert_type(flatten(person_list_admin.get_fields(request)), list[str])

--- a/tests/assert_type/contrib/auth/test_base_user.py
+++ b/tests/assert_type/contrib/auth/test_base_user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import User
 from typing_extensions import assert_type
 

--- a/tests/assert_type/contrib/auth/test_decorators.py
+++ b/tests/assert_type/contrib/auth/test_decorators.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.contrib.auth.decorators import user_passes_test
-from django.http import HttpRequest, HttpResponse
 from django.urls import reverse, reverse_lazy
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponse
 
 reversed_url = reverse("url")
 lazy_url = reverse_lazy("namespace:url")

--- a/tests/assert_type/contrib/auth/test_models.py
+++ b/tests/assert_type/contrib/auth/test_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import AbstractBaseUser, UserManager
 from typing_extensions import assert_type
 

--- a/tests/assert_type/contrib/postgres/test_indexes.py
+++ b/tests/assert_type/contrib/postgres/test_indexes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.postgres.indexes import BrinIndex, BTreeIndex, GinIndex, GistIndex, HashIndex, OpClass, SpGistIndex
 from django.db import models
 from django.db.models import Index

--- a/tests/assert_type/contrib/staticfiles/test_finders.py
+++ b/tests/assert_type/contrib/staticfiles/test_finders.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.finders import AppDirectoriesFinder, BaseFinder, DefaultStorageFinder, FileSystemFinder
 from typing_extensions import assert_type

--- a/tests/assert_type/core/handlers/test_wsgi.py
+++ b/tests/assert_type/core/handlers/test_wsgi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from wsgiref.simple_server import make_server
 
 from django.core.handlers.wsgi import WSGIHandler

--- a/tests/assert_type/core/mail/test_message.py
+++ b/tests/assert_type/core/mail/test_message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from email.mime.image import MIMEImage
 from email.mime.text import MIMEText
 from typing import Any

--- a/tests/assert_type/core/test_checks.py
+++ b/tests/assert_type/core/test_checks.py
@@ -1,9 +1,13 @@
-from collections.abc import Sequence
-from typing import Any
+from __future__ import annotations
 
-from django.apps.config import AppConfig
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
 from django.core.checks import CheckMessage, Warning, register
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.apps.config import AppConfig
 
 
 @register("foo", deploy=True)

--- a/tests/assert_type/core/test_exceptions.py
+++ b/tests/assert_type/core/test_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.core.exceptions import ValidationError
 
 ValidationError(

--- a/tests/assert_type/db/migrations/test_classvar.py
+++ b/tests/assert_type/db/migrations/test_classvar.py
@@ -1,7 +1,11 @@
-from typing import ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db import migrations
-from django.db.migrations.operations.base import Operation
+
+if TYPE_CHECKING:
+    from django.db.migrations.operations.base import Operation
 
 
 class ExplicitMigration(migrations.Migration):

--- a/tests/assert_type/db/migrations/test_operations.py
+++ b/tests/assert_type/db/migrations/test_operations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.migrations import RunSQL
 
 RunSQL(sql="SOME SQL")

--- a/tests/assert_type/db/models/_enums.py
+++ b/tests/assert_type/db/models/_enums.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal
 
 from django.db.models import TextChoices

--- a/tests/assert_type/db/models/fields/test_files.py
+++ b/tests/assert_type/db/models/fields/test_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 from django.db.models.fields.files import FieldFile, ImageFieldFile
 from typing_extensions import assert_type

--- a/tests/assert_type/db/models/fields/test_related.py
+++ b/tests/assert_type/db/models/fields/test_related.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 
 

--- a/tests/assert_type/db/models/fields/test_related_descriptors.py
+++ b/tests/assert_type/db/models/fields/test_related_descriptors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import ClassVar
 
 from django.db import models
@@ -6,7 +8,7 @@ from typing_extensions import assert_type
 
 
 class Other(models.Model):
-    explicit_descriptor: ClassVar[ReverseManyToOneDescriptor["MyModel"]]
+    explicit_descriptor: ClassVar[ReverseManyToOneDescriptor[MyModel]]
 
 
 class MyModel(models.Model):

--- a/tests/assert_type/db/models/functions/test_window.py
+++ b/tests/assert_type/db/models/functions/test_window.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.models import F, Value
 from django.db.models.functions import Lag, Lead, NthValue
 

--- a/tests/assert_type/db/models/test_base.py
+++ b/tests/assert_type/db/models/test_base.py
@@ -1,8 +1,14 @@
-from collections.abc import Iterable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.db import models
-from django.db.models.query import QuerySet
 from typing_extensions import assert_type, override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from django.db.models.query import QuerySet
 
 
 class MyModel(models.Model):

--- a/tests/assert_type/db/models/test_constraints.py
+++ b/tests/assert_type/db/models/test_constraints.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.models import CheckConstraint, Q, UniqueConstraint
 from django.db.models.functions import Lower
 

--- a/tests/assert_type/db/models/test_enums.py
+++ b/tests/assert_type/db/models/test_enums.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from typing import Any, Literal, TypeVar
 

--- a/tests/assert_type/db/models/test_indexes.py
+++ b/tests/assert_type/db/models/test_indexes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 from django.db.models.functions import Lower
 

--- a/tests/assert_type/db/models/test_lookups.py
+++ b/tests/assert_type/db/models/test_lookups.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.db.models import Lookup

--- a/tests/assert_type/db/models/test_managers.py
+++ b/tests/assert_type/db/models/test_managers.py
@@ -4,6 +4,8 @@ A TypeVar with a forward-referenced bound used in a QuerySet subclass
 caused 'Must not defer during final iteration' crash in mypy.
 """
 
+from __future__ import annotations
+
 from typing import TypeVar
 
 from django.db import models

--- a/tests/assert_type/db/models/test_ordering.py
+++ b/tests/assert_type/db/models/test_ordering.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import User
 from django.db.models import F, OrderBy
 from django.db.models.sql.query import Query

--- a/tests/assert_type/db/models/test_query.py
+++ b/tests/assert_type/db/models/test_query.py
@@ -1,7 +1,7 @@
-from collections.abc import Sequence
+from __future__ import annotations
 
-from django.contrib.auth.models import AnonymousUser
-from django.db.models import Model
+from typing import TYPE_CHECKING
+
 from django.db.models.query import (
     QuerySet,
     RawQuerySet,
@@ -9,6 +9,12 @@ from django.db.models.query import (
     prefetch_related_objects,  # pyright: ignore[reportUnknownVariableType]
 )
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from django.contrib.auth.models import AnonymousUser
+    from django.db.models import Model
 
 models_list: list[Model] = []
 prefetch_related_objects(models_list, "pk")

--- a/tests/assert_type/db/test_connection.py
+++ b/tests/assert_type/db/test_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import connection, connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.utils import CursorWrapper

--- a/tests/assert_type/db/test_transaction.py
+++ b/tests/assert_type/db/test_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.transaction import atomic, non_atomic_requests
 from django.http import HttpRequest, HttpResponse
 from typing_extensions import assert_type

--- a/tests/assert_type/forms/test_add_error.py
+++ b/tests/assert_type/forms/test_add_error.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.core.exceptions import ValidationError
 from django.forms import BaseForm
 from django.utils.functional import lazystr

--- a/tests/assert_type/forms/test_fields_choices.py
+++ b/tests/assert_type/forms/test_fields_choices.py
@@ -1,8 +1,12 @@
-from collections.abc import Callable, Mapping, Sequence
-from typing import TypeVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
 
 from django import forms
 from django.db import models
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
 
 _T = TypeVar("_T")
 

--- a/tests/assert_type/forms/test_forms.py
+++ b/tests/assert_type/forms/test_forms.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from django.contrib.messages.views import SuccessMessageMixin
-from django.forms import Form
 from django.views.generic.edit import FormMixin
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.forms import Form
 
 
 def test_in_operator(form: Form, field: str) -> None:

--- a/tests/assert_type/forms/test_formsets.py
+++ b/tests/assert_type/forms/test_formsets.py
@@ -1,6 +1,12 @@
-from django.forms import Form
-from django.forms.formsets import BaseFormSet
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.forms import Form
+    from django.forms.formsets import BaseFormSet
 
 
 def test_in_operator(formset: BaseFormSet[Form], form: Form) -> None:

--- a/tests/assert_type/http/test_redirect.py
+++ b/tests/assert_type/http/test_redirect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse, reverse_lazy

--- a/tests/assert_type/http/test_request.py
+++ b/tests/assert_type/http/test_request.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable, Iterator
 
 from django.http import QueryDict

--- a/tests/assert_type/http/test_response.py
+++ b/tests/assert_type/http/test_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import AsyncIterable, AsyncIterator, Iterator
 
 from django.http.response import HttpResponse, StreamingHttpResponse

--- a/tests/assert_type/middleware/test_middleware.py
+++ b/tests/assert_type/middleware/test_middleware.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.contrib.redirects.middleware import RedirectFallbackMiddleware
-from django.http.request import HttpRequest
 from django.http.response import (
     FileResponse,
     HttpResponse,
@@ -11,6 +14,9 @@ from django.http.response import (
 from django.middleware.common import CommonMiddleware
 from django.middleware.locale import LocaleMiddleware
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from django.http.request import HttpRequest
 
 
 class CustomCommonMiddleware(CommonMiddleware):

--- a/tests/assert_type/tasks/test_tasks.py
+++ b/tests/assert_type/tasks/test_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.tasks import task
 from typing_extensions import assert_type
 

--- a/tests/assert_type/template/backends/test_utils.py
+++ b/tests/assert_type/template/backends/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.http import HttpRequest
 from django.template.backends.utils import csrf_input_lazy, csrf_token_lazy
 from django.utils.functional import _StrPromise

--- a/tests/assert_type/template/test_library.py
+++ b/tests/assert_type/template/test_library.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Any
 

--- a/tests/assert_type/test/client.py
+++ b/tests/assert_type/test/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.test import Client
 from django.urls import reverse, reverse_lazy
 

--- a/tests/assert_type/test/test_client.py
+++ b/tests/assert_type/test/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.core.handlers.asgi import ASGIRequest

--- a/tests/assert_type/test/test_testcase.py
+++ b/tests/assert_type/test/test_testcase.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.core.handlers.wsgi import WSGIRequest
 from django.test.client import Client
 from django.test.testcases import TestCase

--- a/tests/assert_type/test/test_utils.py
+++ b/tests/assert_type/test/test_utils.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.test import override_settings
-from django.test.utils import CaptureQueriesContext
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.test.utils import CaptureQueriesContext
 
 
 def test_in_operator(ctx: CaptureQueriesContext, query: dict[str, str]) -> None:

--- a/tests/assert_type/test_import_all.py
+++ b/tests/assert_type/test_import_all.py
@@ -1,5 +1,7 @@
 # pyright: reportUnusedImport=false
 # ruff: noqa: F401
+from __future__ import annotations
+
 import django
 import django.apps
 import django.apps.config

--- a/tests/assert_type/test_shortcuts.py
+++ b/tests/assert_type/test_shortcuts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.http.request import HttpRequest

--- a/tests/assert_type/urls/test_conf.py
+++ b/tests/assert_type/urls/test_conf.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.conf.urls.i18n import urlpatterns as i18n_urlpatterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth.views import LoginView
 from django.contrib.flatpages import urls as flatpages_urls
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.http import HttpResponse
 from django.urls import URLPattern, URLResolver, _AnyURL, include, path, re_path
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.http import HttpResponse
 
 # Test 'path' accepts mix of pattern and resolver object
 include1: tuple[list[_AnyURL], None, None] = ([], None, None)

--- a/tests/assert_type/urls/test_converters.py
+++ b/tests/assert_type/urls/test_converters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import register_converter
 from django.urls.converters import IntConverter
 

--- a/tests/assert_type/urls/test_resolvers.py
+++ b/tests/assert_type/urls/test_resolvers.py
@@ -1,4 +1,9 @@
-from django.urls.resolvers import ResolverMatch
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.urls.resolvers import ResolverMatch
 
 
 def f(x: ResolverMatch) -> None:

--- a/tests/assert_type/utils/test_connection.py
+++ b/tests/assert_type/utils/test_connection.py
@@ -1,5 +1,11 @@
-from django.db.utils import ConnectionHandler
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.db.utils import ConnectionHandler
 
 
 def test_in_operator(connections: ConnectionHandler, alias: str) -> None:

--- a/tests/assert_type/utils/test_datastructures.py
+++ b/tests/assert_type/utils/test_datastructures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.utils.datastructures import MultiValueDict
 from typing_extensions import assert_type
 

--- a/tests/assert_type/utils/test_decorators.py
+++ b/tests/assert_type/utils/test_decorators.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.contrib.auth.decorators import login_required
-from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.middleware.cache import CacheMiddleware
 from django.utils.decorators import (
@@ -13,6 +14,9 @@ from django.utils.decorators import (
 )
 from django.views.generic.base import View
 from typing_extensions import assert_type, override
+
+if TYPE_CHECKING:
+    from django.http.request import HttpRequest
 
 decorator = decorator_from_middleware(
     CacheMiddleware  # pyrefly: ignore[bad-argument-type]

--- a/tests/assert_type/utils/test_deprecation.py
+++ b/tests/assert_type/utils/test_deprecation.py
@@ -1,8 +1,14 @@
-from collections.abc import Awaitable
+from __future__ import annotations
 
-from django.http import HttpRequest, HttpResponseBase
+from typing import TYPE_CHECKING
+
 from django.utils.deprecation import MiddlewareMixin
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from django.http import HttpRequest, HttpResponseBase
 
 
 class MyMiddleware(MiddlewareMixin):

--- a/tests/assert_type/utils/test_encoding.py
+++ b/tests/assert_type/utils/test_encoding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.utils.encoding import force_bytes, force_str, smart_bytes, smart_str

--- a/tests/assert_type/utils/test_functional.py
+++ b/tests/assert_type/utils/test_functional.py
@@ -1,9 +1,12 @@
-from typing import Any, ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.utils.functional import Promise, cached_property, classproperty, lazystr
 from typing_extensions import assert_type, override
 
-from django_stubs_ext import StrOrPromise
+if TYPE_CHECKING:
+    from django_stubs_ext import StrOrPromise
 
 
 # cached_property: class vs instance attributes

--- a/tests/assert_type/utils/test_safestring.py
+++ b/tests/assert_type/utils/test_safestring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.utils.safestring import SafeString, mark_safe
 from typing_extensions import assert_type
 

--- a/tests/assert_type/utils/test_text.py
+++ b/tests/assert_type/utils/test_text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.utils.functional import _StrPromise
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy

--- a/tests/assert_type/utils/test_timezone.py
+++ b/tests/assert_type/utils/test_timezone.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime, time
 from typing import Literal
 

--- a/tests/assert_type/views/test_decorators.py
+++ b/tests/assert_type/views/test_decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csp import csp_override, csp_report_only_override
 from typing_extensions import assert_type

--- a/tests/assert_type/views/test_function_based_views.py
+++ b/tests/assert_type/views/test_function_based_views.py
@@ -1,9 +1,14 @@
-from collections.abc import AsyncIterator, Iterator
+from __future__ import annotations
 
-from django.http.request import HttpRequest
+from collections.abc import AsyncIterator, Iterator
+from typing import TYPE_CHECKING
+
 from django.http.response import HttpResponse, StreamingHttpResponse
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from django.http.request import HttpRequest
 
 # HttpResponse with various content types
 

--- a/tests/assert_type/views/test_generic.py
+++ b/tests/assert_type/views/test_generic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django import forms
 from django.db import models
 from django.db.models import F

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import os
 import tempfile
 import uuid
-from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
 
 from mypy_django_plugin.config import DjangoPluginConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 TEMPLATE = """
 (config)

--- a/tests/test_generic_consistency.py
+++ b/tests/test_generic_consistency.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import glob
 import importlib


### PR DESCRIPTION
# I have made things!

- Remove use of `Union[X, Y]` in favour of `X | Y`
  - We're targeting Python 3.10+, so the old syntax is no longer necessary
- Use `from __future__ import annotations` everywhere
  - Aligns closer to the behaviour for Python 3.14 onwards
  - Allows not needing to quote annotations in some cases
  - Allows moving non-runtime imports into type checking block
- Enable `strict_equality_for_none`
- Enable `allow_redefinition_new` (planned to be default after mypy v2.0)
- Enable `fixed_format_cache` (to become default in mypy v1.20)
- Remove obsolete `reportShadowedImports` from pyright configuration