### PR TITLE
Fix `databases` type in `SimpleTestCase` to use `Literal["__all__"]`

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -3,7 +3,7 @@ import unittest
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import WSGIHandler
@@ -62,8 +62,7 @@ class SimpleTestCase(unittest.TestCase):
     client: Client
     async_client_class: type[AsyncClient]
     async_client: AsyncClient
-    # TODO: str -> Literal['__all__']
-    databases: set[str] | str
+    databases: set[str] | Literal["__all__"]
     @classmethod
     def ensure_connection_patch_method(cls) -> None: ...
     @override


### PR DESCRIPTION
## Summary

The `databases` attribute in `SimpleTestCase` was typed as `set[str] | str`,
but Django only accepts the string `"__all__"` — not any arbitrary string.

This PR narrows the type to `set[str] | Literal["__all__"]` for better
type safety and accuracy.

Fixes the TODO comment that was left in the code:
`# TODO: str -> Literal['__all__']`

## Changes

- `django-stubs/test/testcases.pyi`: added `Literal` to imports, updated
  `databases` annotation, removed TODO comment
