### PR TITLE
Fix GIS as_sql stub signatures to match runtime

### DIFF
--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,6 +20,18 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
+    # GeoFuncMixin.as_sql drops `template` and `arg_joiner` vs Func.as_sql, but forwards
+    # **extra_context to super().as_sql — so callers can still pass them and they work.
+    # We keep the full Func.as_sql-compatible signature here to avoid MRO conflicts.
+    def as_sql(
+        self,
+        compiler: SQLCompiler,
+        connection: BaseDatabaseWrapper,
+        function: str | None = None,
+        template: str | None = None,
+        arg_joiner: str | None = None,
+        **extra_context: Any,
+    ) -> _AsSqlType: ...
     def resolve_expression(
         self,
         *args: Any,
@@ -45,6 +57,10 @@ class Area(OracleToleranceMixin, GeoFunc):
     @cached_property
     @override
     def output_field(self) -> AreaField: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
@@ -160,6 +176,10 @@ class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
 class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     def as_postgresql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
     ) -> _AsSqlType: ...

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,16 +20,11 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
-    # GeoFuncMixin.as_sql drops `template` and `arg_joiner` vs Func.as_sql, but forwards
-    # **extra_context to super().as_sql — so callers can still pass them and they work.
-    # We keep the full Func.as_sql-compatible signature here to avoid MRO conflicts.
-    def as_sql(
+    def as_sql(  # type: ignore[override]
         self,
         compiler: SQLCompiler,
         connection: BaseDatabaseWrapper,
         function: str | None = None,
-        template: str | None = None,
-        arg_joiner: str | None = None,
         **extra_context: Any,
     ) -> _AsSqlType: ...
     def resolve_expression(
@@ -38,7 +33,8 @@ class GeoFuncMixin:
         **kwargs: Any,
     ) -> Any: ...
 
-class GeoFunc(GeoFuncMixin, Func): ...
+class GeoFunc(GeoFuncMixin, Func):  # type: ignore[misc]
+    ...
 
 class GeomOutputGeoFunc(GeoFunc):
     @cached_property
@@ -98,19 +94,19 @@ class AsWKT(GeoFunc):
     output_field: ClassVar[TextField]
     arity: int
 
-class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):
+class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, num_seg: int = 48, **extra: Any) -> None: ...
     @override
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Centroid(OracleToleranceMixin, GeomOutputGeoFunc):
+class Centroid(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class ClosestPoint(GeomOutputGeoFunc):
+class ClosestPoint(GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: tuple[int, int]
 
-class Difference(OracleToleranceMixin, GeomOutputGeoFunc):
+class Difference(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
@@ -119,7 +115,7 @@ class DistanceResultMixin:
     def output_field(self) -> DistanceField: ...
     def source_is_geography(self) -> Any: ...
 
-class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     geom_param_pos: Any
     spheroid: Any
     def __init__(self, expr1: Any, expr2: Any, spheroid: Any | None = None, **extra: Any) -> None: ...
@@ -154,26 +150,26 @@ class GeometryDistance(GeoFunc):
     arg_joiner: str
     geom_param_pos: Any
 
-class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):
+class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
-class GeometryType(GeoFuncMixin, StandardTransform):
+class GeometryType(GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[CharField]
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class IsEmpty(GeoFuncMixin, StandardTransform):
+class IsEmpty(GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[BooleanField]
 
-class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
+class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[BooleanField]
     @override
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
     @override
@@ -205,7 +201,7 @@ class NumPoints(GeoFunc):
     output_field: ClassVar[IntegerField]
     arity: int
 
-class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     arity: int
     def as_postgresql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
@@ -213,22 +209,22 @@ class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class PointOnSurface(OracleToleranceMixin, GeomOutputGeoFunc):
+class PointOnSurface(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class Reverse(GeoFunc):
+class Reverse(GeoFunc):  # type: ignore[misc]
     arity: int
 
-class Rotate(GeomOutputGeoFunc):
+class Rotate(GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, angle: Any, origin: Any | None = None, **extra: Any) -> None: ...
 
-class Scale(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):
+class Scale(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, x: Any, y: Any, z: float = 0.0, **extra: Any) -> None: ...
 
-class SnapToGrid(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):
+class SnapToGrid(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, *args: Any, **extra: Any) -> None: ...
 
-class SymDifference(OracleToleranceMixin, GeomOutputGeoFunc):
+class SymDifference(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
@@ -239,6 +235,6 @@ class Translate(Scale):
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Union(OracleToleranceMixin, GeomOutputGeoFunc):
+class Union(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,7 +20,7 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
-    def as_sql(  # type: ignore[override]
+    def as_sql(
         self,
         compiler: SQLCompiler,
         connection: BaseDatabaseWrapper,
@@ -102,7 +102,7 @@ class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[m
 class Centroid(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class ClosestPoint(GeomOutputGeoFunc):  # type: ignore[misc]
+class ClosestPoint(GeomOutputGeoFunc):
     arity: int
     geom_param_pos: tuple[int, int]
 
@@ -169,7 +169,7 @@ class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):  # type: i
     @override
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
+class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
     @override
@@ -212,10 +212,10 @@ class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ig
 class PointOnSurface(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class Reverse(GeoFunc):  # type: ignore[misc]
+class Reverse(GeoFunc):
     arity: int
 
-class Rotate(GeomOutputGeoFunc):  # type: ignore[misc]
+class Rotate(GeomOutputGeoFunc):
     def __init__(self, expression: Any, angle: Any, origin: Any | None = None, **extra: Any) -> None: ...
 
 class Scale(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):  # type: ignore[misc]

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,6 +20,18 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
+    # GeoFuncMixin.as_sql drops `template` and `arg_joiner` vs Func.as_sql, but forwards
+    # **extra_context to super().as_sql — so callers can still pass them and they work.
+    # We keep the full Func.as_sql-compatible signature here to avoid MRO conflicts.
+    def as_sql(
+        self,
+        compiler: SQLCompiler,
+        connection: BaseDatabaseWrapper,
+        function: str | None = None,
+        template: str | None = None,
+        arg_joiner: str | None = None,
+        **extra_context: Any,
+    ) -> _AsSqlType: ...
     def resolve_expression(
         self,
         *args: Any,
@@ -45,6 +57,10 @@ class Area(OracleToleranceMixin, GeoFunc):
     @cached_property
     @override
     def output_field(self) -> AreaField[Any, Any]: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
@@ -160,6 +176,10 @@ class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
 class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
+    @override
+    def as_sql(  # type: ignore[override]
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
+    ) -> _AsSqlType: ...
     def as_postgresql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
     ) -> _AsSqlType: ...

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,6 +20,7 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
+    # `as_sql` drops `template`/`arg_joiner` from `Func.as_sql`, matching runtime.
     def as_sql(
         self,
         compiler: SQLCompiler,
@@ -33,8 +34,7 @@ class GeoFuncMixin:
         **kwargs: Any,
     ) -> Any: ...
 
-class GeoFunc(GeoFuncMixin, Func):  # type: ignore[misc]
-    ...
+class GeoFunc(GeoFuncMixin, Func): ...  # type: ignore[misc]
 
 class GeomOutputGeoFunc(GeoFunc):
     @cached_property

--- a/django-stubs/contrib/gis/db/models/functions.pyi
+++ b/django-stubs/contrib/gis/db/models/functions.pyi
@@ -20,16 +20,11 @@ class GeoFuncMixin:
     def name(self) -> str: ...
     @cached_property
     def geo_field(self) -> Any: ...
-    # GeoFuncMixin.as_sql drops `template` and `arg_joiner` vs Func.as_sql, but forwards
-    # **extra_context to super().as_sql — so callers can still pass them and they work.
-    # We keep the full Func.as_sql-compatible signature here to avoid MRO conflicts.
-    def as_sql(
+    def as_sql(  # type: ignore[override]
         self,
         compiler: SQLCompiler,
         connection: BaseDatabaseWrapper,
         function: str | None = None,
-        template: str | None = None,
-        arg_joiner: str | None = None,
         **extra_context: Any,
     ) -> _AsSqlType: ...
     def resolve_expression(
@@ -38,7 +33,8 @@ class GeoFuncMixin:
         **kwargs: Any,
     ) -> Any: ...
 
-class GeoFunc(GeoFuncMixin, Func): ...
+class GeoFunc(GeoFuncMixin, Func):  # type: ignore[misc]
+    ...
 
 class GeomOutputGeoFunc(GeoFunc):
     @cached_property
@@ -98,19 +94,19 @@ class AsWKT(GeoFunc):
     output_field: ClassVar[TextField[Any, Any]]
     arity: int
 
-class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):
+class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, num_seg: int = 48, **extra: Any) -> None: ...
     @override
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Centroid(OracleToleranceMixin, GeomOutputGeoFunc):
+class Centroid(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class ClosestPoint(GeomOutputGeoFunc):
+class ClosestPoint(GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: tuple[int, int]
 
-class Difference(OracleToleranceMixin, GeomOutputGeoFunc):
+class Difference(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
@@ -119,7 +115,7 @@ class DistanceResultMixin:
     def output_field(self) -> DistanceField[Any, Any]: ...
     def source_is_geography(self) -> Any: ...
 
-class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     geom_param_pos: Any
     spheroid: Any
     def __init__(self, expr1: Any, expr2: Any, spheroid: Any | None = None, **extra: Any) -> None: ...
@@ -154,26 +150,26 @@ class GeometryDistance(GeoFunc):
     arg_joiner: str
     geom_param_pos: Any
 
-class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):
+class Intersection(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
-class GeometryType(GeoFuncMixin, StandardTransform):
+class GeometryType(GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[CharField[Any, Any]]
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class IsEmpty(GeoFuncMixin, StandardTransform):
+class IsEmpty(GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[BooleanField[Any, Any]]
 
-class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):
+class IsValid(OracleToleranceMixin, GeoFuncMixin, StandardTransform):  # type: ignore[misc]
     lookup_name: str
     output_field: ClassVar[BooleanField[Any, Any]]
     @override
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     spheroid: Any
     def __init__(self, expr1: Any, spheroid: bool = True, **extra: Any) -> None: ...
     @override
@@ -205,7 +201,7 @@ class NumPoints(GeoFunc):
     output_field: ClassVar[IntegerField[Any, Any]]
     arity: int
 
-class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
+class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):  # type: ignore[misc]
     arity: int
     def as_postgresql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
@@ -213,22 +209,22 @@ class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class PointOnSurface(OracleToleranceMixin, GeomOutputGeoFunc):
+class PointOnSurface(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
 
-class Reverse(GeoFunc):
+class Reverse(GeoFunc):  # type: ignore[misc]
     arity: int
 
-class Rotate(GeomOutputGeoFunc):
+class Rotate(GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, angle: Any, origin: Any | None = None, **extra: Any) -> None: ...
 
-class Scale(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):
+class Scale(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, x: Any, y: Any, z: float = 0.0, **extra: Any) -> None: ...
 
-class SnapToGrid(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):
+class SnapToGrid(SQLiteDecimalToFloatMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     def __init__(self, expression: Any, *args: Any, **extra: Any) -> None: ...
 
-class SymDifference(OracleToleranceMixin, GeomOutputGeoFunc):
+class SymDifference(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any
 
@@ -239,6 +235,6 @@ class Translate(Scale):
     @override
     def as_sqlite(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Union(OracleToleranceMixin, GeomOutputGeoFunc):
+class Union(OracleToleranceMixin, GeomOutputGeoFunc):  # type: ignore[misc]
     arity: int
     geom_param_pos: Any

--- a/django-stubs/contrib/gis/db/models/lookups.pyi
+++ b/django-stubs/contrib/gis/db/models/lookups.pyi
@@ -1,9 +1,13 @@
 from typing import Any
 
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Lookup, Transform
+from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import override
 
-class RasterBandTransform(Transform): ...
+class RasterBandTransform(Transform):
+    @override
+    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...  # type: ignore[override]
 
 class GISLookup(Lookup):
     sql_template: Any

--- a/django-stubs/contrib/gis/db/models/lookups.pyi
+++ b/django-stubs/contrib/gis/db/models/lookups.pyi
@@ -1,10 +1,14 @@
 from re import Pattern
 from typing import Any
 
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Lookup, Transform
+from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import override
 
-class RasterBandTransform(Transform): ...
+class RasterBandTransform(Transform):
+    @override
+    def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> _AsSqlType: ...  # type: ignore[override]
 
 class GISLookup(Lookup):
     sql_template: Any

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -79,10 +79,6 @@ django.contrib.gis.admin.site
 django.contrib.gis.db.backends.spatialite.base.DatabaseWrapper.ops
 django.contrib.gis.db.models.CharField.description
 django.contrib.gis.db.models.Field.description
-django.contrib.gis.db.models.functions.Area.as_sql
-django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql
-django.contrib.gis.db.models.functions.Length.as_sql
-django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql
 django.contrib.gis.forms.inlineformset_factory
 django.contrib.gis.forms.modelformset_factory
 django.contrib.redirects.models.Redirect.id

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -72,10 +72,6 @@ django.contrib.flatpages.models.FlatPage.template_name
 django.contrib.flatpages.models.FlatPage.title
 django.contrib.flatpages.models.FlatPage.url
 django.contrib.gis.db.backends.spatialite.base.DatabaseWrapper.ops
-django.contrib.gis.db.models.functions.Area.as_sql
-django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql
-django.contrib.gis.db.models.functions.Length.as_sql
-django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql
 django.contrib.redirects.models.Redirect.id
 django.contrib.redirects.models.Redirect.new_path
 django.contrib.redirects.models.Redirect.old_path


### PR DESCRIPTION
## Summary

Add missing `as_sql` method stubs to GIS modules.

## Changes

- Add `GeoFuncMixin.as_sql` stub
- Add `Area.as_sql` override stub
- Add `Length.as_sql` override stub
- Add `RasterBandTransform.as_sql` stub
- Add `# type: ignore[misc]` to classes with MRO conflicts
- Remove 4 entries from allowlist_todo.txt

## Why `type: ignore[misc]`?

Django's `GeoFuncMixin.as_sql` intentionally narrows the signature from `Func.as_sql` by removing `template` and `arg_joiner` parameters. This causes MRO conflicts that are expected and safe to ignore.

## Refs allowlist_todo.txt entries:

- `django.contrib.gis.db.models.functions.Area.as_sql`
- `django.contrib.gis.db.models.functions.GeoFuncMixin.as_sql`
- `django.contrib.gis.db.models.functions.Length.as_sql`
- `django.contrib.gis.db.models.lookups.RasterBandTransform.as_sql`