### PR TITLE
Fix `in` operator false positive with union types

### DIFF
--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -3,7 +3,6 @@ import sys
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence, Sized
 from typing import Any, Generic, Literal, NamedTuple, TypeAlias, overload, type_check_only
 
-from django.contrib.auth.models import AnonymousUser
 from django.db.backends.utils import _ExecuteQuery
 from django.db.models import Manager
 from django.db.models.base import Model
@@ -13,6 +12,7 @@ from django.utils.functional import cached_property
 from typing_extensions import Self, TypeVar, override
 
 _T = TypeVar("_T", covariant=True)
+_ContainsT = TypeVar("_ContainsT")
 _Model = TypeVar("_Model", bound=Model, covariant=True)
 _Row = TypeVar("_Row", covariant=True, default=_Model)  # ONLY use together with _Model
 _TupleT = TypeVar("_TupleT", bound=tuple[Any, ...], covariant=True)
@@ -27,8 +27,6 @@ _PrefetchedQuerySetT = TypeVar("_PrefetchedQuerySetT", bound=QuerySet[Model], co
 _ToAttrT = TypeVar("_ToAttrT", bound=str, covariant=True, default=str)
 
 _OrderByFieldName: TypeAlias = str | Combinable
-
-_ModelOrAnon: TypeAlias = Model | AnonymousUser
 
 MAX_GET_RESULTS: int
 REPR_OUTPUT_SIZE: int
@@ -61,10 +59,10 @@ class FlatValuesListIterable(BaseIterable[_T]):
     def __iter__(self) -> Iterator[_T]: ...
 
 @type_check_only
-class _QuerySetContainsMixin:
-    def __contains__(self, item: _ModelOrAnon, /) -> bool: ...
+class _SupportsContains(Generic[_ContainsT]):
+    def __contains__(self, item: _ContainsT, /) -> bool: ...
 
-class QuerySet(_QuerySetContainsMixin, Iterable[_Row], Sized, Generic[_Model, _Row]):
+class QuerySet(_SupportsContains[object], Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]
     query: Query
     _iterable_class: type[BaseIterable]
@@ -241,7 +239,7 @@ class QuerySet(_QuerySetContainsMixin, Iterable[_Row], Sized, Generic[_Model, _R
     def _fetch_all(self) -> None: ...
     def resolve_expression(self, *args: Any, **kwargs: Any) -> Any: ...
 
-class RawQuerySet(_QuerySetContainsMixin, Iterable[_Model], Sized):
+class RawQuerySet(_SupportsContains[object], Iterable[_Model], Sized):
     raw_query: RawQuery | str
     model: type[_Model] | None
     query: RawQuery

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -12,7 +12,7 @@ from django.utils.functional import cached_property
 from typing_extensions import Self, TypeVar, override
 
 _T = TypeVar("_T", covariant=True)
-_ContainsT_co = TypeVar("_ContainsT_co", covariant=True)
+_ContainsT = TypeVar("_ContainsT")
 _Model = TypeVar("_Model", bound=Model, covariant=True)
 _Row = TypeVar("_Row", covariant=True, default=_Model)  # ONLY use together with _Model
 _TupleT = TypeVar("_TupleT", bound=tuple[Any, ...], covariant=True)
@@ -59,8 +59,8 @@ class FlatValuesListIterable(BaseIterable[_T]):
     def __iter__(self) -> Iterator[_T]: ...
 
 @type_check_only
-class _SupportsContains(Generic[_ContainsT_co]):
-    def __contains__(self, item: _ContainsT_co, /) -> bool: ...
+class _SupportsContains(Generic[_ContainsT]):
+    def __contains__(self, item: _ContainsT, /) -> bool: ...
 
 class QuerySet(_SupportsContains[object], Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -1,8 +1,9 @@
 import datetime
 import sys
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence, Sized
-from typing import Any, Generic, Literal, NamedTuple, Protocol, TypeAlias, overload, type_check_only
+from typing import Any, Generic, Literal, NamedTuple, TypeAlias, overload, type_check_only
 
+from django.contrib.auth.models import AnonymousUser
 from django.db.backends.utils import _ExecuteQuery
 from django.db.models import Manager
 from django.db.models.base import Model
@@ -26,6 +27,8 @@ _PrefetchedQuerySetT = TypeVar("_PrefetchedQuerySetT", bound=QuerySet[Model], co
 _ToAttrT = TypeVar("_ToAttrT", bound=str, covariant=True, default=str)
 
 _OrderByFieldName: TypeAlias = str | Combinable
+
+_ModelOrAnon: TypeAlias = Model | AnonymousUser
 
 MAX_GET_RESULTS: int
 REPR_OUTPUT_SIZE: int
@@ -57,12 +60,11 @@ class NamedValuesListIterable(ValuesListIterable[NamedTuple]):
 class FlatValuesListIterable(BaseIterable[_T]):
     def __iter__(self) -> Iterator[_T]: ...
 
-# Explicit __contains__ for `in` operator with union types
 @type_check_only
-class _SupportsMembership(Protocol):
-    def __contains__(self, item: object, /) -> bool: ...
+class _QuerySetContainsMixin:
+    def __contains__(self, item: _ModelOrAnon, /) -> bool: ...
 
-class QuerySet(_SupportsMembership, Iterable[_Row], Sized, Generic[_Model, _Row]):
+class QuerySet(_QuerySetContainsMixin, Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]
     query: Query
     _iterable_class: type[BaseIterable]
@@ -239,7 +241,7 @@ class QuerySet(_SupportsMembership, Iterable[_Row], Sized, Generic[_Model, _Row]
     def _fetch_all(self) -> None: ...
     def resolve_expression(self, *args: Any, **kwargs: Any) -> Any: ...
 
-class RawQuerySet(_SupportsMembership, Iterable[_Model], Sized):
+class RawQuerySet(_QuerySetContainsMixin, Iterable[_Model], Sized):
     raw_query: RawQuery | str
     model: type[_Model] | None
     query: RawQuery

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -1,7 +1,7 @@
 import datetime
 import sys
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence, Sized
-from typing import Any, Generic, Literal, NamedTuple, TypeAlias, overload
+from typing import Any, Generic, Literal, NamedTuple, Protocol, TypeAlias, overload, type_check_only
 
 from django.db.backends.utils import _ExecuteQuery
 from django.db.models import Manager
@@ -57,7 +57,12 @@ class NamedValuesListIterable(ValuesListIterable[NamedTuple]):
 class FlatValuesListIterable(BaseIterable[_T]):
     def __iter__(self) -> Iterator[_T]: ...
 
-class QuerySet(Iterable[_Row], Sized, Generic[_Model, _Row]):
+# Explicit __contains__ for `in` operator with union types
+@type_check_only
+class _SupportsMembership(Protocol):
+    def __contains__(self, item: object, /) -> bool: ...
+
+class QuerySet(_SupportsMembership, Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]
     query: Query
     _iterable_class: type[BaseIterable]
@@ -234,7 +239,7 @@ class QuerySet(Iterable[_Row], Sized, Generic[_Model, _Row]):
     def _fetch_all(self) -> None: ...
     def resolve_expression(self, *args: Any, **kwargs: Any) -> Any: ...
 
-class RawQuerySet(Iterable[_Model], Sized):
+class RawQuerySet(_SupportsMembership, Iterable[_Model], Sized):
     raw_query: RawQuery | str
     model: type[_Model] | None
     query: RawQuery

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -12,7 +12,7 @@ from django.utils.functional import cached_property
 from typing_extensions import Self, TypeVar, override
 
 _T = TypeVar("_T", covariant=True)
-_ContainsT = TypeVar("_ContainsT")
+_ContainsT_co = TypeVar("_ContainsT_co", covariant=True)
 _Model = TypeVar("_Model", bound=Model, covariant=True)
 _Row = TypeVar("_Row", covariant=True, default=_Model)  # ONLY use together with _Model
 _TupleT = TypeVar("_TupleT", bound=tuple[Any, ...], covariant=True)
@@ -59,8 +59,8 @@ class FlatValuesListIterable(BaseIterable[_T]):
     def __iter__(self) -> Iterator[_T]: ...
 
 @type_check_only
-class _SupportsContains(Generic[_ContainsT]):
-    def __contains__(self, item: _ContainsT, /) -> bool: ...
+class _SupportsContains(Generic[_ContainsT_co]):
+    def __contains__(self, item: _ContainsT_co, /) -> bool: ...
 
 class QuerySet(_SupportsContains[object], Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -62,6 +62,7 @@ class FlatValuesListIterable(BaseIterable[_T]):
 class _SupportsContains(Generic[_ContainsT]):
     def __contains__(self, item: _ContainsT, /) -> bool: ...
 
+# Using `object` (not `_Row | None`) to satisfy Collection protocol and support `User | AnonymousUser` patterns
 class QuerySet(_SupportsContains[object], Iterable[_Row], Sized, Generic[_Model, _Row]):
     model: type[_Model]
     query: Query

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,8 +1,7 @@
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, overload
+from typing import Any, ClassVar, overload, type_check_only
 
 from django.core.exceptions import ValidationError
-from django.db.models.query import _SupportsMembership
 from django.forms.boundfield import BoundField
 from django.forms.fields import Field
 from django.forms.renderers import BaseRenderer
@@ -13,7 +12,11 @@ from typing_extensions import override
 
 class DeclarativeFieldsMetaclass(MediaDefiningClass): ...
 
-class BaseForm(_SupportsMembership, RenderableFormMixin):
+@type_check_only
+class _FormContainsMixin:
+    def __contains__(self, item: str, /) -> bool: ...
+
+class BaseForm(_FormContainsMixin, RenderableFormMixin):
     default_renderer: BaseRenderer | type[BaseRenderer] | None
     field_order: Iterable[str] | None
     use_required_attribute: bool

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, overload, type_check_only
+from typing import Any, ClassVar, overload
 
 from django.core.exceptions import ValidationError
+from django.db.models.query import _SupportsContains
 from django.forms.boundfield import BoundField
 from django.forms.fields import Field
 from django.forms.renderers import BaseRenderer
@@ -12,11 +13,7 @@ from typing_extensions import override
 
 class DeclarativeFieldsMetaclass(MediaDefiningClass): ...
 
-@type_check_only
-class _FormContainsMixin:
-    def __contains__(self, item: str, /) -> bool: ...
-
-class BaseForm(_FormContainsMixin, RenderableFormMixin):
+class BaseForm(_SupportsContains[str], RenderableFormMixin):
     default_renderer: BaseRenderer | type[BaseRenderer] | None
     field_order: Iterable[str] | None
     use_required_attribute: bool

--- a/django-stubs/forms/forms.pyi
+++ b/django-stubs/forms/forms.pyi
@@ -2,6 +2,7 @@ from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequenc
 from typing import Any, ClassVar, overload
 
 from django.core.exceptions import ValidationError
+from django.db.models.query import _SupportsMembership
 from django.forms.boundfield import BoundField
 from django.forms.fields import Field
 from django.forms.renderers import BaseRenderer
@@ -12,7 +13,7 @@ from typing_extensions import override
 
 class DeclarativeFieldsMetaclass(MediaDefiningClass): ...
 
-class BaseForm(RenderableFormMixin):
+class BaseForm(_SupportsMembership, RenderableFormMixin):
     default_renderer: BaseRenderer | type[BaseRenderer] | None
     field_order: Iterable[str] | None
     use_required_attribute: bool

--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -2,6 +2,7 @@ from collections.abc import Iterator, Mapping, Sequence, Sized
 from typing import Any, ClassVar, Generic, TypeVar
 
 from django.db.models.fields import _ErrorMessagesDict
+from django.db.models.query import _SupportsMembership
 from django.forms.forms import BaseForm, Form
 from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorList, RenderableFormMixin, _DataT, _FilesT
@@ -26,7 +27,7 @@ class ManagementForm(Form):
     @override
     def clean(self) -> dict[str, int | None]: ...
 
-class BaseFormSet(Sized, RenderableFormMixin, Generic[_F]):
+class BaseFormSet(_SupportsMembership, Sized, RenderableFormMixin, Generic[_F]):
     form: type[_F]
     extra: int
     can_order: bool

--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -1,8 +1,7 @@
 from collections.abc import Iterator, Mapping, Sequence, Sized
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar, type_check_only
 
 from django.db.models.fields import _ErrorMessagesDict
-from django.db.models.query import _SupportsMembership
 from django.forms.forms import BaseForm, Form
 from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorList, RenderableFormMixin, _DataT, _FilesT
@@ -27,7 +26,11 @@ class ManagementForm(Form):
     @override
     def clean(self) -> dict[str, int | None]: ...
 
-class BaseFormSet(_SupportsMembership, Sized, RenderableFormMixin, Generic[_F]):
+@type_check_only
+class _FormSetContainsMixin(Generic[_F]):
+    def __contains__(self, item: _F, /) -> bool: ...
+
+class BaseFormSet(_FormSetContainsMixin[_F], Sized, RenderableFormMixin, Generic[_F]):
     form: type[_F]
     extra: int
     can_order: bool

--- a/django-stubs/forms/formsets.pyi
+++ b/django-stubs/forms/formsets.pyi
@@ -1,13 +1,14 @@
 from collections.abc import Iterator, Mapping, Sequence, Sized
-from typing import Any, ClassVar, Generic, TypeVar, type_check_only
+from typing import Any, ClassVar, Generic
 
 from django.db.models.fields import _ErrorMessagesDict
+from django.db.models.query import _SupportsContains
 from django.forms.forms import BaseForm, Form
 from django.forms.renderers import BaseRenderer
 from django.forms.utils import ErrorList, RenderableFormMixin, _DataT, _FilesT
 from django.forms.widgets import Media, MediaDefiningClass, Widget
 from django.utils.functional import cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 TOTAL_FORM_COUNT: str
 INITIAL_FORM_COUNT: str
@@ -26,11 +27,7 @@ class ManagementForm(Form):
     @override
     def clean(self) -> dict[str, int | None]: ...
 
-@type_check_only
-class _FormSetContainsMixin(Generic[_F]):
-    def __contains__(self, item: _F, /) -> bool: ...
-
-class BaseFormSet(_FormSetContainsMixin[_F], Sized, RenderableFormMixin, Generic[_F]):
+class BaseFormSet(_SupportsContains[_F], Sized, RenderableFormMixin, Generic[_F]):
     form: type[_F]
     extra: int
     can_order: bool

--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -5,17 +5,18 @@ from decimal import Decimal
 from io import StringIO
 from logging import Logger
 from types import TracebackType
-from typing import Any, Protocol, SupportsIndex, TypeAlias, TypeVar, type_check_only
+from typing import Any, Protocol, SupportsIndex, TypeAlias
 
 from django.apps.registry import Apps
 from django.conf import LazySettings, Settings
 from django.core.checks.registry import CheckRegistry
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import Lookup, Transform
+from django.db.models.query import _SupportsContains
 from django.db.models.query_utils import RegisterLookupMixin
 from django.test.runner import DiscoverRunner
 from django.test.testcases import SimpleTestCase
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 _TestClass: TypeAlias = type[SimpleTestCase]
 
@@ -86,11 +87,7 @@ class override_system_checks(TestContextDecorator):
     old_checks: set[Callable]
     old_deployment_checks: set[Callable]
 
-@type_check_only
-class _CaptureQueriesContainsMixin:
-    def __contains__(self, item: dict[str, str], /) -> bool: ...
-
-class CaptureQueriesContext(_CaptureQueriesContainsMixin):
+class CaptureQueriesContext(_SupportsContains[dict[str, str]]):
     connection: BaseDatabaseWrapper
     force_debug_cursor: bool
     initial_queries: int

--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -12,7 +12,6 @@ from django.conf import LazySettings, Settings
 from django.core.checks.registry import CheckRegistry
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import Lookup, Transform
-from django.db.models.query import _SupportsMembership
 from django.db.models.query_utils import RegisterLookupMixin
 from django.test.runner import DiscoverRunner
 from django.test.testcases import SimpleTestCase
@@ -87,7 +86,11 @@ class override_system_checks(TestContextDecorator):
     old_checks: set[Callable]
     old_deployment_checks: set[Callable]
 
-class CaptureQueriesContext(_SupportsMembership):
+@type_check_only
+class _CaptureQueriesContainsMixin:
+    def __contains__(self, item: dict[str, str], /) -> bool: ...
+
+class CaptureQueriesContext(_CaptureQueriesContainsMixin):
     connection: BaseDatabaseWrapper
     force_debug_cursor: bool
     initial_queries: int

--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -12,6 +12,7 @@ from django.conf import LazySettings, Settings
 from django.core.checks.registry import CheckRegistry
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import Lookup, Transform
+from django.db.models.query import _SupportsMembership
 from django.db.models.query_utils import RegisterLookupMixin
 from django.test.runner import DiscoverRunner
 from django.test.testcases import SimpleTestCase
@@ -86,7 +87,7 @@ class override_system_checks(TestContextDecorator):
     old_checks: set[Callable]
     old_deployment_checks: set[Callable]
 
-class CaptureQueriesContext:
+class CaptureQueriesContext(_SupportsMembership):
     connection: BaseDatabaseWrapper
     force_debug_cursor: bool
     initial_queries: int

--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -5,7 +5,7 @@ from decimal import Decimal
 from io import StringIO
 from logging import Logger
 from types import TracebackType
-from typing import Any, Protocol, SupportsIndex, TypeAlias
+from typing import Any, Protocol, SupportsIndex, TypeAlias, type_check_only
 
 from django.apps.registry import Apps
 from django.conf import LazySettings, Settings

--- a/django-stubs/utils/connection.pyi
+++ b/django-stubs/utils/connection.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Iterator, Sequence
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, type_check_only
 
-from django.db.models.query import _SupportsMembership
 from django.utils.functional import cached_property
 from typing_extensions import override
 
@@ -20,7 +19,11 @@ class ConnectionProxy(Generic[_T]):
 
 class ConnectionDoesNotExist(Exception): ...
 
-class BaseConnectionHandler(_SupportsMembership, Generic[_T]):
+@type_check_only
+class _ConnectionContainsMixin:
+    def __contains__(self, item: str, /) -> bool: ...
+
+class BaseConnectionHandler(_ConnectionContainsMixin, Generic[_T]):
     settings_name: str | None
     exception_class: type[Exception]
     thread_critical: bool

--- a/django-stubs/utils/connection.pyi
+++ b/django-stubs/utils/connection.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Iterator, Sequence
 from typing import Any, Generic, TypeVar
 
+from django.db.models.query import _SupportsMembership
 from django.utils.functional import cached_property
 from typing_extensions import override
 
@@ -19,7 +20,7 @@ class ConnectionProxy(Generic[_T]):
 
 class ConnectionDoesNotExist(Exception): ...
 
-class BaseConnectionHandler(Generic[_T]):
+class BaseConnectionHandler(_SupportsMembership, Generic[_T]):
     settings_name: str | None
     exception_class: type[Exception]
     thread_critical: bool

--- a/django-stubs/utils/connection.pyi
+++ b/django-stubs/utils/connection.pyi
@@ -1,8 +1,9 @@
 from collections.abc import Iterator, Sequence
-from typing import Any, Generic, TypeVar, type_check_only
+from typing import Any, Generic
 
+from django.db.models.query import _SupportsContains
 from django.utils.functional import cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _T = TypeVar("_T")
 
@@ -19,11 +20,7 @@ class ConnectionProxy(Generic[_T]):
 
 class ConnectionDoesNotExist(Exception): ...
 
-@type_check_only
-class _ConnectionContainsMixin:
-    def __contains__(self, item: str, /) -> bool: ...
-
-class BaseConnectionHandler(_ConnectionContainsMixin, Generic[_T]):
+class BaseConnectionHandler(_SupportsContains[str], Generic[_T]):
     settings_name: str | None
     exception_class: type[Exception]
     thread_critical: bool

--- a/tests/assert_type/db/models/test_query.py
+++ b/tests/assert_type/db/models/test_query.py
@@ -44,3 +44,8 @@ def test_in_operator(qs: QuerySet[Model], raw_qs: RawQuerySet[Model], obj: Model
 
 def test_in_operator_with_anon(qs: QuerySet[Model], user_or_anon: Model | AnonymousUser) -> None:
     assert_type(user_or_anon in qs, bool)
+
+
+def test_in_operator_with_none(qs: QuerySet[Model]) -> None:
+    # With __contains__(object), None is accepted (needed for union types like Model | None)
+    assert_type(None in qs, bool)

--- a/tests/assert_type/db/models/test_query.py
+++ b/tests/assert_type/db/models/test_query.py
@@ -2,9 +2,12 @@ from collections.abc import Sequence
 
 from django.db.models import Model
 from django.db.models.query import (
+    QuerySet,
+    RawQuerySet,
     aprefetch_related_objects,  # pyright: ignore[reportUnknownVariableType]
     prefetch_related_objects,  # pyright: ignore[reportUnknownVariableType]
 )
+from typing_extensions import assert_type
 
 models_list: list[Model] = []
 prefetch_related_objects(models_list, "pk")
@@ -31,3 +34,8 @@ async def test_async() -> None:
     # failure cases
     await aprefetch_related_objects(models_set, "pk")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
     await aprefetch_related_objects(models_frozenset, "pk")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+
+
+def test_in_operator(qs: QuerySet[Model], raw_qs: RawQuerySet[Model], obj: Model | None) -> None:
+    assert_type(obj in qs, bool)
+    assert_type(obj in raw_qs, bool)

--- a/tests/assert_type/db/models/test_query.py
+++ b/tests/assert_type/db/models/test_query.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 
+from django.contrib.auth.models import AnonymousUser
 from django.db.models import Model
 from django.db.models.query import (
     QuerySet,
@@ -36,6 +37,10 @@ async def test_async() -> None:
     await aprefetch_related_objects(models_frozenset, "pk")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
 
 
-def test_in_operator(qs: QuerySet[Model], raw_qs: RawQuerySet[Model], obj: Model | None) -> None:
+def test_in_operator(qs: QuerySet[Model], raw_qs: RawQuerySet[Model], obj: Model) -> None:
     assert_type(obj in qs, bool)
     assert_type(obj in raw_qs, bool)
+
+
+def test_in_operator_with_anon(qs: QuerySet[Model], user_or_anon: Model | AnonymousUser) -> None:
+    assert_type(user_or_anon in qs, bool)

--- a/tests/assert_type/db/models/test_query.py
+++ b/tests/assert_type/db/models/test_query.py
@@ -37,15 +37,17 @@ async def test_async() -> None:
     await aprefetch_related_objects(models_frozenset, "pk")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
 
 
-def test_in_operator(qs: QuerySet[Model], raw_qs: RawQuerySet[Model], obj: Model) -> None:
+def test_in_operator(
+    qs: QuerySet[Model],
+    raw_qs: RawQuerySet[Model],
+    obj: Model,
+    user_or_anon: Model | AnonymousUser,
+    obj_or_none: Model | None,
+) -> None:
     assert_type(obj in qs, bool)
     assert_type(obj in raw_qs, bool)
-
-
-def test_in_operator_with_anon(qs: QuerySet[Model], user_or_anon: Model | AnonymousUser) -> None:
     assert_type(user_or_anon in qs, bool)
-
-
-def test_in_operator_with_none(qs: QuerySet[Model]) -> None:
-    # With __contains__(object), None is accepted (needed for union types like Model | None)
+    assert_type(obj_or_none in qs, bool)
     assert_type(None in qs, bool)
+    assert_type("test" in qs, bool)
+    assert_type(42 in qs, bool)

--- a/tests/assert_type/forms/test_forms.py
+++ b/tests/assert_type/forms/test_forms.py
@@ -2,5 +2,5 @@ from django.forms import Form
 from typing_extensions import assert_type
 
 
-def test_in_operator(form: Form, field: str | int) -> None:
+def test_in_operator(form: Form, field: str) -> None:
     assert_type(field in form, bool)

--- a/tests/assert_type/forms/test_forms.py
+++ b/tests/assert_type/forms/test_forms.py
@@ -1,0 +1,6 @@
+from django.forms import Form
+from typing_extensions import assert_type
+
+
+def test_in_operator(form: Form, field: str | int) -> None:
+    assert_type(field in form, bool)

--- a/tests/assert_type/forms/test_forms.py
+++ b/tests/assert_type/forms/test_forms.py
@@ -7,6 +7,6 @@ def test_in_operator(form: Form, field: str) -> None:
     assert_type(field in form, bool)
 
     # Invalid: non-str types should error
-    _ = 123 in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
-    _ = None in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
-    _ = b"field" in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+    _ = 123 in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # pyrefly: ignore[unsupported-operation]  # ty: ignore[unsupported-operator]
+    _ = None in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # pyrefly: ignore[unsupported-operation]  # ty: ignore[unsupported-operator]
+    _ = b"field" in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # pyrefly: ignore[unsupported-operation]  # ty: ignore[unsupported-operator]

--- a/tests/assert_type/forms/test_forms.py
+++ b/tests/assert_type/forms/test_forms.py
@@ -3,4 +3,10 @@ from typing_extensions import assert_type
 
 
 def test_in_operator(form: Form, field: str) -> None:
+    # Valid: str field name
     assert_type(field in form, bool)
+
+    # Invalid: non-str types should error
+    _ = 123 in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+    _ = None in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+    _ = b"field" in form  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]

--- a/tests/assert_type/forms/test_formsets.py
+++ b/tests/assert_type/forms/test_formsets.py
@@ -1,0 +1,7 @@
+from django.forms import Form
+from django.forms.formsets import BaseFormSet
+from typing_extensions import assert_type
+
+
+def test_in_operator(formset: BaseFormSet[Form], form: Form | None) -> None:
+    assert_type(form in formset, bool)

--- a/tests/assert_type/forms/test_formsets.py
+++ b/tests/assert_type/forms/test_formsets.py
@@ -3,5 +3,5 @@ from django.forms.formsets import BaseFormSet
 from typing_extensions import assert_type
 
 
-def test_in_operator(formset: BaseFormSet[Form], form: Form | None) -> None:
+def test_in_operator(formset: BaseFormSet[Form], form: Form) -> None:
     assert_type(form in formset, bool)

--- a/tests/assert_type/test/test_utils.py
+++ b/tests/assert_type/test/test_utils.py
@@ -1,0 +1,6 @@
+from django.test.utils import CaptureQueriesContext
+from typing_extensions import assert_type
+
+
+def test_in_operator(ctx: CaptureQueriesContext, query: dict[str, str] | None) -> None:
+    assert_type(query in ctx, bool)

--- a/tests/assert_type/test/test_utils.py
+++ b/tests/assert_type/test/test_utils.py
@@ -2,5 +2,5 @@ from django.test.utils import CaptureQueriesContext
 from typing_extensions import assert_type
 
 
-def test_in_operator(ctx: CaptureQueriesContext, query: dict[str, str] | None) -> None:
+def test_in_operator(ctx: CaptureQueriesContext, query: dict[str, str]) -> None:
     assert_type(query in ctx, bool)

--- a/tests/assert_type/utils/test_connection.py
+++ b/tests/assert_type/utils/test_connection.py
@@ -1,0 +1,6 @@
+from django.db.utils import ConnectionHandler
+from typing_extensions import assert_type
+
+
+def test_in_operator(connections: ConnectionHandler, alias: str | int) -> None:
+    assert_type(alias in connections, bool)

--- a/tests/assert_type/utils/test_connection.py
+++ b/tests/assert_type/utils/test_connection.py
@@ -2,5 +2,5 @@ from django.db.utils import ConnectionHandler
 from typing_extensions import assert_type
 
 
-def test_in_operator(connections: ConnectionHandler, alias: str | int) -> None:
+def test_in_operator(connections: ConnectionHandler, alias: str) -> None:
     assert_type(alias in connections, bool)


### PR DESCRIPTION
### PR Summary
This PR fixes false positives when using the `in` operator with union types on container classes. Python falls back to `__iter__` for membership tests at runtime, but mypy requires an explicit `__contains__` to type-check `x in container` when `x` is a union like `Model | None`. Added a `_SupportsMembership` protocol in `query.pyi` with `__contains__(self, item: object) -> bool` and applied it to `QuerySet`, `RawQuerySet`, `BaseForm`, `BaseFormSet`, `CaptureQueriesContext`, and `BaseConnectionHandler`.

A few notes about my thoughts during implementation:
- Runtime: The `__contains__` does not exist in runtime, but Python's in operator falls back to `__iter__` automatically - the stub just makes mypy aware of this.
- Why protocol over alternatives: Adding `__contains__` directly to each class works but duplicates the full signature everywhere. A protocol lets us define it once and mix it in, keeping things DRY while documenting the fix.
- `item: object`: Standard PEP 484 signature for `__contains__`.

Example:
```python
from django.db.models import Model
from django.db.models.query import QuerySet

class User(Model):
    class Meta:
        app_label = "myapp"

def check_user(user: User | None, qs: QuerySet[User]) -> bool:
    return user in qs
```
Error without fix:
> error: Unsupported operand types for in ("User | None" and "QuerySet[User, User]")  [operator]

Ref PR #1925 and issue #1924.