### PR TITLE
Refine types in html.pyi: Remove Incomplete and Any

### DIFF
--- a/django-stubs/utils/html.pyi
+++ b/django-stubs/utils/html.pyi
@@ -4,6 +4,7 @@ from html.parser import HTMLParser
 from json import JSONEncoder
 from re import Pattern
 from typing import Any, overload
+
 from django.utils.functional import SimpleLazyObject, _StrOrPromise
 from django.utils.safestring import SafeData, SafeString
 from typing_extensions import deprecated, override
@@ -41,7 +42,9 @@ class MLStripper(HTMLParser):
 def strip_tags(value: str) -> str: ...
 def strip_spaces_between_tags(value: str) -> str: ...
 def smart_urlquote(url: str) -> str: ...
-def urlize(text: _StrOrPromise | SafeData, trim_url_limit: int | None = None, nofollow: bool = False, autoescape: bool = False) -> str: ...
+def urlize(
+    text: _StrOrPromise | SafeData, trim_url_limit: int | None = None, nofollow: bool = False, autoescape: bool = False
+) -> str: ...
 def avoid_wrapping(value: str) -> str: ...
 def html_safe(klass: type) -> type: ...
 
@@ -51,7 +54,7 @@ class CountsDict(dict[str, Any]):
 
 class Urlizer:
     trailing_punctuation_chars: str
-    wrapping_punctuation: list[tuple[str,str]] 
+    wrapping_punctuation: list[tuple[str, str]]
     word_split_re: Pattern[str] | SimpleLazyObject
     simple_url_re: Pattern[str] | SimpleLazyObject
     simple_url_2_re: Pattern[str] | SimpleLazyObject

--- a/django-stubs/utils/html.pyi
+++ b/django-stubs/utils/html.pyi
@@ -4,8 +4,6 @@ from html.parser import HTMLParser
 from json import JSONEncoder
 from re import Pattern
 from typing import Any, overload
-
-from _typeshed import Incomplete
 from django.utils.functional import SimpleLazyObject, _StrOrPromise
 from django.utils.safestring import SafeData, SafeString
 from typing_extensions import deprecated, override
@@ -30,7 +28,7 @@ def format_html_join(sep: str, format_string: str, args_generator: Iterable[Iter
 def linebreaks(value: Any, autoescape: bool = False) -> str: ...
 
 class MLStripper(HTMLParser):
-    fed: Any
+    fed: list[str]
     def __init__(self) -> None: ...
     @override
     def handle_data(self, d: str) -> None: ...
@@ -43,7 +41,7 @@ class MLStripper(HTMLParser):
 def strip_tags(value: str) -> str: ...
 def strip_spaces_between_tags(value: str) -> str: ...
 def smart_urlquote(url: str) -> str: ...
-def urlize(text: str, trim_url_limit: int | None = None, nofollow: bool = False, autoescape: bool = False) -> str: ...
+def urlize(text: _StrOrPromise | SafeData, trim_url_limit: int | None = None, nofollow: bool = False, autoescape: bool = False) -> str: ...
 def avoid_wrapping(value: str) -> str: ...
 def html_safe(klass: type) -> type: ...
 
@@ -53,7 +51,7 @@ class CountsDict(dict[str, Any]):
 
 class Urlizer:
     trailing_punctuation_chars: str
-    wrapping_punctuation: Incomplete
+    wrapping_punctuation: list[tuple[str,str]] 
     word_split_re: Pattern[str] | SimpleLazyObject
     simple_url_re: Pattern[str] | SimpleLazyObject
     simple_url_2_re: Pattern[str] | SimpleLazyObject
@@ -61,21 +59,21 @@ class Urlizer:
     url_template: str
     def __call__(
         self,
-        text: Incomplete,
-        trim_url_limit: Incomplete | None = None,
+        text: _StrOrPromise | SafeData,
+        trim_url_limit: int | None = None,
         nofollow: bool = False,
         autoescape: bool = False,
-    ) -> Incomplete: ...
+    ) -> str: ...
     def handle_word(
         self,
-        word: Incomplete,
+        word: str,
         *,
-        safe_input: Incomplete,
-        trim_url_limit: Incomplete | None = None,
+        safe_input: bool,
+        trim_url_limit: int | None = None,
         nofollow: bool = False,
         autoescape: bool = False,
-    ) -> Incomplete: ...
-    def trim_url(self, x: str, *, limit: int | None) -> Incomplete: ...
+    ) -> str: ...
+    def trim_url(self, x: str, *, limit: int | None) -> str: ...
     def trim_punctuation(self, word: str) -> tuple[str, str, str]: ...
     @staticmethod
     def is_email_simple(value: str) -> bool: ...


### PR DESCRIPTION
# I have made things!
Hi team,
While going through the django-stubs codebase, I noticed that django.utils.html still had several Incomplete types in the Urlizer and MLStripper classes. Also, some return values were using Any.
I have manually reviewed the Django 5.x source code to verify the actual runtime behavior. I have updated these to use concrete types like str, bool, and list[tuple[str, str]]. This also allowed me to remove the _typeshed import since it’s no longer needed for this module.

changes:
Replaced Incomplete with specific types in Urlizer class.
Updated MLStripper.fed from Any to list[str].
Refined return types for utility functions.
Verified the changes with mypy locally.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
