### PR TITLE
Use `TypedDictType` directly when merging typeddict

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -544,17 +544,16 @@ def convert_any_to_type(typ: MypyType, referred_to_type: MypyType) -> MypyType:
 def make_typeddict(
     api: SemanticAnalyzer | CheckerPluginInterface,
     fields: dict[str, MypyType],
-    required_keys: set[str],
-    readonly_keys: set[str],
 ) -> TypedDictType:
+    """Create a TypedDict from a python dict of field names and types."""
     if isinstance(api, CheckerPluginInterface):
         fallback_type = api.named_generic_type("typing._TypedDict", [])
     else:
         fallback_type = api.named_type("typing._TypedDict", [])
     return TypedDictType(
-        fields,
-        required_keys=required_keys,
-        readonly_keys=readonly_keys,
+        items=fields,
+        required_keys=set(fields.keys()),
+        readonly_keys=set(),
         fallback=fallback_type,
     )
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1170,11 +1170,11 @@ def get_annotated_type(
         if model_type.args:
             annotations = get_proper_type(model_type.args[0])
             if isinstance(annotations, TypedDictType):
-                fields_dict = helpers.make_typeddict(
-                    api,
-                    fields={**annotations.items, **fields_dict.items},
+                fields_dict = TypedDictType(
+                    items={**annotations.items, **fields_dict.items},
                     required_keys={*annotations.required_keys, *fields_dict.required_keys},
                     readonly_keys={*annotations.readonly_keys, *fields_dict.readonly_keys},
+                    fallback=annotations.fallback,
                 )
     else:
         annotated_model = helpers.lookup_fully_qualified_typeinfo(api, model_type.type.fullname + "@AnnotatedWith")

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -333,12 +333,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
 
     annotated_type: ProperType = django_model.typ
     if all_fields:
-        fields_dict = helpers.make_typeddict(
-            api,
-            fields=all_fields,
-            required_keys=set(all_fields.keys()),
-            readonly_keys=set(),
-        )
+        fields_dict = helpers.make_typeddict(api, all_fields)
         annotated_type = get_annotated_type(api, django_model.typ, fields_dict=fields_dict)
 
     row_type: MypyType
@@ -434,7 +429,7 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
 
     # Collect `**expressions` types -- `.values(lower_name=Lower("name"), foo=F("name"))`
     column_types.update(gather_expression_types(ctx))
-    row_type = helpers.make_typeddict(ctx.api, column_types, set(column_types.keys()), set())
+    row_type = helpers.make_typeddict(ctx.api, column_types)
     return default_return_type.copy_modified(args=[django_model.typ, row_type])
 
 
@@ -818,12 +813,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     if not new_attrs:
         return ctx.default_return_type
 
-    fields_dict = helpers.make_typeddict(
-        api,
-        fields=new_attrs,
-        required_keys=set(new_attrs.keys()),
-        readonly_keys=set(),
-    )
+    fields_dict = helpers.make_typeddict(api, new_attrs)
 
     annotated_model = get_annotated_type(api, qs_model.typ, fields_dict=fields_dict)
 


### PR DESCRIPTION


# I have made things!
Also make `helpers.make_typeddict` a shortcut to create a typedict from python dict

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
