### PR TITLE
Prevent Renovate from bumping Django 5.x pin to 6.x

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,5 +32,11 @@
       matchDatasources: ["github-runners"],
       enabled: false,
     },
+    {
+      // Django 6.0 dropped Python <3.12 support, keep the compat pin on 5.x
+      matchPackageNames: ["django"],
+      matchCurrentVersion: "/^5\\./",
+      allowedVersions: "<6.0.0",
+    },
   ],
 }


### PR DESCRIPTION
Django 6.0 dropped Python <3.12 support so the conditional dep `django==5.2.x; python_version < '3.12'` must stay on 5.x.

Adds a `matchCurrentVersion` constraint so Renovate still proposes 5.2 patch updates but won't cross the major version boundary.

See #3281 for the bogus PR this prevents.