### PR TITLE
Make Func generic over output_field

### DIFF
--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -187,7 +187,7 @@ class OuterRef(F):
     def __init__(self, name: str | OuterRef) -> None: ...
     def relabeled_clone(self, relabels: Any) -> Self: ...
 
-class Func(SQLiteNumericMixin, Expression):
+class Func(SQLiteNumericMixin, Expression, Generic[_OutputField]):
     @cached_property
     @override
     def allowed_default(self) -> bool: ...  # type: ignore[override]
@@ -197,7 +197,7 @@ class Func(SQLiteNumericMixin, Expression):
     arity: int | None
     source_expressions: list[Expression]
     extra: dict[Any, Any]
-    def __init__(self, *expressions: Any, output_field: Field | None = None, **extra: Any) -> None: ...
+    def __init__(self, *expressions: Any, output_field: _OutputField | None = None, **extra: Any) -> None: ...
     @override
     def as_sql(
         self,

--- a/django-stubs/db/models/functions/text.pyi
+++ b/django-stubs/db/models/functions/text.pyi
@@ -3,7 +3,7 @@ from typing import Any, ClassVar
 from django.db import models
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Func, Transform
-from django.db.models.expressions import Combinable, Expression, Value
+from django.db.models.expressions import Combinable, Expression, Value, _OutputField
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import override
 
@@ -36,9 +36,16 @@ class ConcatPair(Func):
 class Concat(Func):
     def __init__(self, *expressions: Any, **extra: Any) -> None: ...
 
-class Left(Func):
+class Left(Func[_OutputField]):
     output_field: ClassVar[models.CharField]
-    def __init__(self, expression: Combinable | str, length: Expression | int, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: Combinable | str,
+        length: Expression | int,
+        *,
+        output_field: _OutputField | None = None,
+        **extra: Any,
+    ) -> None: ...
     def get_substr(self) -> Substr: ...
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
@@ -72,7 +79,7 @@ class Replace(Func):
 class Reverse(Transform):
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 
-class Right(Left):
+class Right(Left[_OutputField]):
     @override
     def get_substr(self) -> Substr: ...
 
@@ -93,10 +100,16 @@ class StrIndex(Func):
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any
     ) -> _AsSqlType: ...
 
-class Substr(Func):
+class Substr(Func[_OutputField]):
     output_field: ClassVar[models.CharField]
     def __init__(
-        self, expression: Combinable | str, pos: Expression | int, length: Expression | int | None = None, **extra: Any
+        self,
+        expression: Combinable | str,
+        pos: Expression | int,
+        length: Expression | int | None = None,
+        *,
+        output_field: _OutputField | None = None,
+        **extra: Any,
     ) -> None: ...
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
 

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -11,7 +11,7 @@ from django.contrib.sitemaps import Sitemap
 from django.contrib.syndication.views import Feed
 from django.core.files.utils import FileProxyMixin
 from django.core.paginator import Paginator
-from django.db.models.expressions import ExpressionWrapper, Subquery
+from django.db.models.expressions import ExpressionWrapper, Func, Subquery
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey
 from django.db.models.fields.related_descriptors import (
@@ -85,6 +85,7 @@ _need_generic: list[MPGeneric[Any]] = [
     MPGeneric(Lookup),
     MPGeneric(BaseConnectionHandler),
     MPGeneric(ExpressionWrapper),
+    MPGeneric(Func),
     MPGeneric(Subquery),
     MPGeneric(ReverseManyToOneDescriptor),
     MPGeneric(ModelIterable),

--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -57,6 +57,7 @@ QUERYDICT_CLASS_FULLNAME = "django.http.request.QueryDict"
 
 COMBINABLE_EXPRESSION_FULLNAME = "django.db.models.expressions.Combinable"
 F_EXPRESSION_FULLNAME = "django.db.models.expressions.F"
+FUNC_EXPRESSION_FULLNAME = "django.db.models.expressions.Func"
 
 ANY_ATTR_ALLOWED_CLASS_FULLNAME = "django_stubs_ext.AnyAttrAllowed"
 TYPED_MODEL_META_FULLNAME = "django_stubs_ext.db.models.TypedModelMeta"

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -158,6 +158,9 @@ class NewSemanalDjangoPlugin(Plugin):
             if info.has_base(fullnames.PREFETCH_CLASS_FULLNAME):
                 return partial(querysets.specialize_prefetch_type, django_context=self.django_context)
 
+            if info.has_base(fullnames.FUNC_EXPRESSION_FULLNAME):
+                return querysets.reparameterize_func_output_field
+
         return None
 
     @cached_property

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -244,16 +244,58 @@ def gather_kwargs(ctx: MethodContext) -> dict[str, MypyType] | None:
     return kwargs
 
 
+def reparameterize_func_output_field(ctx: FunctionContext) -> MypyType:
+    """Reparameterize Func[_OutputField] from the output_field argument.
+
+    When a generic Func subclass like Substr is nested directly inside a call with
+    **kwargs: Any (e.g., QuerySet.annotate()), mypy infers _OutputField=Any because
+    the target type is unconstrained. This hook corrects the return type by extracting
+    the actual output_field argument type.
+    """
+    default = get_proper_type(ctx.default_return_type)
+    if not isinstance(default, Instance) or not default.args:
+        return ctx.default_return_type
+
+    # Only act when the generic arg is Any (i.e., mypy didn't infer it)
+    if not isinstance(get_proper_type(default.args[0]), AnyType):
+        return ctx.default_return_type
+
+    # Use the output_field argument type to fill the generic param
+    output_field_type = helpers.get_call_argument_type_by_name(ctx, "output_field")
+    if output_field_type is not None:
+        field_type = get_proper_type(output_field_type)
+        if isinstance(field_type, Instance):
+            return default.copy_modified(args=[field_type])
+
+    return ctx.default_return_type
+
+
 def _resolve_output_field_type(expr_type: MypyType) -> MypyType | None:
     """Try to resolve the Python type for an expression's output_field.
 
-    Handles both ClassVar declarations (Var nodes) and @property/@cached_property
-    definitions (Decorator nodes). Returns None if the type can't be statically resolved.
+    Handles multiple resolution strategies, in order of priority:
+    1. Generic type args on the expression (e.g. Substr(output_field=BinaryField()) → bytes)
+    2. ClassVar output_field declarations (e.g. Count.output_field: ClassVar[IntegerField] → int)
+    3. @property/@cached_property output_field definitions (e.g. ArrayAgg → list[Any])
+
+    Generic args take priority so that expressions like Substr(output_field=BinaryField())
+    can override the default ClassVar[CharField] when a specific output field type is provided.
     """
     proper = get_proper_type(expr_type)
     if not isinstance(proper, Instance):
         return None
 
+    # First, check generic type args for Field subclasses.
+    # This supports the Generic[_OutputField] pattern (e.g., Subquery[IntegerField], Substr[BinaryField]).
+    # Generic args take priority over ClassVar so that explicit type params override defaults.
+    for arg in proper.args:
+        arg_proper = get_proper_type(arg)
+        if isinstance(arg_proper, Instance) and arg_proper.type.has_base(fullnames.FIELD_FULLNAME):
+            type_args = helpers.get_field_type_args(arg_proper)
+            if type_args is not None and not isinstance(type_args.get, AnyType):
+                return type_args.get
+
+    # Then check static output_field declarations (ClassVar or @property/@cached_property).
     output_field_sym = proper.type.get("output_field")
     if output_field_sym is None or output_field_sym.node is None:
         return None
@@ -272,15 +314,6 @@ def _resolve_output_field_type(expr_type: MypyType) -> MypyType | None:
         result = helpers.get_private_descriptor_type(field_type.type, "_pyi_private_get_type", is_nullable=False)
         if not isinstance(get_proper_type(result), AnyType):
             return result
-
-    # Fallback: extract _GT from generic type args that are Field subclasses.
-    # This preserves nullability from null=True (e.g., IntegerField(null=True) → int | None).
-    for arg in proper.args:
-        arg_proper = get_proper_type(arg)
-        if isinstance(arg_proper, Instance) and arg_proper.type.has_base(fullnames.FIELD_FULLNAME):
-            type_args = helpers.get_field_type_args(arg_proper)
-            if type_args is not None and not isinstance(type_args.get, AnyType):
-                return type_args.get
 
     return None
 

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -686,6 +686,42 @@
                 class User(models.Model):
                     username = models.CharField(max_length=100)
 
+-   case: annotate_resolves_output_field_from_func_generic
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import User
+        from django.db.models import BinaryField
+        from django.db.models.functions import Substr, Left, Right
+
+        # Substr with explicit output_field=BinaryField() via variable
+        sub = Substr("username", 1, 100, output_field=BinaryField())
+        val = User.objects.annotate(preview=sub).get().preview
+        reveal_type(val)  # N: Revealed type is "bytes | memoryview[int]"
+
+        # Substr with explicit output_field=BinaryField() inlined
+        val2 = User.objects.annotate(preview=Substr("username", 1, 100, output_field=BinaryField())).get().preview
+        reveal_type(val2)  # N: Revealed type is "bytes | memoryview[int]"
+
+        # Left with explicit output_field=BinaryField()
+        left_expr = Left("username", 5, output_field=BinaryField())
+        left_val = User.objects.annotate(prefix=left_expr).get().prefix
+        reveal_type(left_val)  # N: Revealed type is "bytes | memoryview[int]"
+
+        # Right with explicit output_field=BinaryField()
+        right_expr = Right("username", 5, output_field=BinaryField())
+        right_val = User.objects.annotate(suffix=right_expr).get().suffix
+        reveal_type(right_val)  # N: Revealed type is "bytes | memoryview[int]"
+
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class User(models.Model):
+                    username = models.CharField(max_length=100)
+
 - case: test_values_and_values_list_on_with_annotations_queryset
   main: |
     from typing_extensions import TypedDict, reveal_type


### PR DESCRIPTION
Substr, Left, and Right declare `output_field = CharField()` but return bytes when applied to a `BinaryField`. This change makes Func generic over _OutputField so that passing `output_field=BinaryField()` correctly infers the annotation type as bytes instead of str.

Fixes https://github.com/typeddjango/django-stubs/issues/3310 as long as users explicitly declare `output_field=BinaryField()` in the Substr call.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
