### PR TITLE
Add `backend` attribute stub for authenticated users

### DIFF
--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -23,6 +23,7 @@ class AbstractBaseUser(models.Model):
     password = models.CharField(max_length=128)
     last_login = models.DateTimeField(blank=True, null=True)
     is_active: bool | BooleanField[bool | Combinable, bool]
+    backend: str  # Set dynamically by authenticate(), used by login()
 
     def get_username(self) -> str: ...
     def natural_key(self) -> tuple[str]: ...

--- a/tests/assert_type/contrib/auth/test_base_user.py
+++ b/tests/assert_type/contrib/auth/test_base_user.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import User
+from typing_extensions import assert_type
+
+
+def get_backend() -> str:
+    return "django.contrib.auth.backends.ModelBackend"
+
+
+user = User()
+user.backend = get_backend()
+assert_type(user.backend, str)


### PR DESCRIPTION
### PR Summary
This PR adds the `backend` attribute to `AbstractBaseUser`. Django's `authenticate()` sets this on the user as a string path to the auth backend, and `login()` uses it to save the backend in the session. Without this, `user.backend` caused a type error even though it works at runtime.

Now, this is technically a "lie" - the attribute doesn't exist on fresh `User()` instances, only after `authenticate()` sets it. However:
- Python's type system can't express "possibly missing" class attributes ([`NotRequired`](https://peps.python.org/pep-0655/) only _currently?_ works for TypedDict).
- `str | None` doesn't help either - checking `if user.backend is not None` would also crash with `AttributeError` if missing.
- This follows established patterns in django-stubs: `HttpRequest.user`, `HttpRequest.session`, `BaseInlineFormSet.fk` are all phantom attributes set at runtime.

In future, ideally we would like something like `backend: NotRequired[str]` which errors on direct access but narrows safely after `hasattr` checks, but `NotRequired` currently only works for `TypedDict` (see: python/typing#601).

Closes #1478
