### PR TITLE
Type admin site as DefaultAdminSite inheriting from Adminsite

### DIFF
--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -13,7 +13,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
 from django.template.response import TemplateResponse
 from django.urls import URLPattern, URLResolver
-from django.utils.functional import LazyObject, _StrOrPromise
+from django.utils.functional import _StrOrPromise
 
 all_sites: WeakSet[AdminSite]
 
@@ -81,6 +81,6 @@ class AdminSite:
     def catch_all_view(self, request: HttpRequest, url: str) -> HttpResponse: ...
     def get_log_entries(self, request: HttpRequest) -> QuerySet[LogEntry]: ...
 
-class DefaultAdminSite(LazyObject[AdminSite]): ...
+class DefaultAdminSite(AdminSite): ...
 
-site: AdminSite
+site: DefaultAdminSite

--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -13,7 +13,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
 from django.template.response import TemplateResponse
 from django.urls import URLPattern, URLResolver
-from django.utils.functional import _StrOrPromise
+from django.utils.functional import LazyObject, _StrOrPromise
 
 all_sites: WeakSet[AdminSite]
 
@@ -81,6 +81,7 @@ class AdminSite:
     def catch_all_view(self, request: HttpRequest, url: str) -> HttpResponse: ...
     def get_log_entries(self, request: HttpRequest) -> QuerySet[LogEntry]: ...
 
-class DefaultAdminSite(AdminSite): ...
+class DefaultAdminSite(LazyObject[AdminSite]): ...
 
-site: DefaultAdminSite
+# site is actually an instance of DefaultAdminSite, but it proxies through to a AdminSite
+site: AdminSite

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -20,6 +20,9 @@ django.contrib.sites.migrations.*
 # default_storage is actually an instance of DefaultStorage, but it proxies through to a Storage
 django.core.files.storage.default_storage
 
+# site is actually an instance of DefaultAdminSite, but it proxies through to an AdminSite
+django.contrib.admin.sites.site
+
 # default_task_backend is actually an instance of ConnectionProxy, but it proxies through to a BaseTaskBackend
 django.tasks.default_task_backend
 

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -15,7 +15,6 @@ django.contrib.admin.models.LogEntry.object_id
 django.contrib.admin.models.LogEntry.object_repr
 django.contrib.admin.models.LogEntry.user
 django.contrib.admin.models.LogEntry.user_id
-django.contrib.admin.sites.site
 django.contrib.auth.admin.UserAdmin.fieldsets
 django.contrib.auth.base_user.AbstractBaseUser.last_login
 django.contrib.auth.base_user.AbstractBaseUser.password


### PR DESCRIPTION
# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

## Related issues
Fixes stubtest error: `django.contrib.admin.site  variable differs from runtime type django.contrib.admin.sites.DefaultAdminSite`



## AI Policy
*  [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
