### PR TITLE
Fix row type lost when using `.annotate(...)` on custom bound `QuerySet`

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 def determine_proper_manager_type(ctx: FunctionContext) -> MypyType:
     """
     Fill the manager TypeVar on instantiation using the enclosing class.
-    For ex:
+    For example:
 
         class MyModel(Model):
             objects = MyManager()

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -332,7 +332,7 @@ def reparametrize_queryset(instance: Instance, args: list[MypyType]) -> Instance
         if base.type.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
             instance.type.bases[i] = base.copy_modified(args=args)
 
-    return instance.copy_modified(args=args)
+    return instance
 
 
 def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: DjangoContext) -> MypyType:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -206,7 +206,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
 
     if flat and named:
         ctx.api.fail("'flat' and 'named' can't be used together", ctx.context)
-        return default_return_type.copy_modified(args=[django_model.typ, AnyType(TypeOfAny.from_error)])
+        return reparametrize_queryset(default_return_type, [django_model.typ, AnyType(TypeOfAny.from_error)])
 
     annotation_types = _get_annotation_field_types(django_model.typ) if django_model.is_annotated else {}
     row_type = get_values_list_row_type(
@@ -217,7 +217,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
         flat=flat,
         named=named,
     )
-    ret = default_return_type.copy_modified(args=[django_model.typ, row_type])
+    ret = reparametrize_queryset(default_return_type, [django_model.typ, row_type])
     if not named and (field_lookups := resolve_field_lookups(ctx.args[0], django_context)):
         # For non-named values_list, the row type does not encode column names.
         # Attach selected field names to the returned QuerySet instance so that
@@ -318,6 +318,23 @@ def gather_expression_types(ctx: MethodContext) -> dict[str, MypyType]:
     return result
 
 
+def reparametrize_queryset(instance: Instance, args: list[MypyType]) -> Instance:
+    """Reparametrize a QuerySet instance with new type arguments.
+
+    When the instance's type is generic, the args are applied directly.
+    Otherwise, walks the base class hierarchy to find the closest generic
+    QuerySet ancestor and applies args to that instead.
+    """
+    if instance.type.is_generic():
+        return instance.copy_modified(args=args)
+
+    for i, base in enumerate(instance.type.bases):
+        if base.type.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
+            instance.type.bases[i] = base.copy_modified(args=args)
+
+    return instance.copy_modified(args=args)
+
+
 def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     django_model = helpers.get_model_info_from_qs_ctx(ctx, django_context)
     if django_model is None:
@@ -367,7 +384,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
             row_type = annotated_type
     else:
         row_type = annotated_type
-    return default_return_type.copy_modified(args=[annotated_type, row_type])
+    return reparametrize_queryset(default_return_type, [annotated_type, row_type])
 
 
 def resolve_field_lookups(lookup_exprs: Sequence[Expression], django_context: DjangoContext) -> list[str] | None:
@@ -435,14 +452,14 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
             if django_model.is_annotated:
                 column_types[field_lookup] = AnyType(TypeOfAny.from_omitted_generics)
             else:
-                return default_return_type.copy_modified(args=[django_model.typ, AnyType(TypeOfAny.from_error)])
+                return reparametrize_queryset(default_return_type, [django_model.typ, AnyType(TypeOfAny.from_error)])
         else:
             column_types[field_lookup] = field_lookup_type
 
     # Collect `**expressions` types -- `.values(lower_name=Lower("name"), foo=F("name"))`
     column_types.update(gather_expression_types(ctx))
     row_type = helpers.make_typeddict(ctx.api, column_types)
-    return default_return_type.copy_modified(args=[django_model.typ, row_type])
+    return reparametrize_queryset(default_return_type, [django_model.typ, row_type])
 
 
 def _infer_prefetch_queryset_type(queryset_expr: Expression, api: TypeChecker) -> Instance | None:
@@ -839,7 +856,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     else:
         row_type = annotated_model
 
-    return default_return_type.copy_modified(args=[annotated_model, row_type])
+    return reparametrize_queryset(default_return_type, [annotated_model, row_type])
 
 
 def _try_get_field(

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -56,6 +56,18 @@ if TYPE_CHECKING:
 
 
 def determine_proper_manager_type(ctx: FunctionContext) -> MypyType:
+    """
+    Fill the manager TypeVar on instantiation using the enclosing class.
+    For ex:
+
+        class MyModel(Model):
+            objects = MyManager()
+
+    Is interpreted as:
+
+        class MyModel(Model):
+            objects: MyManager[MyModel] = MyManager()
+    """
     default_return_type = get_proper_type(ctx.default_return_type)
     assert isinstance(default_return_type, Instance)
 

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -719,3 +719,29 @@
         from django.db import models
         class MyModel(models.Model):
             name = models.CharField(max_length=100)
+
+# Regression test from https://github.com/typeddjango/django-stubs/issues/1049
+- case: custom_queryset_with_annotations_issue_1049
+  main: |
+    from typing_extensions import reveal_type
+    from myapp.models import Accommodation, SomeQuerySet
+    from django.db.models import Value
+
+    queryset = SomeQuerySet().annotate(hello=Value(True)).filter(is_on_shelf=True).annotate(hi=Value(False))
+    reveal_type(queryset)  # N: Revealed type is "myapp.models.SomeQuerySet[myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})], myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]]"
+    reveal_type(queryset.first())  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})] | None"
+    reveal_type(queryset.get(pk=1))  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"
+    reveal_type(queryset[0])  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+
+        class Accommodation(models.Model):
+            is_on_shelf = models.BooleanField()
+
+        class SomeQuerySet(models.QuerySet["Accommodation"]):
+            pass

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -728,7 +728,7 @@
     from django.db.models import Value
 
     queryset = SomeQuerySet().annotate(hello=Value(True)).filter(is_on_shelf=True).annotate(hi=Value(False))
-    reveal_type(queryset)  # N: Revealed type is "myapp.models.SomeQuerySet[myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})], myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]]"
+    reveal_type(queryset)  # N: Revealed type is "myapp.models.SomeQuerySet"
     reveal_type(queryset.first())  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})] | None"
     reveal_type(queryset.get(pk=1))  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"
     reveal_type(queryset[0])  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"


### PR DESCRIPTION
# I have made thing

The annotated types are lost when we use `.annotate` on a queryset like this

```python
class SomeQuerySet(QuerySet[Accommodation]): # SomeQuerySet is not generic, and bind the queryset typevar
    pass
```

The root issue is exactly here in `extract_proper_type_queryset_annotate` because in our case, `default_return_type` is `SomeQuerySet(models.QuerySet["Accommodation"])` which is not generic. So we try to add updated typevars to `SomeQuerySet` instead of the child `QuerySet`.
https://github.com/typeddjango/django-stubs/blob/61722fdcf4dab387819db406920f099c4464b33f/mypy_django_plugin/transformers/querysets.py#L358 

The fix here is to ensure we patch the correct TypeVar bound `Instance`. 

## Related issues
Fixes #1049
Blocking #3266

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
