### PR TITLE
Make Lookup type argument optional by defaulting _T to Any

### DIFF
--- a/django-stubs/db/models/lookups.pyi
+++ b/django-stubs/db/models/lookups.pyi
@@ -10,7 +10,7 @@ from django.utils.datastructures import OrderedSet
 from django.utils.functional import cached_property
 from typing_extensions import override
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", default=Any)
 
 class Lookup(Expression, Generic[_T]):
     lookup_name: str | None

--- a/tests/assert_type/db/models/test_lookups.py
+++ b/tests/assert_type/db/models/test_lookups.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from django.db.models import Lookup
+from typing_extensions import assert_type
+
+
+# Lookup can be used without explicit type argument (defaults to Any).
+# Regression test for https://github.com/typeddjango/django-stubs/issues/2649.
+def test_lookup_optional_type_arg(lookup: Lookup, typed_lookup: Lookup[int]) -> None:
+    assert_type(lookup, Lookup)
+    assert_type(typed_lookup, Lookup[int])
+
+
+class MyLookup(Lookup): ...
+
+
+class MyTypedLookup(Lookup[Any]): ...
+
+
+def test_subclass_without_type_arg(lookup: MyLookup, typed: MyTypedLookup) -> None:
+    # MyLookup(Lookup) is equivalent to MyLookup(Lookup[Any])
+    assert_type(lookup, MyLookup)
+    assert_type(typed, MyTypedLookup)


### PR DESCRIPTION
Fixes #2649.

The type argument is still required because: 
  1. Subclasses specialize `_T` with concrete types, for ex `PatternLookup(BuiltinLookup[str])`, `IsNull(BuiltinLookup[bool])`, `Exact[int | float]`, etc.                     
  2. The plugin code in `_resolve_lookup_type_from_lookup_class` extracts that type argument to determine what types are valid for lookup values. This powers error messages like: `User.objects.filter(username__contains=1) # E: Incompatible type for lookup 'username__contains': (got "int", expected "str")`  

Having a default to Any is a good middle ground I think, people can still have more precise types if needed