### PR TITLE
Fix GIS `as_sql` stub signatures to match runtime

### DIFF
--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,6 +20,18 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
+    # GeoFuncMixin.as_sql drops `template` and `arg_joiner` vs Func.as_sql, but forwards
+    # **extra_context to super().as_sql — so callers can still pass them and they work.
+    # We keep the full Func.as_sql-compatible signature here to avoid MRO conflicts.
+    def as_sql(
+        self,
+        compiler: SQLCompiler,
+        connection: BaseDatabaseWrapper,
+        function: str | None = None,
+        template: str | None = None,
+        arg_joiner: str | None = None,
+        **extra_context: Any,
+    ) -> _AsSqlType: ...
     def resolve_expression(
         self,
         *args: Any,
@@ -45,6 +57,10 @@ class Area(OracleToleranceMixin, GeoFunc):
     @cached_property
     @override
     def output_field(self) -> AreaField: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
@@ -160,6 +176,10 @@ class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
 class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     def as_postgresql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
     ) -> _AsSqlType: ...

--- a/django-stubs/contrib/gis/db/models/lookups.pyi
+++ b/django-stubs/contrib/gis/db/models/lookups.pyi
@@ -1,9 +1,13 @@
 from typing import Any
 
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Lookup, Transform
+from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import override
 
-class RasterBandTransform(Transform): ...
+class RasterBandTransform(Transform):
+    @override
+    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...  # type: ignore[override]
 
 class GISLookup(Lookup):
     sql_template: Any

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -79,10 +79,6 @@ django.contrib.gis.admin.site
 django.contrib.gis.db.backends.spatialite.base.DatabaseWrapper.ops
 django.contrib.gis.db.models.CharField.description
 django.contrib.gis.db.models.Field.description
-django.contrib.gis.db.models.functions.Area.as_sql
-django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql
-django.contrib.gis.db.models.functions.Length.as_sql
-django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql
 django.contrib.gis.forms.inlineformset_factory
 django.contrib.gis.forms.modelformset_factory
 django.contrib.redirects.models.Redirect.id


### PR DESCRIPTION
Add missing `as_sql` method stubs for `GeoFuncMixin`, `Area`, `Length`,
and `RasterBandTransform` to match their runtime signatures.

- `GeoFuncMixin.as_sql`: uses `Func.as_sql`-compatible signature
  (including `template`/`arg_joiner`) to avoid MRO conflicts across
  all 16+ subclasses that inherit from both `GeoFuncMixin` and `Func`.
- `Area.as_sql` / `Length.as_sql`: override without `function` param
  (Django's intentional LSP narrowing).
- `RasterBandTransform.as_sql`: override with bare `(compiler, connection)`
  signature matching the runtime `compiler.compile(self.lhs)` delegation.

## Related issues

- Refs allowlist_todo.txt entries:
  - `django.contrib.gis.db.models.functions.Area.as_sql`
  - `django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql`
  - `django.contrib.gis.db.models.functions.Length.as_sql`
  - `django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql`
