### PR TITLE
Resolve .values_list() field types on annotated querysets

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -107,7 +107,7 @@ def get_values_list_row_type(
     django_context: DjangoContext,
     model_cls: type[Model],
     *,
-    is_annotated: bool,
+    annotation_types: dict[str, MypyType],
     flat: bool,
     named: bool,
 ) -> MypyType:
@@ -132,17 +132,10 @@ def get_values_list_row_type(
                     typechecker_api, model_info, field, method="values_list"
                 )
                 column_types[field.attname] = column_type
-            if is_annotated:
-                # Return a NamedTuple with a fallback so that it's possible to access any field
-                return helpers.make_oneoff_named_tuple(
-                    typechecker_api,
-                    "Row",
-                    column_types,
-                    extra_bases=[typechecker_api.named_generic_type(fullnames.ANY_ATTR_ALLOWED_CLASS_FULLNAME, [])],
-                )
+            column_types.update(annotation_types)
             return helpers.make_oneoff_named_tuple(typechecker_api, "Row", column_types)
         # flat=False, named=False, all fields
-        if is_annotated:
+        if annotation_types:
             return typechecker_api.named_generic_type("builtins.tuple", [AnyType(TypeOfAny.special_form)])
         field_lookups = []
         for field in django_context.get_model_fields(model_cls):
@@ -154,11 +147,20 @@ def get_values_list_row_type(
 
     column_types = {}
     for field_lookup in field_lookups:
+        if field_lookup in annotation_types:
+            column_types[field_lookup] = annotation_types[field_lookup]
+            continue
+
         lookup_field_type = get_field_type_from_lookup(
-            ctx, django_context, model_cls, lookup=field_lookup, method="values_list", silent_on_error=is_annotated
+            ctx,
+            django_context,
+            model_cls,
+            lookup=field_lookup,
+            method="values_list",
+            silent_on_error=bool(annotation_types),
         )
         if lookup_field_type is None:
-            if is_annotated:
+            if annotation_types:
                 lookup_field_type = AnyType(TypeOfAny.from_omitted_generics)
             else:
                 return AnyType(TypeOfAny.from_error)
@@ -194,8 +196,14 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
         ctx.api.fail("'flat' and 'named' can't be used together", ctx.context)
         return default_return_type.copy_modified(args=[django_model.typ, AnyType(TypeOfAny.from_error)])
 
+    annotation_types = _get_annotation_field_types(django_model.typ) if django_model.is_annotated else {}
     row_type = get_values_list_row_type(
-        ctx, django_context, django_model.cls, is_annotated=django_model.is_annotated, flat=flat, named=named
+        ctx,
+        django_context,
+        django_model.cls,
+        annotation_types=annotation_types,
+        flat=flat,
+        named=named,
     )
     ret = default_return_type.copy_modified(args=[django_model.typ, row_type])
     if not named and (field_lookups := resolve_field_lookups(ctx.args[0], django_context)):

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -147,8 +147,8 @@ def get_values_list_row_type(
 
     column_types = {}
     for field_lookup in field_lookups:
-        if field_lookup in annotation_types:
-            column_types[field_lookup] = annotation_types[field_lookup]
+        if annotation_type := annotation_types.get(field_lookup):
+            column_types[field_lookup] = annotation_type
             continue
 
         lookup_field_type = get_field_type_from_lookup(
@@ -412,8 +412,8 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
     # Collect `*fields` types -- `.values("id", "name")`
     for field_lookup in field_lookups:
         # Check annotation fields first for annotated querysets
-        if field_lookup in annotation_types:
-            column_types[field_lookup] = annotation_types[field_lookup]
+        if annotation_type := annotation_types.get(field_lookup):
+            column_types[field_lookup] = annotation_type
             continue
 
         field_lookup_type = get_field_type_from_lookup(

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -653,7 +653,7 @@
                 class User(models.Model):
                     username = models.CharField(max_length=100)
 
-- case: test_values_on_with_annotations_queryset
+- case: test_values_and_values_list_on_with_annotations_queryset
   main: |
     from typing_extensions import TypedDict, reveal_type
     from django.db.models import QuerySet
@@ -685,6 +685,32 @@
     # .values() with no params on annotated queryset includes model + annotation fields
     bare_values = qs.values().get()
     reveal_type(bare_values)  # N: Revealed type is "TypedDict({'id': int, 'name': str, 'extra_id': int | None})"
+
+    # .values_list() with annotation field should resolve its type
+    vl_annotation = qs.values_list("extra_id").get()
+    reveal_type(vl_annotation)  # N: Revealed type is "tuple[int | None]"
+
+    # .values_list() with model field should still work
+    vl_model = qs.values_list("name").get()
+    reveal_type(vl_model)  # N: Revealed type is "tuple[str]"
+
+    # .values_list() with both model and annotation fields
+    vl_mixed = qs.values_list("name", "extra_id").get()
+    reveal_type(vl_mixed)  # N: Revealed type is "tuple[str, int | None]"
+
+    # .values_list(flat=True) with annotation field
+    vl_flat = qs.values_list("extra_id", flat=True).get()
+    reveal_type(vl_flat)  # N: Revealed type is "int | None"
+
+    # .values_list(named=True) with annotation field
+    vl_named = qs.values_list("name", "extra_id", named=True).get()
+    reveal_type(vl_named.name)  # N: Revealed type is "str"
+    reveal_type(vl_named.extra_id)  # N: Revealed type is "int | None"
+
+    # .values_list(named=True) with no params merges model + annotation fields
+    vl_named_bare = qs.values_list(named=True).get()
+    reveal_type(vl_named_bare.name)  # N: Revealed type is "str"
+    reveal_type(vl_named_bare.extra_id)  # N: Revealed type is "int | None"
 
   installed_apps:
     - myapp


### PR DESCRIPTION
Extend annotation type resolution to values_list(), matching the values() support added in #3232.

For named=True with no params, annotation fields are now merged into the NamedTuple instead of relying on the AnyAttrAllowed fallback base.

*AI Disclosure: I've used AI to write these changes, but I've carefully guided and reviewed the output.*