### PR TITLE
Allow missing config section when `DJANGO_SETTINGS_MODULE` is set

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -89,7 +89,9 @@ class DjangoPluginConfig:
         try:
             config: dict[str, Any] = data["tool"]["django-stubs"]
         except KeyError:
-            toml_exit(MISSING_SECTION.format(section="tool.django-stubs"))
+            if not os.getenv(DJANGO_SETTINGS_ENV_VAR):
+                toml_exit(MISSING_SECTION.format(section="tool.django-stubs"))
+            config = {}
 
         django_settings_module = config.get("django_settings_module") or os.getenv(DJANGO_SETTINGS_ENV_VAR)
         if not django_settings_module:
@@ -117,9 +119,10 @@ class DjangoPluginConfig:
 
         section = "mypy.plugins.django-stubs"
         if not parser.has_section(section):
-            exit_with_error(MISSING_SECTION.format(section=section))
+            if not os.getenv(DJANGO_SETTINGS_ENV_VAR):
+                exit_with_error(MISSING_SECTION.format(section=section))
 
-        if parser.has_option(section, "django_settings_module"):
+        if parser.has_section(section) and parser.has_option(section, "django_settings_module"):
             django_settings_module = parser.get(section, "django_settings_module").strip("'\"")
         else:
             django_settings_module = os.getenv(DJANGO_SETTINGS_ENV_VAR, "")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -241,3 +241,33 @@ def test_correct_configuration_with_django_setting_from_env(boolean_value: str) 
 
     assert config.django_settings_module == django_settings_env_value
     assert config.strict_settings is (boolean_value.lower() == "true")
+
+
+def test_toml_missing_section_with_env_var() -> None:
+    """Missing [tool.django-stubs] section works when DJANGO_SETTINGS_MODULE is set."""
+    config_file_contents = """
+    [tool.mypy]
+    plugins = ["mypy_django_plugin.main"]
+    """
+    with write_to_file(config_file_contents, suffix=".toml") as filename:
+        with mock.patch.dict(os.environ, {"DJANGO_SETTINGS_MODULE": "my.module"}):
+            config = DjangoPluginConfig(filename)
+
+    assert config.django_settings_module == "my.module"
+    assert config.strict_settings is True
+
+
+def test_ini_missing_section_with_env_var() -> None:
+    """Missing [mypy.plugins.django-stubs] section works when DJANGO_SETTINGS_MODULE is set."""
+    config_file_contents = "\n".join(
+        [
+            "[mypy]",
+            "plugins = mypy_django_plugin.main",
+        ]
+    )
+    with write_to_file(config_file_contents) as filename:
+        with mock.patch.dict(os.environ, {"DJANGO_SETTINGS_MODULE": "my.module"}):
+            config = DjangoPluginConfig(filename)
+
+    assert config.django_settings_module == "my.module"
+    assert config.strict_settings is True


### PR DESCRIPTION
### PR Summary
When `DJANGO_SETTINGS_MODULE` is set as an env var, the plugin currently still requires an empty `[tool.django-stubs]` (or `[mypy.plugins.django-stubs]`) section to exist in the config file. This is annoying for setups that rely on the env var (Docker, CI, multi-environment deploys). PR #2021 made `django_settings_module` optional within the section, but the section itself remained mandatory - so the env var fallback was unreachable when the section was missing. This PR just adds an env var check before erroring on a missing section, so if you've got `DJANGO_SETTINGS_MODULE` set, it uses that with defaults and moves on.

Fixes #2912