### PR TITLE
Fix mypy crash on QuerySet subclass with forward-referenced TypeVar

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -520,6 +520,11 @@ def add_as_manager_to_queryset_class(ctx: ClassDefContext) -> None:
     if queryset_info is None:
         return _defer()
 
+    # If any of the queryset's type vars have unresolved bounds (placeholders),
+    # defer to avoid generating methods with unresolved types that crash mypy.
+    if any(has_placeholder(tv) for tv in queryset_info.defn.type_vars):
+        return _defer()
+
     # either a manual `as_manager` definition or this is a deferral pass
     if "as_manager" in queryset_info.names:
         return

--- a/tests/assert_type/db/models/test_managers.py
+++ b/tests/assert_type/db/models/test_managers.py
@@ -1,0 +1,21 @@
+"""Regression test for https://github.com/typeddjango/django-stubs/issues/2911.
+
+A TypeVar with a forward-referenced bound used in a QuerySet subclass
+caused 'Must not defer during final iteration' crash in mypy.
+"""
+
+from typing import TypeVar
+
+from django.db import models
+from django.db.models.query import QuerySet
+
+T = TypeVar("T", bound="MyModel")
+
+
+class MyModelQuerySet(QuerySet[T]):
+    pass
+
+
+class MyModel(models.Model):
+    class Meta:
+        app_label = "myapp"


### PR DESCRIPTION
Prior to the plugin code change, a fresh mypy --strict tests/assert_type was crashing like so:

```
tests/assert_type/db/models/test_managers.py:15: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 1.19.1
Traceback (most recent call last):
  File "mypy/semanal.py", line 7568, in accept
  File "mypy/nodes.py", line 995, in accept
  File "mypy/semanal.py", line 978, in visit_func_def
  File "mypy/semanal.py", line 1023, in analyze_func_def
  File "mypy/semanal.py", line 7214, in defer
AssertionError: Must not defer during final iteration
tests/assert_type/db/models/test_managers.py:15: : note: use --pdb to drop into pdb
```
Fixes #2911


