### PR TITLE
refactor: use f-string in config.py

### DIFF
--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -102,7 +102,8 @@ class DjangoPluginConfig:
         self.django_settings_module = django_settings_module
 
         if not isinstance(self.django_settings_module, str):
-            toml_exit("invalid 'django_settings_module': the setting must be a string")
+            # Refactored to f-string for better readability
+            toml_exit(f"invalid '{"django_settings_module"}': the setting must be a string")
 
         self.strict_settings = config.get("strict_settings", True)
         if not isinstance(self.strict_settings, bool):

--- a/mypy_django_plugin/config.py
+++ b/mypy_django_plugin/config.py
@@ -103,7 +103,7 @@ class DjangoPluginConfig:
 
         if not isinstance(self.django_settings_module, str):
             # Refactored to f-string for better readability
-            toml_exit(f"invalid '{"django_settings_module"}': the setting must be a string")
+            toml_exit(f"invalid '{'django_settings_module'}': the setting must be a string")
 
         self.strict_settings = config.get("strict_settings", True)
         if not isinstance(self.strict_settings, bool):


### PR DESCRIPTION
# I have made things!
I have updated the django_settings_module check in config.py to use an f-string for the error message.

Why this change is made?
Just a small refactor to make the code a bit more modern and readable. I only changed this specific line and kept the other .format() calls as they are, since those use constants and I didn't want to mess with the existing test strings or the project structure.

## Related issues
Supersedes #3306

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
