### PR TITLE
Prefetch related queryset incompatible type

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -140,10 +140,6 @@ def _process_dynamic_method(
     # used by the typing stubs.
     if method_name in MANAGER_METHODS_RETURNING_QUERYSET:
         ret_type = queryset_instance
-        # Keep method-level type variables (e.g. _LookupT in prefetch_related)
-        # but remove Self since we've replaced the return type.
-        if base_that_has_method.self_type:
-            variables = tuple(v for v in variables if v.id != base_that_has_method.self_type.id)
     args_types = method_type.arg_types[1:]
     if _has_compatible_type_vars(base_that_has_method):
         typed_var = manager_instance.args or queryset_info.bases[0].args
@@ -161,6 +157,10 @@ def _process_dynamic_method(
     if base_that_has_method.self_type:
         # Manages -> Self returns
         ret_type = _replace_type_var(ret_type, base_that_has_method.self_type.fullname, queryset_instance)
+        # The `self` argument is also stripped (lines below), so its `Self` type variable
+        # has no binding site and should be removed. Other method-level type variables
+        # (e.g. _LookupT in prefetch_related) are preserved for call-site inference.
+        variables = tuple(v for v in variables if v.id != base_that_has_method.self_type.id)
 
     # Drop any 'self' argument as our manager is already initialized
     return method_type.copy_modified(

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -140,7 +140,10 @@ def _process_dynamic_method(
     # used by the typing stubs.
     if method_name in MANAGER_METHODS_RETURNING_QUERYSET:
         ret_type = queryset_instance
-        variables = ()
+        # Keep method-level type variables (e.g. _LookupT in prefetch_related)
+        # but remove Self since we've replaced the return type.
+        if base_that_has_method.self_type:
+            variables = tuple(v for v in variables if v.id != base_that_has_method.self_type.id)
     args_types = method_type.arg_types[1:]
     if _has_compatible_type_vars(base_that_has_method):
         typed_var = manager_instance.args or queryset_info.bases[0].args

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -674,7 +674,7 @@
         reveal_type(MyModel.objects.none)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
         reveal_type(MyModel.objects.only)  # N: Revealed type is "def (*fields: str) -> myapp.models.MyQuerySet"
         reveal_type(MyModel.objects.order_by)  # N: Revealed type is "def (*field_names: str | django.db.models.expressions.Combinable) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.prefetch_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def (*lookups: str | django.db.models.query.Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> myapp.models.MyQuerySet)"
+        reveal_type(MyModel.objects.prefetch_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def [_LookupT <: str, _PrefetchedQuerySetT <: django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model] = django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model], _ToAttrT <: str = str] (*lookups: str | django.db.models.query.Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> myapp.models.MyQuerySet)"
         reveal_type(MyModel.objects.reverse)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
         reveal_type(MyModel.objects.select_for_update)  # N: Revealed type is "def (nowait: bool =, skip_locked: bool =, of: typing.Sequence[str] =, no_key: bool =) -> myapp.models.MyQuerySet"
         reveal_type(MyModel.objects.select_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def (*fields: str) -> myapp.models.MyQuerySet)"

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -517,3 +517,40 @@
 
                 class TaggedItem(models.Model):
                     tag = models.CharField(max_length=100)
+
+-   case: prefetch_related_from_queryset_incompatible_type
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Object, RelatedObject
+        from django.db.models import Prefetch
+
+        Object.objects.prefetch_related(Prefetch("related_objects")).all()
+
+        Object.objects.prefetch_related(Prefetch("related_objects", queryset=RelatedObject.objects.select_related("other_object"))).all()
+
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                import typing
+                from django.db import models
+
+                T = typing.TypeVar("T", bound="models.Model")
+                class BaseManager(models.Manager[T]): ...
+
+                class BaseObject(models.Model):
+                    objects = BaseManager["BaseObject"]()
+
+                class ObjectQuerySet(models.QuerySet["Object"]): ...
+
+                class ObjectManager(BaseManager["Object"]): ...
+
+                class Object(BaseObject):
+                    objects: typing.ClassVar = ObjectManager.from_queryset(ObjectQuerySet)()
+
+                class OtherObject(models.Model): ...
+
+                class RelatedObject(models.Model):
+                    object = models.ForeignKey(Object, on_delete=models.CASCADE, related_name="related_objects")
+                    other_object = models.ForeignKey(OtherObject, on_delete=models.CASCADE)


### PR DESCRIPTION
## Observed issue
When calling `prefetch_related` on a manager created via `from_queryset()`, passing a `Prefetch(...)` argument produced a spurious "[arg-type]" error.

### Example
```python
from django.db import models

class ObjectQuerySet(models.QuerySet["Object"]): ...
class ObjectManager(models.Manager["Object"]): ...

class Object(models.Model):
    objects = ObjectManager.from_queryset(ObjectQuerySet)()

class RelatedObject(models.Model):
    object = models.ForeignKey(Object, on_delete=models.CASCADE, related_name="related_objects")

from django.db.models import Prefetch

# Both of these incorrectly produce arg-type errors:
Object.objects.prefetch_related(Prefetch("related_objects"))
Object.objects.prefetch_related(
    Prefetch("related_objects", queryset=RelatedObject.objects.all())
)
```
Generates errors like these:
```
error: Argument 1 to "prefetch_related" of "QuerySet" has incompatible type "Prefetch[Literal['related_objects'], _PrefetchedQuerySetT, _ToAttrT]"; expected "str | Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]"  [arg-type]

error: Argument 1 to "Prefetch" has incompatible type "str"; expected "_LookupT"  [arg-type]
```

## Root cause

It appears that the loss of all type variables, when the return type for the `prefetch_related` is dynamically updated to the concrete `QuerySet` type, prevents the correct argument matching.

More generally, in `_process_dynamic_method`, when resolving methods on managers created via `from_queryset()`, all method-level type variables were unconditionally cleared by setting `variables = ()` for `MANAGER_METHODS_RETURNING_QUERYSET` methods. I believe this was originally correct when the stubs used `Any` for all other argument types except `self`. Once more precise typing/overloads for the remaining arguments were added to the stubs, simply clearing all variables was no longer correct. For example, `_LookupT`, `_PrefetchedQuerySetT`, and `_ToAttrT` from `prefetch_related` is stripped, meaning mypy is unable to infer types for `Prefetch(...)` arguments.

## Fix

Replace the blanket `variables = ()` with a targeted filter that removes only the `Self` type variable, thus preserving other method-level type variables. Additionally relocate this logic to a more general location not specific to "queryset returning methods" but to where references to the `Self` type variable is replaced.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
