### PR TITLE
feat: annotate HttpRequest as readable, HttpResponse as writable

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -1,4 +1,5 @@
 import datetime
+import sys
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol, TypeAlias, TypeVar, overload, type_check_only
@@ -11,6 +12,11 @@ from django.urls import ResolverMatch
 from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, MultiValueDict
 from django.utils.functional import cached_property
 from typing_extensions import Self, override
+
+if sys.version_info >= (3, 14):
+    from io import Reader
+else:
+    from typing_extensions import Reader
 
 RAISE_ERROR: object
 host_validation_re: Pattern[str]
@@ -42,7 +48,7 @@ class HttpHeaders(CaseInsensitiveMapping[str]):
     @classmethod
     def to_asgi_names(cls, headers: Mapping[str, Any]) -> dict[str, Any]: ...
 
-class HttpRequest:
+class HttpRequest(Reader):
     GET: _ImmutableQueryDict
     POST: _ImmutableQueryDict
     COOKIES: dict[str, str]

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -12,7 +12,6 @@ from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, M
 from django.utils.functional import cached_property
 from typing_extensions import Reader, Self, override
 
-
 RAISE_ERROR: object
 host_validation_re: Pattern[str]
 

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -1,5 +1,4 @@
 import datetime
-import sys
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol, TypeAlias, TypeVar, overload, type_check_only
@@ -11,12 +10,8 @@ from django.core.files import uploadedfile, uploadhandler
 from django.urls import ResolverMatch
 from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, MultiValueDict
 from django.utils.functional import cached_property
-from typing_extensions import Self, override
+from typing_extensions import Reader, Self, override
 
-if sys.version_info >= (3, 14):
-    from io import Reader
-else:
-    from typing_extensions import Reader
 
 RAISE_ERROR: object
 host_validation_re: Pattern[str]
@@ -48,7 +43,7 @@ class HttpHeaders(CaseInsensitiveMapping[str]):
     @classmethod
     def to_asgi_names(cls, headers: Mapping[str, Any]) -> dict[str, Any]: ...
 
-class HttpRequest(Reader):
+class HttpRequest(Reader[bytes]):
     GET: _ImmutableQueryDict
     POST: _ImmutableQueryDict
     COOKIES: dict[str, str]

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -7,8 +7,7 @@ from typing import Any, Literal, NoReturn, TypeVar, overload, type_check_only
 
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
 from django.utils.functional import _StrOrPromise, cached_property
-from typing_extensions import override, Writer
-
+from typing_extensions import Writer, override
 
 class BadHeaderError(ValueError): ...
 

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -1,5 +1,4 @@
 import datetime
-import sys
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator, Mapping
 from http.cookies import SimpleCookie
 from io import BytesIO
@@ -8,12 +7,8 @@ from typing import Any, Literal, NoReturn, TypeVar, overload, type_check_only
 
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
 from django.utils.functional import _StrOrPromise, cached_property
-from typing_extensions import override
+from typing_extensions import override, Writer
 
-if sys.version_info >= (3, 14):
-    from io import Writer
-else:
-    from typing_extensions import Writer
 
 class BadHeaderError(ValueError): ...
 
@@ -27,7 +22,7 @@ class ResponseHeaders(CaseInsensitiveMapping[str]):
     def pop(self, key: str, default: _Z = ...) -> _Z | tuple[str, str]: ...
     def setdefault(self, key: str, value: str | bytes | int) -> None: ...
 
-class HttpResponseBase(Writer):
+class HttpResponseBase(Writer[str | bytes]):
     status_code: int
     streaming: bool
     cookies: SimpleCookie

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -1,4 +1,5 @@
 import datetime
+import sys
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator, Mapping
 from http.cookies import SimpleCookie
 from io import BytesIO
@@ -8,6 +9,11 @@ from typing import Any, Literal, NoReturn, TypeVar, overload, type_check_only
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
 from django.utils.functional import _StrOrPromise, cached_property
 from typing_extensions import override
+
+if sys.version_info >= (3, 14):
+    from io import Writer
+else:
+    from typing_extensions import Writer
 
 class BadHeaderError(ValueError): ...
 
@@ -21,7 +27,7 @@ class ResponseHeaders(CaseInsensitiveMapping[str]):
     def pop(self, key: str, default: _Z = ...) -> _Z | tuple[str, str]: ...
     def setdefault(self, key: str, value: str | bytes | int) -> None: ...
 
-class HttpResponseBase:
+class HttpResponseBase(Writer):
     status_code: int
     streaming: bool
     cookies: SimpleCookie


### PR DESCRIPTION
`HttpRequest`s are readable, while `HttpResponse`s are writable. It's insufficient that they have `read` and `write` methods respectively, as one would have to use a `Protocol`. However `Reader` and `Writer` are already available in the `io` package and are better suited.