### PR TITLE
Expose django admin fieldset types in `django_stubs_ext`

### DIFF
--- a/ext/django_stubs_ext/__init__.py
+++ b/ext/django_stubs_ext/__init__.py
@@ -1,3 +1,5 @@
+from .aliases import FieldOpts as FieldOpts
+from .aliases import FieldsetSpec as FieldsetSpec
 from .aliases import QuerySetAny as QuerySetAny
 from .aliases import StrOrPromise, StrPromise
 from .aliases import ValuesQuerySet as ValuesQuerySet
@@ -9,6 +11,8 @@ from .types import AnyAttrAllowed as AnyAttrAllowed
 __all__ = [
     "Annotations",
     "AnyAttrAllowed",
+    "FieldOpts",
+    "FieldsetSpec",
     "QuerySetAny",
     "StrOrPromise",
     "StrPromise",

--- a/ext/django_stubs_ext/aliases.py
+++ b/ext/django_stubs_ext/aliases.py
@@ -1,6 +1,8 @@
 import typing
 
 if typing.TYPE_CHECKING:
+    from django.contrib.admin.options import _FieldOpts as FieldOpts
+    from django.contrib.admin.options import _FieldsetSpec as FieldsetSpec
     from django.db.models.query import _QuerySet
     from django.utils.functional import _StrOrPromise as StrOrPromise
     from django.utils.functional import _StrPromise as StrPromise
@@ -13,8 +15,10 @@ else:
     from django.utils.functional import Promise as StrPromise
 
     StrOrPromise = str | StrPromise
+    FieldOpts = dict
+    FieldsetSpec = list
     # Deprecated type aliases. Use the QuerySet class directly instead.
     QuerySetAny = QuerySet
     ValuesQuerySet = QuerySet
 
-__all__ = ["QuerySetAny", "StrOrPromise", "StrPromise", "ValuesQuerySet"]
+__all__ = ["FieldOpts", "FieldsetSpec", "QuerySetAny", "StrOrPromise", "StrPromise", "ValuesQuerySet"]


### PR DESCRIPTION
Fixes #1960 

Some open quiestions:
- should we use a namespace ? ie `from django_stubs_ext.admin import FieldsetSpec`
- should I move `FieldsetSpec` in django_stub_ext and import it in the stubs ?