### PR TITLE
Use `ignoreDeps` to prevent Renovate from updating Python versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:best-practices"],
+  // Python versions in CI are managed manually (test-older-django pins 3.10)
+  ignoreDeps: ["python"],
   suppressNotifications: ["prEditedNotification"],
   mode: "full",
   // Wait 3 days before proposing updates to limit supply chain attack exposure
@@ -16,11 +18,6 @@
     {
       matchPackageNames: ["mypy"],
       rangeStrategy: "widen",
-    },
-    {
-      // NOTE: Keep `test-older-django` python version in sync
-      matchPackageNames: ["python"],
-      allowedVersions: "3.10",
     },
     {
       // Group upload/download artifact updates, the versions are dependent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          # NOTE: Keep renovate.json python "allowedVersions" in sync
           python-version: '3.10'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

The `allowedVersions: "3.10"` rule was not working — Renovate still created PRs to bump Python (see #3279). Use `ignoreDeps: ["python"]` instead, as recommended by Renovate [here](https://github.com/typeddjango/django-stubs/pull/3279#issuecomment-4208779615).