### PR TITLE
refactor: add __all__ to main.py for explicit exports

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -53,7 +53,7 @@ from mypy_django_plugin.transformers.models import (
     set_auth_user_model_boolean_fields,
 )
 from mypy_django_plugin.transformers.request import check_querydict_is_mutable
-
+__all__ = ["plugin"]
 if TYPE_CHECKING:
     from collections.abc import Callable
 

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -53,6 +53,7 @@ from mypy_django_plugin.transformers.models import (
     set_auth_user_model_boolean_fields,
 )
 from mypy_django_plugin.transformers.request import check_querydict_is_mutable
+
 __all__ = ["plugin"]
 if TYPE_CHECKING:
     from collections.abc import Callable


### PR DESCRIPTION
# I have made things!

Added __all__ to main.py to explicitly define the public API.
This improves code maintainability and prevents namespace pollution without affecting any plugin logic.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
