### PR TITLE
Add debugging tip for yml tests in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,16 @@ just stubtest --allowlist extra.txt
 
 If you get unexpected results, clear the mypy cache with `just clean`.
 
+### Debugging plugin code
+
+For yml tests, we use a dedicated [pytest plugin](https://github.com/typeddjango/pytest-mypy-plugins) that is by default
+running mypy in a subprocess, making it difficult to debug.
+To avoid that, run pytest with the `--mypy-same-process` flag.
+
+```shell
+pytest --mypy-same-process tests/typecheck/managers/querysets/test_annotate.yml
+```
+
 ### Testing stubs with `stubtest`
 
 Run `just stubtest` (or [`./scripts/stubtest.sh`](scripts/stubtest.sh) directly) to test that stubs and sources are in-line.


### PR DESCRIPTION
## I have made things!

I'm using that all the time to debug in pycharm, probably worth mentioning


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
