### PR TITLE
Support WithAnnotations TypedDict fields in queryset validation

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -250,12 +250,20 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
         if check_valid_attr_value(ctx, django_context, django_model, attr_name)
     }
 
+    existing_row_extra_attrs: dict[str, MypyType] = {}
+    if len(default_return_type.args) > 1:
+        original_row_type = get_proper_type(default_return_type.args[1])
+        if isinstance(original_row_type, Instance) and original_row_type.extra_attrs:
+            existing_row_extra_attrs = dict(original_row_type.extra_attrs.attrs)
+
+    all_fields = {**existing_row_extra_attrs, **expression_types}
+
     annotated_type: ProperType = django_model.typ
-    if expression_types:
+    if all_fields:
         fields_dict = helpers.make_typeddict(
             api,
-            fields=expression_types,
-            required_keys=set(expression_types.keys()),
+            fields=all_fields,
+            required_keys=set(all_fields.keys()),
             readonly_keys=set(),
         )
         annotated_type = get_annotated_type(api, django_model.typ, fields_dict=fields_dict)
@@ -465,6 +473,29 @@ def _get_selected_fields_from_queryset_type(qs_type: Instance) -> set[str] | Non
     return None
 
 
+def _get_annotated_fields_from_queryset_type(qs_type: Instance) -> set[str]:
+    """
+    Derive annotated field names from a QuerySet type.
+
+    Sources:
+      - args[0].extra_attrs: from .annotate() calls
+      - args[1].extra_attrs: from WithAnnotations[Model, TypedDict]
+    """
+    fields: set[str] = set()
+
+    if len(qs_type.args) >= 1:
+        model_type = get_proper_type(qs_type.args[0])
+        if isinstance(model_type, Instance) and model_type.extra_attrs:
+            fields.update(model_type.extra_attrs.attrs.keys())
+
+    if len(qs_type.args) >= 2:
+        row_type = get_proper_type(qs_type.args[1])
+        if isinstance(row_type, Instance) and row_type.extra_attrs:
+            fields.update(row_type.extra_attrs.attrs.keys())
+
+    return fields
+
+
 def check_valid_attr_value(
     ctx: MethodContext,
     django_context: DjangoContext,
@@ -482,6 +513,7 @@ def check_valid_attr_value(
         - new_attr_names: A mapping of field names to types currently being added to the model
     """
     deselected_fields: set[str] | None = None
+    annotated_fields: set[str] = set()
     if isinstance(ctx.type, Instance):
         selected_fields = _get_selected_fields_from_queryset_type(ctx.type)
         if selected_fields is not None:
@@ -489,6 +521,7 @@ def check_valid_attr_value(
             deselected_fields = model_field_names - selected_fields
             new_attr_names = new_attr_names or set()
             new_attr_names.update(selected_fields - model_field_names)
+        annotated_fields = _get_annotated_fields_from_queryset_type(ctx.type)
 
     is_conflicting_attr_value = bool(
         # 1. Conflict with another symbol on the model (If not de-selected via a prior .values/.values_list call).
@@ -499,7 +532,7 @@ def check_valid_attr_value(
         # Ex:
         #     User.objects.annotate(foo=...).prefetch_related(Prefetch(...,to_attr="foo"))
         #     User.objects.prefetch_related(Prefetch(...,to_attr="foo")).prefetch_related(Prefetch(...,to_attr="foo"))
-        or (model.typ.extra_attrs and attr_name in model.typ.extra_attrs.attrs)
+        or attr_name in annotated_fields
         # 3. Conflict with another symbol added in the current processing.
         # Ex:
         #     User.objects.prefetch_related(
@@ -936,11 +969,12 @@ def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> Mypy
         return ctx.default_return_type
 
     selected_fields = _get_selected_fields_from_queryset_type(ctx.type) if isinstance(ctx.type, Instance) else None
+    annotated_fields = _get_annotated_fields_from_queryset_type(ctx.type) if isinstance(ctx.type, Instance) else set()
 
     for lookup_value in _extract_field_names_from_varargs(ctx):
         parts = lookup_value.removeprefix("-").split(LOOKUP_SEP)
 
-        if django_model.typ.extra_attrs and parts[0] in django_model.typ.extra_attrs.attrs:
+        if parts[0] in annotated_fields:
             # Skip validation for annotated fields
             continue
         if selected_fields is not None and parts[0] in selected_fields:

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -185,3 +185,111 @@
                 class Article(models.Model):
                     created = models.DateTimeField(auto_now_add=True)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+-   case: order_by_with_annotations_typeddict
+    installed_apps:
+        - myapp
+    main: |
+        from typing import TYPE_CHECKING, TypedDict
+        from django.db.models import QuerySet, Value, IntegerField
+        from django_stubs_ext import WithAnnotations
+        from myapp.models import Item
+
+        class ExtraAnnotation(TypedDict):
+            extra_id: int | None
+
+        if TYPE_CHECKING:
+            ItemWithExtraAnnotation = WithAnnotations[Item, ExtraAnnotation]
+        else:
+            ItemWithExtraAnnotation = Item
+
+        ItemWithExtraAnnotationQuerySet = QuerySet[Item, ItemWithExtraAnnotation]
+
+        def annotate_extra(qs: QuerySet[Item]) -> ItemWithExtraAnnotationQuerySet:
+            return qs.annotate(extra_id=Value(None, output_field=IntegerField()))
+
+        qs = annotate_extra(Item.objects.all())
+        qs.order_by("extra_id")
+        qs.order_by("-extra_id")
+        qs.order_by("name", "extra_id")
+        qs.order_by("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: id, name  [misc]
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Item(models.Model):
+                    name = models.CharField(max_length=100)
+
+
+-   case: order_by_combined_annotate_and_withannotations
+    installed_apps:
+        - myapp
+    main: |
+        from typing import TYPE_CHECKING, TypedDict
+        from django.db.models import QuerySet, F
+        from django_stubs_ext import WithAnnotations
+        from myapp.models import Item
+        class DeclaredAnnotation(TypedDict):
+            declared_field: int
+
+        if TYPE_CHECKING:
+            ItemWithDeclared = WithAnnotations[Item, DeclaredAnnotation]
+        else:
+            ItemWithDeclared = Item
+
+        def get_qs() -> QuerySet[Item, ItemWithDeclared]:
+            return Item.objects.all()  # type: ignore[return-value]
+
+        qs = get_qs().annotate(runtime_field=F("id"))
+        qs.order_by("declared_field")
+        qs.order_by("runtime_field")
+        qs.order_by("declared_field", "-runtime_field", "name")
+        qs.order_by("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: id, name  [misc]
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Item(models.Model):
+                    name = models.CharField(max_length=100)
+
+
+-   case: order_by_with_multiple_withannotations_fields
+    installed_apps:
+        - myapp
+    main: |
+        from typing import TYPE_CHECKING, TypedDict
+        from django.db.models import QuerySet
+        from django_stubs_ext import WithAnnotations
+        from myapp.models import Item
+
+        class MultipleAnnotations(TypedDict):
+            field_a: int
+            field_b: str
+            field_c: float
+
+        if TYPE_CHECKING:
+            ItemWithMultiple = WithAnnotations[Item, MultipleAnnotations]
+        else:
+            ItemWithMultiple = Item
+
+        def get_qs() -> QuerySet[Item, ItemWithMultiple]:
+            return Item.objects.all()  # type: ignore[return-value]
+
+        qs = get_qs()
+        qs.order_by("field_a")
+        qs.order_by("-field_b")
+        qs.order_by("field_c")
+        qs.order_by("field_a", "-field_b", "field_c", "name")
+        qs.order_by("nonexistent")  # E: Cannot resolve keyword 'nonexistent' into field. Choices are: id, name  [misc]
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Item(models.Model):
+                    name = models.CharField(max_length=100)

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -201,6 +201,43 @@
         )
 
 
+-   case: prefetch_related_to_attr_conflict_with_withannotations
+    installed_apps:
+        - myapp
+    main: |
+        from django.db.models import Prefetch, QuerySet, Value, IntegerField
+        from myapp.models import Article, Tag
+        from typing import TYPE_CHECKING, TypedDict
+        from django_stubs_ext import WithAnnotations
+
+        class ExtraAnnotation(TypedDict):
+            extra_id: int | None
+
+        if TYPE_CHECKING:
+            ArticleWithExtra = WithAnnotations[Article, ExtraAnnotation]
+        else:
+            ArticleWithExtra = Article
+
+        ArticleWithExtraQuerySet = QuerySet[Article, ArticleWithExtra]
+
+        def annotate_extra(qs: QuerySet[Article]) -> ArticleWithExtraQuerySet:
+            return qs.annotate(extra_id=Value(None, output_field=IntegerField()))
+
+        qs = annotate_extra(Article.objects.all())
+        qs.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="extra_id"))  # E: Attribute "extra_id" already defined on "myapp.models.Article"  [no-redef]
+        qs.prefetch_related(Prefetch("tags", Tag.objects.all(), to_attr="prefetched_tags"))
+
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Tag(models.Model): ...
+                class Article(models.Model):
+                    tags = models.ManyToManyField(to=Tag, related_name="articles", blank=True)
+
+
 -   case: prefetch_related_to_attr_conflict_with_model_attr
     installed_apps:
         - myapp


### PR DESCRIPTION
### PR Summary
When using `WithAnnotations[Model, TypedDict]` to declare annotated fields, `order_by()` was incorrectly reporting "Cannot resolve keyword" errors for fields defined in the TypedDict. The plugin was only checking `args[0].extra_attrs` (set by `.annotate()`) but `WithAnnotations` places its fields in `args[1].extra_attrs`. This PR also fixes `prefetch_related` conflict detection for `WithAnnotations` fields and preserves declared fields when chaining `.annotate()` on a `WithAnnotations` queryset.

Fixes #3207