### PR TITLE
Include django and django-stubs versions in plugin config data

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import itertools
 import sys
 from collections.abc import Callable
@@ -327,6 +328,8 @@ class NewSemanalDjangoPlugin(Plugin):
         # Cache would be cleared if any settings do change.
         extra_data = {
             "AUTH_USER_MODEL": self.django_context.settings.AUTH_USER_MODEL,
+            "django_version": importlib.metadata.version("django"),
+            "django_stubs_version": importlib.metadata.version("django-stubs"),
         }
         return self.plugin_config.to_json(extra_data)
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -331,6 +331,10 @@ class NewSemanalDjangoPlugin(Plugin):
             "django_version": importlib.metadata.version("django"),
             "django_stubs_version": importlib.metadata.version("django-stubs"),
         }
+        try:
+            extra_data["django_stubs_ext_version"] = importlib.metadata.version("django-stubs-ext")
+        except importlib.metadata.PackageNotFoundError:
+            pass
         return self.plugin_config.to_json(extra_data)
 
 


### PR DESCRIPTION
This ensures mypy automatically invalidates its cache whenever either package version changes, preventing stale cache issues when upgrading django-stubs or django.

It would crash if django or django-stubs is not installed with importlib.metadata.PackageNotFoundError, should we handle it ?

Closes #2338


