### PR TITLE
Propagate `WithAnnotations` through custom `QuerySet` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,41 @@ func(MyModel.objects.annotate(foo=Value("")).get(id=1))  # OK
 func(MyModel.objects.annotate(bar=Value("")).get(id=1))  # Error
 ```
 
+You can also use `WithAnnotations` in custom `QuerySet` methods by making the queryset generic over a
+model `TypeVar`. This way the return type stays accurate through chained calls and manager access:
+
+```python
+from typing import TypeVar, TypedDict
+from django.db import models
+from django.db.models import Manager
+from django_stubs_ext import WithAnnotations
+
+
+class SalesDict(TypedDict):
+    total_sales: int
+
+
+_Model = TypeVar("_Model", bound=models.Model, covariant=True)
+
+
+class ProductQuerySet(models.QuerySet[_Model]):
+    def with_sales(self) -> "ProductQuerySet[WithAnnotations[_Model, SalesDict]]":
+        return self.annotate(total_sales=models.Sum("order__amount"))
+
+
+ProductManager = Manager.from_queryset(ProductQuerySet)
+
+
+class Product(models.Model):
+    name = models.CharField(max_length=100)
+    objects = ProductManager()
+
+
+product = Product.objects.with_sales().get(id=1)
+product.total_sales  # OK, int
+product.name  # OK, str
+```
+
 ### Why am I getting incompatible argument type mentioning `_StrPromise`?
 
 The lazy translation functions of Django (such as `gettext_lazy`) return a `Promise` instead of `str`. These two types [cannot be used interchangeably](https://github.com/typeddjango/django-stubs/pull/1139#issuecomment-1232167698). The return type of these functions was therefore [changed](https://github.com/typeddjango/django-stubs/pull/689) to reflect that.

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -54,6 +54,7 @@ from mypy.types import (
     get_proper_type,
 )
 from mypy.types import Type as MypyType
+from mypy.typevars import fill_typevars, fill_typevars_with_any
 from typing_extensions import Self
 
 from mypy_django_plugin.lib import fullnames
@@ -120,6 +121,25 @@ def mark_as_annotated_model(model: TypeInfo) -> None:
 
 def is_annotated_model(model: TypeInfo) -> bool:
     return get_django_metadata(model).get("is_annotated_model", False)
+
+
+def get_or_create_annotated_type(api: SemanticAnalyzer, model_info: TypeInfo, annotations_info: TypeInfo) -> TypeInfo:
+    """Look up or create the `Model@AnnotatedWith` synthetic class for *model_info*."""
+    annotated_model_name = model_info.name + "@AnnotatedWith"
+    annotated_model = lookup_fully_qualified_typeinfo(api, model_info.fullname + "@AnnotatedWith")
+    if annotated_model is None:
+        model_type = fill_typevars_with_any(model_info)
+        assert isinstance(model_type, Instance)
+        annotations_type = fill_typevars(annotations_info)
+        assert isinstance(annotations_type, Instance)
+        model_module = api.modules[model_info.module_name]
+        annotated_model = add_new_class_for_module(
+            model_module, name=annotated_model_name, bases=[model_type, annotations_type]
+        )
+        annotated_model.defn.type_vars = annotations_info.defn.type_vars
+        annotated_model.add_type_vars()
+        mark_as_annotated_model(annotated_model)
+    return annotated_model
 
 
 class IncompleteDefnException(Exception):

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -541,20 +541,36 @@ def convert_any_to_type(typ: MypyType, referred_to_type: MypyType) -> MypyType:
     return typ
 
 
+def _get_fallback_typeddict(api: SemanticAnalyzer | CheckerPluginInterface) -> Instance:
+    if isinstance(api, CheckerPluginInterface):
+        return api.named_generic_type("typing._TypedDict", [])
+    return api.named_type("typing._TypedDict", [])
+
+
 def make_typeddict(
     api: SemanticAnalyzer | CheckerPluginInterface,
     fields: dict[str, MypyType],
 ) -> TypedDictType:
     """Create a TypedDict from a python dict of field names and types."""
-    if isinstance(api, CheckerPluginInterface):
-        fallback_type = api.named_generic_type("typing._TypedDict", [])
-    else:
-        fallback_type = api.named_type("typing._TypedDict", [])
     return TypedDictType(
         items=fields,
         required_keys=set(fields.keys()),
         readonly_keys=set(),
-        fallback=fallback_type,
+        fallback=_get_fallback_typeddict(api),
+    )
+
+
+def merge_typeddict(
+    api: SemanticAnalyzer | CheckerPluginInterface,
+    left: TypedDictType,
+    right: TypedDictType,
+) -> TypedDictType:
+    """Merge two TypedDictType type into one with anonymous fallback."""
+    return TypedDictType(
+        items={**left.items, **right.items},
+        required_keys={*left.required_keys, *right.required_keys},
+        readonly_keys={*left.readonly_keys, *right.readonly_keys},
+        fallback=_get_fallback_typeddict(api),
     )
 
 

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -229,7 +229,7 @@ class DjangoModel(NamedTuple):
         return cls(cls=model_cls, typ=model_type, is_annotated=is_annotated)
 
 
-def extract_model_type_from_queryset(queryset_type: Instance, api: TypeChecker) -> Instance | None:
+def extract_model_type_from_queryset(queryset_type: Instance) -> Instance | None:
     """Extract the django model `Instance` associated to a queryset `Instance`"""
     for base_type in [queryset_type, *queryset_type.type.bases]:
         if (
@@ -257,8 +257,7 @@ def get_model_info_from_qs_ctx(
     """
     Extract DjangoModel details from a queryset/manager `MethodContext`
     """
-    api = get_typechecker_api(ctx)
-    if not (isinstance(ctx.type, Instance) and (model_type := extract_model_type_from_queryset(ctx.type, api))):
+    if not (isinstance(ctx.type, Instance) and (model_type := extract_model_type_from_queryset(ctx.type))):
         return None
 
     return DjangoModel.from_model_type(model_type, django_context)

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -208,12 +208,7 @@ class NewSemanalDjangoPlugin(Plugin):
         if method_name == "__init_subclass__" or fullname.startswith("builtins."):
             return None
 
-        if class_fullname.endswith("QueryDict"):
-            info = self._get_typeinfo_or_none(class_fullname)
-            if info and info.has_base(fullnames.QUERYDICT_CLASS_FULLNAME):
-                return check_querydict_is_mutable
-
-        elif method_name == "__get__":
+        if method_name == "__get__":
             hooks = {
                 fullnames.MANYTOMANY_FIELD_FULLNAME: manytomany.refine_many_to_many_related_manager,
                 fullnames.MANY_TO_MANY_DESCRIPTOR: manytomany.refine_many_to_many_related_manager,
@@ -221,16 +216,20 @@ class NewSemanalDjangoPlugin(Plugin):
             }
             return hooks.get(class_fullname)
 
-        if method_name in self.manager_and_queryset_method_hooks:
-            info = self._get_typeinfo_or_none(class_fullname)
-            if info and helpers.has_any_of_bases(
-                info, [fullnames.QUERYSET_CLASS_FULLNAME, fullnames.MANAGER_CLASS_FULLNAME]
-            ):
-                return self.manager_and_queryset_method_hooks[method_name]
-        elif method_name == "get_field":
-            info = self._get_typeinfo_or_none(class_fullname)
-            if info and info.has_base(fullnames.OPTIONS_CLASS_FULLNAME):
-                return partial(meta.return_proper_field_type_from_get_field, django_context=self.django_context)
+        info = self._get_typeinfo_or_none(class_fullname)
+        if not info:
+            return None
+
+        if class_fullname.endswith("QueryDict") and info.has_base(fullnames.QUERYDICT_CLASS_FULLNAME):
+            return check_querydict_is_mutable
+
+        if method_name in self.manager_and_queryset_method_hooks and helpers.has_any_of_bases(
+            info, [fullnames.QUERYSET_CLASS_FULLNAME, fullnames.MANAGER_CLASS_FULLNAME]
+        ):
+            return self.manager_and_queryset_method_hooks[method_name]
+
+        if method_name == "get_field" and info.has_base(fullnames.OPTIONS_CLASS_FULLNAME):
+            return partial(meta.return_proper_field_type_from_get_field, django_context=self.django_context)
 
         return None
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -231,6 +231,9 @@ class NewSemanalDjangoPlugin(Plugin):
         if method_name == "get_field" and info.has_base(fullnames.OPTIONS_CLASS_FULLNAME):
             return partial(meta.return_proper_field_type_from_get_field, django_context=self.django_context)
 
+        if helpers.has_any_of_bases(info, [fullnames.QUERYSET_CLASS_FULLNAME, fullnames.MANAGER_CLASS_FULLNAME]):
+            return partial(querysets.merge_annotations_from_custom_method, django_context=self.django_context)
+
         return None
 
     @override

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -278,34 +278,31 @@ class NewSemanalDjangoPlugin(Plugin):
             )
 
         info = self._get_typeinfo_or_none(class_name)
+        if not info:
+            return None
 
         # Lookup of the '.is_superuser' attribute
-        if info and info.has_base(fullnames.PERMISSION_MIXIN_CLASS_FULLNAME) and attr_name == "is_superuser":
+        if info.has_base(fullnames.PERMISSION_MIXIN_CLASS_FULLNAME) and attr_name == "is_superuser":
             return partial(set_auth_user_model_boolean_fields, django_context=self.django_context)
 
         # Lookup of the 'user.is_staff' or 'user.is_active' attribute
-        if info and info.has_base(fullnames.ABSTRACT_USER_MODEL_FULLNAME) and attr_name in ("is_staff", "is_active"):
+        if info.has_base(fullnames.ABSTRACT_USER_MODEL_FULLNAME) and attr_name in ("is_staff", "is_active"):
             return partial(set_auth_user_model_boolean_fields, django_context=self.django_context)
 
         # Lookup of a method on a dynamically generated manager class
         # i.e. a manager class only existing while mypy is running, not collected from the AST
-        if (
-            info
-            and info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME)
-            and "from_queryset_manager" in helpers.get_django_metadata(info)
-        ):
+        if info.has_base(
+            fullnames.BASE_MANAGER_CLASS_FULLNAME
+        ) and "from_queryset_manager" in helpers.get_django_metadata(info):
             return resolve_manager_method
 
-        if info and info.has_base(fullnames.STR_PROMISE_FULLNAME):
+        if info.has_base(fullnames.STR_PROMISE_FULLNAME):
             return resolve_str_promise_attribute
 
-        if info and (
-            (
-                info.has_base(fullnames.CHOICES_TYPE_METACLASS_FULLNAME)
-                and attr_name in {"choices", "labels", "values", "__empty__"}
-            )
-            or (info.has_base(fullnames.CHOICES_CLASS_FULLNAME) and attr_name in {"label", "value"})
-        ):
+        if (
+            info.has_base(fullnames.CHOICES_TYPE_METACLASS_FULLNAME)
+            and attr_name in {"choices", "labels", "values", "__empty__"}
+        ) or (info.has_base(fullnames.CHOICES_CLASS_FULLNAME) and attr_name in {"label", "value"}):
             return choices.transform_into_proper_attr_type
 
         return None

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1170,12 +1170,7 @@ def get_annotated_type(
         if model_type.args:
             annotations = get_proper_type(model_type.args[0])
             if isinstance(annotations, TypedDictType):
-                fields_dict = TypedDictType(
-                    items={**annotations.items, **fields_dict.items},
-                    required_keys={*annotations.required_keys, *fields_dict.required_keys},
-                    readonly_keys={*annotations.readonly_keys, *fields_dict.readonly_keys},
-                    fallback=annotations.fallback,
-                )
+                fields_dict = helpers.merge_typeddict(api, annotations, fields_dict)
     else:
         annotated_model = helpers.lookup_fully_qualified_typeinfo(api, model_type.type.fullname + "@AnnotatedWith")
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -26,7 +26,7 @@ from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
 from mypy.types import AnyType, Instance, ProperType, TypedDictType, TypeOfAny, TypeType, TypeVarType, get_proper_type
 from mypy.types import Type as MypyType
-from mypy.typevars import fill_typevars, fill_typevars_with_any
+from mypy.typevars import fill_typevars
 from typing_extensions import override
 
 from mypy_django_plugin.errorcodes import MANAGER_MISSING
@@ -222,38 +222,26 @@ class AddAnnotateUtilities(ModelClassInitializer):
     @override
     def run(self) -> None:
         annotations = self.lookup_typeinfo_or_incomplete_defn_error("django_stubs_ext.Annotations")
-        exception_bases = {
-            model_exc_name: self.lookup_typeinfo_or_incomplete_defn_error(base_exc_name)
-            for model_exc_name, base_exc_name in [
-                ("DoesNotExist", fullnames.OBJECT_DOES_NOT_EXIST),
-                ("NotUpdated", fullnames.OBJECT_NOT_UPDATED),
-                ("MultipleObjectsReturned", fullnames.MULTIPLE_OBJECTS_RETURNED),
-            ]
-        }
-        annotated_model_name = self.model_classdef.info.name + "@AnnotatedWith"
-        annotated_model = self.lookup_typeinfo(self.model_classdef.info.module_name + "." + annotated_model_name)
-        if annotated_model is None:
-            model_type = fill_typevars_with_any(self.model_classdef.info)
-            assert isinstance(model_type, Instance)
-            annotations_type = fill_typevars(annotations)
-            assert isinstance(annotations_type, Instance)
-            annotated_model = self.add_new_class_for_current_module(
-                annotated_model_name, bases=[model_type, annotations_type]
-            )
-            annotated_model.defn.type_vars = annotations.defn.type_vars
-            annotated_model.add_type_vars()
-            helpers.mark_as_annotated_model(annotated_model)
-            if self.is_model_abstract:
-                # Below are abstract attributes, and in a stub file mypy requires
-                # explicit ABCMeta if not all abstract attributes are implemented i.e.
-                # class is kept abstract. So we add the attributes to get mypy off our
-                # back
-                for model_exc_name, base_exc_type in exception_bases.items():
-                    helpers.add_new_sym_for_info(
-                        annotated_model,
-                        model_exc_name,
-                        TypeType(Instance(base_exc_type, [])),
-                    )
+        annotated_model = helpers.get_or_create_annotated_type(self.api, self.model_classdef.info, annotations)
+        if self.is_model_abstract:
+            # Below are abstract attributes, and in a stub file mypy requires
+            # explicit ABCMeta if not all abstract attributes are implemented i.e.
+            # class is kept abstract. So we add the attributes to get mypy off our
+            # back
+            exception_bases = {
+                model_exc_name: self.lookup_typeinfo_or_incomplete_defn_error(base_exc_name)
+                for model_exc_name, base_exc_name in [
+                    ("DoesNotExist", fullnames.OBJECT_DOES_NOT_EXIST),
+                    ("NotUpdated", fullnames.OBJECT_NOT_UPDATED),
+                    ("MultipleObjectsReturned", fullnames.MULTIPLE_OBJECTS_RETURNED),
+                ]
+            }
+            for model_exc_name, base_exc_type in exception_bases.items():
+                helpers.add_new_sym_for_info(
+                    annotated_model,
+                    model_exc_name,
+                    TypeType(Instance(base_exc_type, [])),
+                )
 
 
 class InjectAnyAsBaseForNestedMeta(ModelClassInitializer):
@@ -1132,7 +1120,17 @@ def handle_annotated_type(ctx: AnalyzeTypeContext, fullname: str) -> MypyType:
         return AnyType(TypeOfAny.from_omitted_generics) if is_with_annotations else ctx.type
     type_arg = get_proper_type(ctx.api.analyze_type(args[0]))
     if not isinstance(type_arg, Instance) or not helpers.is_model_type(type_arg.type):
-        return type_arg
+        if isinstance(type_arg, TypeVarType):
+            # When the first arg is a TypeVar bounded by a Model (e.g. WithAnnotations[_Model, BarDict]),
+            # use the upper bound to look up @AnnotatedWith. The method hook
+            # (merge_annotations_from_custom_method) will later replace it with the actual concrete model.
+            upper = get_proper_type(type_arg.upper_bound)
+            if isinstance(upper, Instance) and helpers.is_model_type(upper.type):
+                type_arg = upper
+            else:
+                return type_arg
+        else:
+            return type_arg
 
     fields_dict = None
     if len(args) > 1:
@@ -1173,6 +1171,13 @@ def get_annotated_type(
                 fields_dict = helpers.merge_typeddict(api, annotations, fields_dict)
     else:
         annotated_model = helpers.lookup_fully_qualified_typeinfo(api, model_type.type.fullname + "@AnnotatedWith")
+        if annotated_model is None and isinstance(api, SemanticAnalyzer):
+            # Create @AnnotatedWith lazily when it doesn't exist yet. This happens when
+            # WithAnnotations is used with a TypeVar whose upper bound is a model that
+            # hasn't been processed by AddAnnotateUtilities (e.g. the base Model class).
+            annotations_info = helpers.lookup_fully_qualified_typeinfo(api, ANNOTATIONS_FULLNAME)
+            if annotations_info is not None:
+                annotated_model = helpers.get_or_create_annotated_type(api, model_type.type, annotations_info)
 
     if annotated_model is None:
         return model_type

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -387,6 +387,32 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
     return reparametrize_queryset(default_return_type, [annotated_type, row_type])
 
 
+def merge_annotations_from_custom_method(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
+    """
+    Method hook for custom QuerySet/Manager methods that return annotated querysets.
+
+    Ensures extra_attrs are set on annotated model Instances (so attribute access works)
+    and merges annotations from the caller queryset with annotations from the return type.
+    """
+    django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
+    if django_model is None:
+        return ctx.default_return_type
+
+    default_return_type = get_proper_type(ctx.default_return_type)
+    if not (
+        isinstance(default_return_type, Instance)
+        and (ret_model := helpers.extract_model_type_from_queryset(default_return_type))
+        and helpers.is_annotated_model(ret_model.type)
+        and ret_model.args
+        and isinstance(new_td := get_proper_type(ret_model.args[0]), TypedDictType)
+    ):
+        return ctx.default_return_type
+
+    api = helpers.get_typechecker_api(ctx)
+    annotated_type = get_annotated_type(api, django_model.typ, fields_dict=new_td)
+    return reparametrize_queryset(default_return_type, [annotated_type, annotated_type])
+
+
 def resolve_field_lookups(lookup_exprs: Sequence[Expression], django_context: DjangoContext) -> list[str] | None:
     field_lookups = []
     for field_lookup_expr in lookup_exprs:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -36,6 +36,7 @@ from mypy.types import (
     TupleType,
     TypedDictType,
     TypeOfAny,
+    TypeVarType,
     get_proper_type,
 )
 from mypy.types import Type as MypyType
@@ -335,9 +336,38 @@ def reparametrize_queryset(instance: Instance, args: list[MypyType]) -> Instance
     return instance
 
 
+def _extract_model_type_var_upper_bound(ctx: MethodContext) -> Instance | None:
+    """When the queryset's model type arg is a TypeVar bounded by a Model, return the upper bound."""
+    if not isinstance(ctx.type, Instance):
+        return None
+    for base_type in [ctx.type, *ctx.type.type.bases]:
+        if not len(base_type.args) or base_type.type.has_base(fullnames.MANY_RELATED_MANAGER):
+            continue
+        model = get_proper_type(base_type.args[0])
+        if isinstance(model, TypeVarType):
+            upper = get_proper_type(model.upper_bound)
+            if isinstance(upper, Instance) and helpers.is_model_type(upper.type):
+                return upper
+    return None
+
+
 def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
     if django_model is None:
+        # When the queryset's model is a TypeVar (e.g. inside a generic queryset method body),
+        # use the TypeVar's upper bound to build a temporary annotated type. This allows
+        # `self.annotate(...)` to return `QS[Model@AnnotatedWith[...]]` which is compatible
+        # with return types declared as `QS[WithAnnotations[_Model, ...]]`.
+        upper_bound = _extract_model_type_var_upper_bound(ctx)
+        if upper_bound is not None:
+            default_return_type = get_proper_type(ctx.default_return_type)
+            if isinstance(default_return_type, Instance):
+                api = helpers.get_typechecker_api(ctx)
+                expression_types = gather_expression_types(ctx)
+                if expression_types:
+                    fields_dict = helpers.make_typeddict(api, expression_types)
+                    upper_annotated = get_annotated_type(api, upper_bound, fields_dict=fields_dict)
+                    return reparametrize_queryset(default_return_type, [upper_annotated, upper_annotated])
         return AnyType(TypeOfAny.from_omitted_generics)
 
     default_return_type = get_proper_type(ctx.default_return_type)

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -500,7 +500,7 @@ def _resolve_prefetch_queryset_argument(
     # First try to get queryset type from specialized type arg
     queryset_type = get_proper_type(type_arg)
     if isinstance(queryset_type, Instance):
-        elem_model = helpers.extract_model_type_from_queryset(queryset_type, api)
+        elem_model = helpers.extract_model_type_from_queryset(queryset_type)
         # If we got a valid specific model type, return the queryset type
         if elem_model is not None and elem_model.type.fullname != fullnames.MODEL_CLASS_FULLNAME:
             return queryset_type
@@ -805,7 +805,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
         # 3.b) Extract model type from queryset type (or from the lookup value)
         elem_model: Instance | None = None
         if queryset_type is not None and isinstance(queryset_type, Instance):
-            elem_model = helpers.extract_model_type_from_queryset(queryset_type, api)
+            elem_model = helpers.extract_model_type_from_queryset(queryset_type)
         elif lookup:
             try:
                 observed_model_cls = django_context.resolve_lookup_into_field(qs_model.cls, lookup)[1]

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -886,10 +886,10 @@
 
         class FooQuerySet(models.QuerySet[_Model]):
             def with_bar(self) -> "FooQuerySet[WithAnnotations[_Model, BarDict]]":
-                return self.annotate(bar=models.Value("bar"))  # type: ignore[no-any-return]
+                return self.annotate(bar=models.Value("bar"))
 
-            def with_baz(self) -> "FooQuerySet[WithAnnotations[FooModel, BazDict]]":
-                return self.annotate(baz=models.Value("baz"))  # type: ignore[no-any-return]
+            def with_baz(self) -> "FooQuerySet[WithAnnotations[_Model, BazDict]]":
+                return self.annotate(baz=models.Value("baz"))
 
         FooManager = Manager.from_queryset(FooQuerySet)
 

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -745,3 +745,153 @@
 
         class SomeQuerySet(models.QuerySet["Accommodation"]):
             pass
+
+- case: custom_queryset_method_with_annotations
+  main: |
+    from typing_extensions import reveal_type
+    from myapp.models import FooModel
+    from django.db.models.expressions import F
+
+    # Simple method
+    qs = FooModel.objects.with_bar()
+    reveal_type(qs)  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel@AnnotatedWith[TypedDict(myapp.models.BarDict, {'bar': str})], myapp.models.FooModel@AnnotatedWith[TypedDict(myapp.models.BarDict, {'bar': str})]]"
+    obj = qs.get()
+    reveal_type(obj.bar)  # N: Revealed type is "str"
+    reveal_type(obj.name)  # N: Revealed type is "str"
+    obj.nonexistent  # E: "FooModel@AnnotatedWith[BarDict]" has no attribute "nonexistent"  [attr-defined]
+
+    # Chained methods
+    qs2 = FooModel.objects.with_bar().with_baz()
+    reveal_type(qs2)  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel@AnnotatedWith[TypedDict({'bar': str, 'baz': int})], myapp.models.FooModel@AnnotatedWith[TypedDict({'bar': str, 'baz': int})]]"
+    obj2 = qs2[0]
+    reveal_type(obj2.bar)  # N: Revealed type is "str"
+    reveal_type(obj2.baz)  # N: Revealed type is "int"
+    reveal_type(obj2.name)  # N: Revealed type is "str"
+
+    # Chained with regular methods
+    filtered = FooModel.objects.with_bar().filter(name="x")
+    maybe = filtered.first()
+    reveal_type(maybe)  # N: Revealed type is "myapp.models.FooModel@AnnotatedWith[TypedDict(myapp.models.BarDict, {'bar': str})] | None"
+    if maybe:
+        reveal_type(maybe.bar)  # N: Revealed type is "str"
+        reveal_type(maybe.name)  # N: Revealed type is "str"
+
+    # Built-in .annotate() then custom method
+    mixed = FooModel.objects.annotate(extra=F("id")).with_bar()
+    mixed_obj = mixed.get()
+    reveal_type(mixed_obj.extra)  # N: Revealed type is "Any"
+    reveal_type(mixed_obj.bar)  # N: Revealed type is "str"
+
+    # Instance extraction propagate annotations correctly
+    qs3 = FooModel.objects.with_bar()
+    reveal_type(qs3.get().bar)  # N: Revealed type is "str"
+    reveal_type(qs3[0].bar)  # N: Revealed type is "str"
+    first = qs3.first()
+    if first:
+        reveal_type(first.bar)  # N: Revealed type is "str"
+    for item in qs3:
+        reveal_type(item.bar)  # N: Revealed type is "str"
+        break
+
+    # later annotation overrides
+    collision = FooModel.objects.with_bar().with_bar_int()
+    reveal_type(collision.get().bar)  # N: Revealed type is "int"
+
+    # Custom method without WithAnnotations: noop
+    plain = FooModel.objects.active()
+    reveal_type(plain)  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel, myapp.models.FooModel]"
+
+    # Custom then .annotate() then custom: all three layers merge
+    triple = FooModel.objects.with_bar().annotate(extra=F("id")).with_baz()
+    triple_obj = triple.get()
+    reveal_type(triple_obj.bar)  # N: Revealed type is "str"
+    reveal_type(triple_obj.extra)  # N: Revealed type is "Any"
+    reveal_type(triple_obj.baz)  # N: Revealed type is "int"
+
+    # Works on queryset too
+    triple = FooModel.objects.all().with_bar().annotate(extra=F("id")).with_baz()
+    triple_obj = triple.get()
+    reveal_type(triple_obj.bar)  # N: Revealed type is "str"
+    reveal_type(triple_obj.extra)  # N: Revealed type is "Any"
+    reveal_type(triple_obj.baz)  # N: Revealed type is "int"
+
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from typing_extensions import TypedDict, Self
+        from django.db import models
+        from django_stubs_ext import WithAnnotations
+
+        class BarDict(TypedDict):
+            bar: str
+
+        class BazDict(TypedDict):
+            baz: int
+
+        class BarIntDict(TypedDict):
+            bar: int
+
+        class FooQuerySet(models.QuerySet):
+            def with_bar(self) -> "FooQuerySet[WithAnnotations[FooModel, BarDict]]":
+                return self.annotate(bar=models.Value("x"))  # type: ignore[no-any-return]
+
+            def with_baz(self) -> "FooQuerySet[WithAnnotations[FooModel, BazDict]]":
+                return self.annotate(baz=models.Value(1))  # type: ignore[no-any-return]
+
+            def with_bar_int(self) -> "FooQuerySet[WithAnnotations[FooModel, BarIntDict]]":
+                return self.annotate(bar=models.Value(1))  # type: ignore[no-any-return]
+
+            def active(self) -> Self:
+                return self.filter(active=True)
+
+        FooManager = models.Manager.from_queryset(FooQuerySet)
+
+        class FooModel(models.Model):
+            name = models.CharField(max_length=100)
+            objects = FooManager()
+
+# Regression test from https://github.com/typeddjango/django-stubs/issues/2681#issuecomment-3610917062
+- case: custom_queryset_with_annotations_issue_2681_comment
+  main: |
+    from typing_extensions import reveal_type
+    from myapp.models import FooModel
+
+    reveal_type(FooModel.objects.with_bar())  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel@AnnotatedWith[TypedDict(myapp.models.BarDict, {'bar': str})], myapp.models.FooModel@AnnotatedWith[TypedDict(myapp.models.BarDict, {'bar': str})]]"
+    reveal_type(FooModel.objects.with_bar().with_baz())  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel@AnnotatedWith[TypedDict({'bar': str, 'baz': str})], myapp.models.FooModel@AnnotatedWith[TypedDict({'bar': str, 'baz': str})]]"
+
+    obj = FooModel.objects.with_bar().with_baz().get()
+    reveal_type(obj.bar)  # N: Revealed type is "str"
+    reveal_type(obj.baz)  # N: Revealed type is "str"
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from typing_extensions import TypedDict, TypeVar
+        from django.db import models
+        from django.db.models import Manager
+        from django_stubs_ext import WithAnnotations
+
+        class BarDict(TypedDict):
+            bar: str
+
+        class BazDict(TypedDict):
+            baz: str
+
+        _Model = TypeVar("_Model", bound=models.Model, covariant=True)
+
+        class FooQuerySet(models.QuerySet[_Model]):
+            def with_bar(self) -> "FooQuerySet[WithAnnotations[FooModel, BarDict]]":
+                return self.annotate(bar=models.Value("bar"))  # type: ignore[no-any-return]
+
+            def with_baz(self) -> "FooQuerySet[WithAnnotations[FooModel, BazDict]]":
+                return self.annotate(baz=models.Value("baz"))  # type: ignore[no-any-return]
+
+        FooManager = Manager.from_queryset(FooQuerySet)
+
+        class FooModel(models.Model):
+            objects = FooManager()

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -799,7 +799,7 @@
 
     # Custom method without WithAnnotations: noop
     plain = FooModel.objects.active()
-    reveal_type(plain)  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel, myapp.models.FooModel]"
+    reveal_type(plain)  # N: Revealed type is "myapp.models.FooQuerySet[myapp.models.FooModel]"
 
     # Custom then .annotate() then custom: all three layers merge
     triple = FooModel.objects.with_bar().annotate(extra=F("id")).with_baz()
@@ -821,7 +821,7 @@
     - path: myapp/__init__.py
     - path: myapp/models.py
       content: |
-        from typing_extensions import TypedDict, Self
+        from typing_extensions import TypedDict, TypeVar, Self
         from django.db import models
         from django_stubs_ext import WithAnnotations
 
@@ -834,15 +834,17 @@
         class BarIntDict(TypedDict):
             bar: int
 
-        class FooQuerySet(models.QuerySet):
-            def with_bar(self) -> "FooQuerySet[WithAnnotations[FooModel, BarDict]]":
-                return self.annotate(bar=models.Value("x"))  # type: ignore[no-any-return]
+        _Model = TypeVar("_Model", bound=models.Model, covariant=True)
 
-            def with_baz(self) -> "FooQuerySet[WithAnnotations[FooModel, BazDict]]":
-                return self.annotate(baz=models.Value(1))  # type: ignore[no-any-return]
+        class FooQuerySet(models.QuerySet[_Model]):
+            def with_bar(self) -> "FooQuerySet[WithAnnotations[_Model, BarDict]]":
+                return self.annotate(bar=models.Value("x"))
 
-            def with_bar_int(self) -> "FooQuerySet[WithAnnotations[FooModel, BarIntDict]]":
-                return self.annotate(bar=models.Value(1))  # type: ignore[no-any-return]
+            def with_baz(self) -> "FooQuerySet[WithAnnotations[_Model, BazDict]]":
+                return self.annotate(baz=models.Value(1))
+
+            def with_bar_int(self) -> "FooQuerySet[WithAnnotations[_Model, BarIntDict]]":
+                return self.annotate(bar=models.Value(1))
 
             def active(self) -> Self:
                 return self.filter(active=True)

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -885,7 +885,7 @@
         _Model = TypeVar("_Model", bound=models.Model, covariant=True)
 
         class FooQuerySet(models.QuerySet[_Model]):
-            def with_bar(self) -> "FooQuerySet[WithAnnotations[FooModel, BarDict]]":
+            def with_bar(self) -> "FooQuerySet[WithAnnotations[_Model, BarDict]]":
                 return self.annotate(bar=models.Value("bar"))  # type: ignore[no-any-return]
 
             def with_baz(self) -> "FooQuerySet[WithAnnotations[FooModel, BazDict]]":


### PR DESCRIPTION
# I have made things!
Add a method hook that fires for any method call on a `QuerySet`/`Manager` subclass that returns a `WithAnnotation[...]` in order to merge the annotations

Also does some minor short circuting in `get_method_hook` and `get_attribute_hook

## Related issues
Fixes #2681


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
