### PR TITLE
Type-check (a)get_or_create and (a)update_or_create kwargs

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -175,6 +175,10 @@ class NewSemanalDjangoPlugin(Plugin):
             "filter": typecheck_filtering_method,
             "get": typecheck_filtering_method,
             "aget": typecheck_filtering_method,
+            "get_or_create": typecheck_filtering_method,
+            "aget_or_create": typecheck_filtering_method,
+            "update_or_create": typecheck_filtering_method,
+            "aupdate_or_create": typecheck_filtering_method,
             "exclude": typecheck_filtering_method,
             "prefetch_related": partial(
                 querysets.extract_prefetch_related_annotations, django_context=self.django_context

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -19,10 +19,11 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
     if django_model is None:
         return ctx.default_return_type
 
-    # Expected formal arguments for filter methods are `*args` and `**kwargs`. We'll only typecheck
-    # `**kwargs`, which means that `arg_names[1]` is what we're interested in.
-    lookup_kwargs = ctx.arg_names[1] if len(ctx.arg_names) >= 2 else []
-    provided_lookup_types = ctx.arg_types[1] if len(ctx.arg_types) >= 2 else []
+    # We only typecheck the `**kwargs` formal parameter. Python's grammar guarantees
+    # `**kwargs` is the last formal parameter when present, which holds for every
+    # method this hook is registered for (`filter`, `get_or_create`, `update_or_create`, ...).
+    lookup_kwargs = ctx.arg_names[-1]
+    provided_lookup_types = ctx.arg_types[-1]
 
     for lookup_kwarg, provided_type in zip(lookup_kwargs, provided_lookup_types, strict=False):
         if lookup_kwarg is None:

--- a/tests/typecheck/managers/querysets/test_get_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_get_or_create.yml
@@ -1,0 +1,34 @@
+-   case: get_or_create_typechecks_kwargs
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import MyModel
+
+        # Return type is preserved
+        reveal_type(MyModel.objects.get_or_create(num=1))  # N: Revealed type is "tuple[myapp.models.MyModel, bool]"
+
+        # Valid field kwarg and lookup expression
+        MyModel.objects.get_or_create(num=1)
+        MyModel.objects.get_or_create(num__gte=1)
+
+        # `defaults` alongside lookup kwargs
+        MyModel.objects.get_or_create(num=1, defaults={"num": 2})
+
+        # Unknown field is rejected
+        MyModel.objects.get_or_create(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id, num  [misc]
+
+        # Invalid type for a known field is rejected
+        MyModel.objects.get_or_create(num=MyModel())  # E: Incompatible type for lookup 'num': (got "MyModel", expected "str | int")  [misc]
+
+        # Async variant shares the same validation
+        async def main() -> None:
+            await MyModel.objects.aget_or_create(num=1)
+            await MyModel.objects.aget_or_create(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id, num  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    num = models.IntegerField()

--- a/tests/typecheck/managers/querysets/test_update_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_update_or_create.yml
@@ -1,0 +1,32 @@
+-   case: update_or_create_typechecks_kwargs
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import MyModel
+
+        # Return type is preserved
+        reveal_type(MyModel.objects.update_or_create(num=1))  # N: Revealed type is "tuple[myapp.models.MyModel, bool]"
+
+        # Valid field kwarg, lookup expression, defaults and create_defaults
+        MyModel.objects.update_or_create(num=1)
+        MyModel.objects.update_or_create(num__gte=1)
+        MyModel.objects.update_or_create(num=1, defaults={"num": 2}, create_defaults={"num": 3})
+
+        # Unknown field is rejected
+        MyModel.objects.update_or_create(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id, num  [misc]
+
+        # Invalid type for a known field is rejected
+        MyModel.objects.update_or_create(num=MyModel())  # E: Incompatible type for lookup 'num': (got "MyModel", expected "str | int")  [misc]
+
+        # Async variant shares the same validation
+        async def main() -> None:
+            await MyModel.objects.aupdate_or_create(num=1)
+            await MyModel.objects.aupdate_or_create(unknown_field=True)  # E: Cannot resolve keyword 'unknown_field' into field. Choices are: id, num  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    num = models.IntegerField()


### PR DESCRIPTION
Wire these methods into the existing filter-style typecheck hook so their lookup kwargs are validated against model fields.

Refs https://github.com/typeddjango/django-stubs/issues/1307

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
