### PR TITLE
Improve type precision in template backends

### DIFF
--- a/django-stubs/template/backends/jinja2.pyi
+++ b/django-stubs/template/backends/jinja2.pyi
@@ -1,16 +1,17 @@
 from collections.abc import Callable
 from typing import Any
 
-from _typeshed import Incomplete
 from django.http.request import HttpRequest
 from django.template.exceptions import TemplateSyntaxError
 from django.utils.functional import cached_property
+from jinja2 import Environment
+from jinja2 import Template as Jinja2Template
 from typing_extensions import override
 
 from .base import BaseEngine
 
 class Jinja2(BaseEngine):
-    env: Any
+    env: Environment
     context_processors: list[str]
     def __init__(self, params: dict[str, Any]) -> None: ...
     @override
@@ -18,18 +19,18 @@ class Jinja2(BaseEngine):
     @override
     def get_template(self, template_name: str) -> Template: ...
     @cached_property
-    def template_context_processors(self) -> list[Callable]: ...
+    def template_context_processors(self) -> list[Callable[[HttpRequest], dict[str, Any]]]: ...
+
+class Template:
+    template: Jinja2Template
+    backend: Jinja2
+    origin: Origin
+    def __init__(self, template: Jinja2Template, backend: Jinja2) -> None: ...
+    def render(self, context: dict[str, Any] | None = None, request: HttpRequest | None = None) -> str: ...
 
 class Origin:
     name: str
     template_name: str | None
     def __init__(self, name: str, template_name: str | None) -> None: ...
-
-class Template:
-    template: Incomplete
-    backend: Jinja2
-    origin: Origin
-    def __init__(self, template: Incomplete, backend: Jinja2) -> None: ...
-    def render(self, context: dict[str, Any] | None = ..., request: HttpRequest | None = ...) -> str: ...
 
 def get_exception_info(exception: TemplateSyntaxError) -> dict[str, Any]: ...

--- a/django-stubs/template/engine.pyi
+++ b/django-stubs/template/engine.pyi
@@ -1,7 +1,9 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeAlias
+from typing import Any, ClassVar, TypeAlias
 
+from django.http.request import HttpRequest
 from django.template.base import Origin
+from django.template.context import Context
 from django.template.library import Library
 from django.template.loaders.base import Loader
 from django.utils.functional import cached_property
@@ -12,7 +14,7 @@ from .base import Template
 _Loader: TypeAlias = Any
 
 class Engine:
-    default_builtins: Any
+    default_builtins: ClassVar[list[str]]
     dirs: list[str]
     app_dirs: bool
     autoescape: bool
@@ -41,7 +43,7 @@ class Engine:
     @staticmethod
     def get_default() -> Engine: ...
     @cached_property
-    def template_context_processors(self) -> Sequence[Callable]: ...
+    def template_context_processors(self) -> Sequence[Callable[[HttpRequest], dict[str, Any]]]: ...
     def get_template_builtins(self, builtins: list[str]) -> list[Library]: ...
     def get_template_libraries(self, libraries: dict[str, str]) -> dict[str, Library]: ...
     @cached_property
@@ -53,5 +55,7 @@ class Engine:
     ) -> tuple[Template, Origin]: ...
     def from_string(self, template_code: str) -> Template: ...
     def get_template(self, template_name: str) -> Template: ...
-    def render_to_string(self, template_name: str, context: dict[str, Any] | None = None) -> SafeString: ...
+    def render_to_string(
+        self, template_name: str | list[str] | tuple[str, ...], context: dict[str, Any] | Context | None = None
+    ) -> SafeString: ...
     def select_template(self, template_name_list: list[str]) -> Template: ...


### PR DESCRIPTION
### PR Summary
This PR tightens a few types in `django.template.backends.jinja2` and `django.template.engine`. The jinja2 backend's `template` and `env` attributes now point at the real `jinja2.Template` and `jinja2.Environment` instead of `Incomplete`/`Any`, and context processors in both files get their actual `(HttpRequest) -> dict[str, Any]` shape instead of bare `Callable`. Along the way: `Engine.render_to_string` now accepts a list/tuple of template names and a `Context` object, `Engine.default_builtins` becomes `ClassVar[list[str]]`, and a few small additional cleanups.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
