### PR TITLE
Cache apt packages for GDAL in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Cache apt packages
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: /var/cache/apt/archives
+          key: apt-gdal-${{ runner.os }}
       - name: Setup system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install binutils libproj-dev gdal-bin
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends libgdal-dev libproj-dev
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -88,10 +93,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Cache apt packages
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: /var/cache/apt/archives
+          key: apt-gdal-${{ runner.os }}
       - name: Setup system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install binutils libproj-dev gdal-bin
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends libgdal-dev libproj-dev
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Set up Python
@@ -120,10 +130,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: Setup system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -230,10 +236,6 @@ jobs:
             django-version: '6.0'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - name: Setup system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Cache apt packages
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: /var/cache/apt/archives
+          key: apt-gdal-${{ runner.os }}
+      - name: Setup system dependencies
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends libgdal-dev libproj-dev
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# I have made things!
Noticed It was taking a noticeable time in every ci run (~20-25s) so probably worth caching
It improves slightly here (~12-17s)

PS: I also tried https://github.com/marketplace/actions/cache-apt-packages but it's not working properly for us due to gdal triggering a bunch of post install scripts

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
