### PR TITLE
Propagate Subquery output field type through generics

### DIFF
--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -16,6 +16,7 @@ from django.utils.deconstruct import _Deconstructible
 from django.utils.functional import cached_property
 from typing_extensions import Never, Self, override
 
+_OutputField = TypeVar("_OutputField", bound=Field, default=Field)
 _Numeric: TypeAlias = float | Decimal
 _ExprListCompatible: TypeAlias = Sequence[BaseExpression | F | str] | BaseExpression | F | str
 
@@ -311,13 +312,13 @@ class Case(Expression):
         **extra_context: Any,
     ) -> _AsSqlType: ...
 
-class Subquery(BaseExpression, Combinable):
+class Subquery(BaseExpression, Combinable, Generic[_OutputField]):
     template: str
     subquery: bool
     query: Query
     extra: dict[Any, Any]
     def __init__(
-        self, queryset: Query | QuerySet | Subquery, output_field: Field | None = None, **extra: Any
+        self, queryset: Query | QuerySet | Subquery, output_field: _OutputField | None = None, **extra: Any
     ) -> None: ...
     @property
     def external_aliases(self) -> set[str]: ...

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -11,7 +11,7 @@ from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
 from django.core.paginator import Paginator
-from django.db.models.expressions import ExpressionWrapper
+from django.db.models.expressions import ExpressionWrapper, Subquery
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey
 from django.db.models.fields.related_descriptors import (
@@ -85,6 +85,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(Lookup),
     MPGeneric(BaseConnectionHandler),
     MPGeneric(ExpressionWrapper),
+    MPGeneric(Subquery),
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),
     # These types do have native `__class_getitem__` method since django 3.1:

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -6,6 +6,7 @@ from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy import checker
 from mypy.checker import TypeChecker
+from mypy.maptype import map_instance_to_supertype
 from mypy.mro import calculate_mro
 from mypy.nodes import (
     GDEF,
@@ -46,6 +47,7 @@ from mypy.types import (
     Instance,
     LiteralType,
     NoneTyp,
+    ProperType,
     TupleType,
     Type,
     TypedDictType,
@@ -431,6 +433,20 @@ def get_private_descriptor_type(type_info: TypeInfo, private_field_name: str, is
             descriptor_type = make_optional_type(descriptor_type)
         return descriptor_type
     return AnyType(TypeOfAny.explicit)
+
+
+class FieldTypeArgs(NamedTuple):
+    set: ProperType
+    get: ProperType
+
+
+def get_field_type_args(field_type: Instance) -> FieldTypeArgs | None:
+    """Extract (_ST, _GT) from a Field instance by mapping to the base Field class."""
+    base_field_info = next((base for base in field_type.type.mro if base.fullname == fullnames.FIELD_FULLNAME), None)
+    if base_field_info is None:
+        return None
+    mapped = map_instance_to_supertype(field_type, base_field_info)
+    return FieldTypeArgs(set=get_proper_type(mapped.args[0]), get=get_proper_type(mapped.args[1]))
 
 
 def get_field_lookup_exact_type(api: TypeChecker, field: Field[Any, Any]) -> MypyType:

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.fields import AutoField, Field
 from django.db.models.fields.related import RelatedField
-from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import AssignmentStmt, NameExpr, TypeInfo
 from mypy.types import AnyType, Instance, NoneType, ProperType, TypeOfAny, UninhabitedType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
@@ -156,15 +155,14 @@ def set_descriptor_types_for_field(
     )
 
     # reconcile set and get types with the base field class
-    base_field_type = next(base for base in default_return_type.type.mro if base.fullname == fullnames.FIELD_FULLNAME)
-    mapped_instance = map_instance_to_supertype(default_return_type, base_field_type)
-    mapped_set_type, mapped_get_type = tuple(get_proper_type(arg) for arg in mapped_instance.args)
+    mapped_types = helpers.get_field_type_args(default_return_type)
+    assert mapped_types is not None
 
-    # bail if either mapped_set_type or mapped_get_type have type Never
-    if not (isinstance(mapped_set_type, UninhabitedType) or isinstance(mapped_get_type, UninhabitedType)):
+    # bail if either mapped set or get type is Never
+    if not (isinstance(mapped_types.set, UninhabitedType) or isinstance(mapped_types.get, UninhabitedType)):
         # always replace set_type and get_type with (non-Any) mapped types
-        set_type = helpers.convert_any_to_type(mapped_set_type, set_type)
-        get_type = get_proper_type(helpers.convert_any_to_type(mapped_get_type, get_type))
+        set_type = helpers.convert_any_to_type(mapped_types.set, set_type)
+        get_type = get_proper_type(helpers.convert_any_to_type(mapped_types.get, get_type))
 
         # the get_type must be optional if the field is nullable
         if (is_get_nullable or is_nullable) and not (

--- a/mypy_django_plugin/transformers/fields.py
+++ b/mypy_django_plugin/transformers/fields.py
@@ -235,7 +235,7 @@ def transform_into_proper_return_type(ctx: FunctionContext, django_context: Djan
 
     outer_model_info = helpers.get_typechecker_api(ctx).scope.active_class()
     if outer_model_info is None or not helpers.is_model_type(outer_model_info):
-        return ctx.default_return_type
+        return set_descriptor_types_for_field(ctx)
 
     assert isinstance(outer_model_info, TypeInfo)
 

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -268,10 +268,20 @@ def _resolve_output_field_type(expr_type: MypyType) -> MypyType | None:
         if isinstance(func_type, CallableType):
             field_type = get_proper_type(func_type.ret_type)
 
-    if not isinstance(field_type, Instance):
-        return None
+    if isinstance(field_type, Instance):
+        result = helpers.get_private_descriptor_type(field_type.type, "_pyi_private_get_type", is_nullable=False)
+        if not isinstance(get_proper_type(result), AnyType):
+            return result
 
-    return helpers.get_private_descriptor_type(field_type.type, "_pyi_private_get_type", is_nullable=False)
+    # Fallback: check generic type arguments for Field types (e.g., Subquery[IntegerField] → int)
+    for arg in proper.args:
+        arg_proper = get_proper_type(arg)
+        if isinstance(arg_proper, Instance) and arg_proper.type.has_base(fullnames.FIELD_FULLNAME):
+            result = helpers.get_private_descriptor_type(arg_proper.type, "_pyi_private_get_type", is_nullable=False)
+            if not isinstance(get_proper_type(result), AnyType):
+                return result
+
+    return None
 
 
 def gather_expression_types(ctx: MethodContext) -> dict[str, MypyType]:

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -15,6 +15,7 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.db.models.lookups import Transform
 from django.db.models.sql.query import Query
 from mypy.errorcodes import NO_REDEF
+from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import (
     ARG_NAMED,
     ARG_NAMED_OPT,
@@ -273,13 +274,20 @@ def _resolve_output_field_type(expr_type: MypyType) -> MypyType | None:
         if not isinstance(get_proper_type(result), AnyType):
             return result
 
-    # Fallback: check generic type arguments for Field types (e.g., Subquery[IntegerField] → int)
+    # Fallback: extract _GT from generic type args that are Field subclasses.
+    # This preserves nullability from null=True (e.g., IntegerField(null=True) → int | None).
     for arg in proper.args:
         arg_proper = get_proper_type(arg)
         if isinstance(arg_proper, Instance) and arg_proper.type.has_base(fullnames.FIELD_FULLNAME):
-            result = helpers.get_private_descriptor_type(arg_proper.type, "_pyi_private_get_type", is_nullable=False)
-            if not isinstance(get_proper_type(result), AnyType):
-                return result
+            base_field_type = next(
+                (base for base in arg_proper.type.mro if base.fullname == fullnames.FIELD_FULLNAME), None
+            )
+            if base_field_type is not None:
+                mapped = map_instance_to_supertype(arg_proper, base_field_type)
+                if len(mapped.args) >= 2:
+                    get_type = get_proper_type(mapped.args[1])
+                    if not isinstance(get_type, AnyType):
+                        return get_type
 
     return None
 

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -15,7 +15,6 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.db.models.lookups import Transform
 from django.db.models.sql.query import Query
 from mypy.errorcodes import NO_REDEF
-from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import (
     ARG_NAMED,
     ARG_NAMED_OPT,
@@ -279,15 +278,9 @@ def _resolve_output_field_type(expr_type: MypyType) -> MypyType | None:
     for arg in proper.args:
         arg_proper = get_proper_type(arg)
         if isinstance(arg_proper, Instance) and arg_proper.type.has_base(fullnames.FIELD_FULLNAME):
-            base_field_type = next(
-                (base for base in arg_proper.type.mro if base.fullname == fullnames.FIELD_FULLNAME), None
-            )
-            if base_field_type is not None:
-                mapped = map_instance_to_supertype(arg_proper, base_field_type)
-                if len(mapped.args) >= 2:
-                    get_type = get_proper_type(mapped.args[1])
-                    if not isinstance(get_type, AnyType):
-                        return get_type
+            type_args = helpers.get_field_type_args(arg_proper)
+            if type_args is not None and not isinstance(type_args.get, AnyType):
+                return type_args.get
 
     return None
 

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -667,6 +667,11 @@
         val_str = User.objects.annotate(val=char_subquery).get().val
         reveal_type(val_str)  # N: Revealed type is "str"
 
+        # Subquery with nullable output_field → int | None
+        nullable_sub = Subquery(User.objects.filter(pk=OuterRef('pk')).values('id')[:1], output_field=IntegerField(null=True))
+        val_nullable = User.objects.annotate(val=nullable_sub).get().val
+        reveal_type(val_nullable)  # N: Revealed type is "int | None"
+
         # Subquery without output_field → Any
         plain_subquery = Subquery(User.objects.filter(pk=OuterRef('pk')).values('id')[:1])
         val_any = User.objects.annotate(val=plain_subquery).get().val

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -651,6 +651,36 @@
                 class User(models.Model):
                     username = models.CharField(max_length=100)
 
+-   case: annotate_resolves_output_field_from_subquery_generic
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import User
+        from django.db.models import Subquery, OuterRef, IntegerField, CharField, Exists
+
+        # Subquery with explicit output_field=IntegerField() → int
+        int_subquery = Subquery(User.objects.filter(pk=OuterRef('pk')).values('id')[:1], output_field=IntegerField())
+        val_int = User.objects.annotate(val=int_subquery).get().val
+        reveal_type(val_int)  # N: Revealed type is "int"
+
+        # Subquery with explicit output_field=CharField() → str
+        char_subquery = Subquery(User.objects.filter(pk=OuterRef('pk')).values('username')[:1], output_field=CharField())
+        val_str = User.objects.annotate(val=char_subquery).get().val
+        reveal_type(val_str)  # N: Revealed type is "str"
+
+        # Subquery without output_field → Any
+        plain_subquery = Subquery(User.objects.filter(pk=OuterRef('pk')).values('id')[:1])
+        val_any = User.objects.annotate(val=plain_subquery).get().val
+        reveal_type(val_any)  # N: Revealed type is "Any"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class User(models.Model):
+                    username = models.CharField(max_length=100)
+
 - case: test_values_and_values_list_on_with_annotations_queryset
   main: |
     from typing_extensions import TypedDict, reveal_type


### PR DESCRIPTION
Make Subquery generic over its output field so that passing an explicit output_field preserves the type through .annotate().

```python
# Before: val is Any
# After:  val is int                                                                                          
sub = Subquery(qs.values("id")[:1], output_field=IntegerField())
val = MyModel.objects.annotate(val=sub).get().val 
```

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
