### PR TITLE
Fix cross-test mypy cache contamination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ redis = ["redis", "types-redis"]
 tests = [
   # Dev tools:
   "pytest==9.0.3",
-  "pytest-mypy-plugins==4.0.0",
+  "pytest-mypy-plugins==4.0.1",
   "pytest-shard==0.1.2",
   "pytest-xdist==3.8.0",
   # Django deps:

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ dev = [
     { name = "pyrefly", specifier = "==0.60.2" },
     { name = "pyright", specifier = "==1.1.408" },
     { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-mypy-plugins", specifier = "==4.0.0" },
+    { name = "pytest-mypy-plugins", specifier = "==4.0.1" },
     { name = "pytest-shard", specifier = "==0.1.2" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -348,7 +348,7 @@ tests = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
     { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-mypy-plugins", specifier = "==4.0.0" },
+    { name = "pytest-mypy-plugins", specifier = "==4.0.1" },
     { name = "pytest-shard", specifier = "==0.1.2" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -978,7 +978,7 @@ wheels = [
 
 [[package]]
 name = "pytest-mypy-plugins"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
@@ -991,9 +991,9 @@ dependencies = [
     { name = "regex" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/9d/9e463cbfa15350ac2f39b07e62325df3346a507ad22346e25d53034e83f5/pytest_mypy_plugins-4.0.0.tar.gz", hash = "sha256:2b4d83d1050aff6f65d85d0deed678ff0ae12b188843f4b00223187e86372f23", size = 29535, upload-time = "2026-03-12T16:10:52.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/66/a450eca9b6fbf37b30ef35f4301c0c4e54f426c6559565c1d1a6a635e077/pytest_mypy_plugins-4.0.1.tar.gz", hash = "sha256:331cce9609805f75b71b432dddabe53c4527771af12786a6c47f914635106e70", size = 30094, upload-time = "2026-04-14T14:40:20.757Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/ed/f15c05575ed4cadeb4cb7da48af1e5f11f4daa8608f21a39b1767cb88308/pytest_mypy_plugins-4.0.0-py3-none-any.whl", hash = "sha256:e59ba09d09bf34ed05ca0c32c5e19fa0fc723d63d77eac71e75d47b4473a74f2", size = 20957, upload-time = "2026-03-12T16:10:50.736Z" },
+    { url = "https://files.pythonhosted.org/packages/01/45/707daa3580248a0160f31956aba4acdd0c11c43f162fa8a3657424b0c239/pytest_mypy_plugins-4.0.1-py3-none-any.whl", hash = "sha256:d5d5f5d1d88ed57f1501d3b605bee8af0f077759298e9162679616f6a5d5709b", size = 21184, upload-time = "2026-04-14T14:40:19.445Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# I have made things!

Prior to this change, I was having the `models_triple_circular_reference` test always failing when running the full test suite with `pytest -n auto` while it was passing in isolation.

The issue was with pytest-mypy-plugin that was not handling correctly new mypy cache format.
The fix is to pull https://github.com/typeddjango/pytest-mypy-plugins/pull/186

This is slightly slower but is expected since previously we were not doing any cache cleanup because of the bug.
**I can confirm that it fixes `pytest -n auto locally`**

<details><summary>Outdated investigation</summary>
<p>

Use a unique cache directory per test instead of per worker to prevent stale module entries from contaminating subsequent tests that reuse module names like "myapp".

~Marking as draft for now to check if the performance impact is ok or not~
The performance hit is too high (2x slower), I can fix the offending test by renaming the app but it seem brittle. Should something be patched in pytest-mypy-plugin @sobolevn ?
```
  ┌──────────────────────────────┬────────────────┬───────────────┬──────────────┐                                                                              
  │             Job              │ #3296 (before) │ #3299 (after) │    Change    │                                                                              
  ├──────────────────────────────┼────────────────┼───────────────┼──────────────┤                                                                              
  │ test (avg across all shards) │ ~1m55s         │ ~3m35s        │ ~1.9x slower │                   
  ├──────────────────────────────┼────────────────┼───────────────┼──────────────┤                   
  │ test-older-django (avg)      │ ~2m00s         │ ~3m41s        │ ~1.8x slower │                                                                              
  ├──────────────────────────────┼────────────────┼───────────────┼──────────────┤
```

</p>
</details> 


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
