### PR TITLE
Preserve NamedTuple row type when annotating values_list(named=True) querysets

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -59,7 +59,7 @@ from typing_extensions import Self
 from mypy_django_plugin.lib import fullnames
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, Mapping
 
     from django.db.models.base import Model
     from django.db.models.fields import Field
@@ -499,6 +499,17 @@ def make_oneoff_named_tuple(
         current_module, name, bases=[api.named_generic_type("typing.NamedTuple", []), *extra_bases], fields=fields
     )
     return TupleType(list(fields.values()), fallback=Instance(namedtuple_info, []))
+
+
+def extend_oneoff_named_tuple(
+    api: TypeChecker, name: str, original: TupleType, extra_fields: Mapping[str, MypyType]
+) -> TupleType:
+    existing_fields = {
+        field_name: sym.node.type or AnyType(TypeOfAny.special_form)
+        for field_name, sym in original.partial_fallback.type.names.items()
+        if sym.plugin_generated and isinstance(sym.node, Var)
+    }
+    return make_oneoff_named_tuple(api, name, {**existing_fields, **extra_fields})
 
 
 def make_tuple(api: TypeChecker, fields: list[MypyType]) -> TupleType:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -351,9 +351,14 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
             )
         elif isinstance(original_row_type, TupleType):
             if original_row_type.partial_fallback.type.has_base("typing.NamedTuple"):
-                # TODO: Use a NamedTuple which contains the known fields, but also
-                #  falls back to allowing any attribute access.
-                row_type = AnyType(TypeOfAny.implementation_artifact)
+                # Rebuild the NamedTuple with existing fields + annotation fields.
+                existing_fields = {
+                    name: sym.node.type or AnyType(TypeOfAny.special_form)
+                    for name, sym in original_row_type.partial_fallback.type.names.items()
+                    if sym.plugin_generated and isinstance(sym.node, Var)
+                }
+                annotation_fields = {name: AnyType(TypeOfAny.from_omitted_generics) for name in expression_types}
+                row_type = helpers.make_oneoff_named_tuple(api, "Row", {**existing_fields, **annotation_fields})
             else:
                 row_type = api.named_generic_type("builtins.tuple", [AnyType(TypeOfAny.from_omitted_generics)])
         elif isinstance(original_row_type, Instance) and helpers.is_model_type(original_row_type.type):

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -352,13 +352,8 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
         elif isinstance(original_row_type, TupleType):
             if original_row_type.partial_fallback.type.has_base("typing.NamedTuple"):
                 # Rebuild the NamedTuple with existing fields + annotation fields.
-                existing_fields = {
-                    name: sym.node.type or AnyType(TypeOfAny.special_form)
-                    for name, sym in original_row_type.partial_fallback.type.names.items()
-                    if sym.plugin_generated and isinstance(sym.node, Var)
-                }
                 annotation_fields = {name: AnyType(TypeOfAny.from_omitted_generics) for name in expression_types}
-                row_type = helpers.make_oneoff_named_tuple(api, "Row", {**existing_fields, **annotation_fields})
+                row_type = helpers.extend_oneoff_named_tuple(api, "Row", original_row_type, annotation_fields)
             else:
                 row_type = api.named_generic_type("builtins.tuple", [AnyType(TypeOfAny.from_omitted_generics)])
         elif isinstance(original_row_type, Instance) and helpers.is_model_type(original_row_type.type):

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -323,13 +323,12 @@
         qs2 = Blog.objects.values_list('text').annotate(foo=F('id'))
         reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], tuple[Any, ...]]"
         qs3 = Blog.objects.values_list('text', named=True).annotate(foo=F('id'))
-        # TODO: Would be nice to infer a NamedTuple which contains the field 'text' (str) + any number of other fields.
-        #  The reason it would have to appear to have any other fields is that annotate could potentially be called with
-        #  arbitrary parameters such that we wouldn't know how many extra fields there might be.
-        #  But it's not trivial to make such a NamedTuple, partly because since it is also an ordinary tuple, it would
-        #  have to have an arbitrary length, but still have certain fields at certain indices with specific types.
-        #  For now, Any :)
-        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], Any]"
+        reveal_type(qs3) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], tuple[str, Any, fallback=main.Row3]]"
+        qs3_chained = Blog.objects.values_list('text', named=True).annotate(foo=F('id')).annotate(bar=F('num_posts'))
+        qs3_chained_row = qs3_chained.get()
+        reveal_type(qs3_chained_row.text) # N: Revealed type is "str"
+        reveal_type(qs3_chained_row.foo) # N: Revealed type is "Any"
+        reveal_type(qs3_chained_row.bar) # N: Revealed type is "Any"
         qs4 = Blog.objects.values_list('text', flat=True).annotate(foo=F('id'))
         reveal_type(qs4) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], str]"
 
@@ -345,8 +344,7 @@
 
         before_values_list_named_no_params = Blog.objects.values_list(named=True).annotate(foo=F('id')).get()
         reveal_type(before_values_list_named_no_params.foo) # N: Revealed type is "Any"
-        # TODO: Would be nice to infer str:
-        reveal_type(before_values_list_named_no_params.text) # N: Revealed type is "Any"
+        reveal_type(before_values_list_named_no_params.text) # N: Revealed type is "str"
 
     installed_apps:
         - myapp


### PR DESCRIPTION
Previously, chaining `.annotate()` after `.values_list(named=True)` collapsed the row type to Any, losing type information about the original fields. Now we rebuild the NamedTuple with the existing fields plus annotation fields, so attribute access on the result is properly typed.