### PR TITLE
Add more test field nullable

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -42,6 +42,7 @@ from mypy_django_plugin.transformers.functional import resolve_str_promise_attri
 from mypy_django_plugin.transformers.managers import (
     add_as_manager_to_queryset_class,
     create_new_manager_class_from_from_queryset_method,
+    reparametrize_any_field_hook,
     reparametrize_any_manager_hook,
     reparametrize_any_queryset_hook,
     resolve_manager_method,
@@ -250,6 +251,8 @@ class NewSemanalDjangoPlugin(Plugin):
             return reparametrize_any_manager_hook
         if info and info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
             return reparametrize_any_queryset_hook
+        if info and info.has_base(fullnames.FIELD_FULLNAME):
+            return reparametrize_any_field_hook
         return None
 
     @override

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -613,6 +613,10 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
     Note that this does not happen if mypy is run with disallow_any_generics = True,
     as not specifying the generic type is then considered an error.
     """
+    if ctx.api.options.disallow_any_generics:
+        # Let mypy's own "missing type arguments" error stand rather than silently reparametrize.
+        return
+
     class_info = ctx.api.lookup_fully_qualified_or_none(ctx.cls.fullname)
     if class_info is None or class_info.node is None:
         return
@@ -626,7 +630,7 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
         (base for base in class_info.node.bases if base.type.has_base(base_class_fullname)),
         None,
     )
-    if parent_class is None or len(parent_class.args) < 1:
+    if parent_class is None or not parent_class.args:
         return
 
     model_param = get_proper_type(parent_class.args[0])
@@ -685,3 +689,21 @@ def reparametrize_any_manager_hook(ctx: ClassDefContext) -> None:
     as not specifying the generic type is then considered an error.
     """
     reparametrize_generic_class(ctx, fullnames.BASE_MANAGER_CLASS_FULLNAME)
+
+
+def reparametrize_any_field_hook(ctx: ClassDefContext) -> None:
+    """
+    Add implicit generics to Field subclasses that omit the parent's TypeVars.
+
+    Eg.
+
+        class HTMLField(models.TextField): ...
+
+    is interpreted as:
+
+        class HTMLField(models.TextField[_ST_Text, _GT_Text]): ...
+
+    Without this, mypy treats `HTMLField` as non-Generic and the set/get args
+    assigned by the field function hook don't propagate through `__get__`.
+    """
+    reparametrize_generic_class(ctx, fullnames.FIELD_FULLNAME)

--- a/tests/typecheck/fields/test_custom_fields.yml
+++ b/tests/typecheck/fields/test_custom_fields.yml
@@ -22,7 +22,7 @@
 
         reveal_type(user.my_custom_field_any1)  # N: Revealed type is "Any"
         reveal_type(user.my_custom_field_any2)  # N: Revealed type is "Any"
-        reveal_type(user.my_custom_field_any3)  # N: Revealed type is "Any"
+        reveal_type(user.my_custom_field_any3)  # N: Revealed type is "Any | None"
         reveal_type(user.my_custom_field_any4)  # N: Revealed type is "Any"
     monkeypatch: true
     installed_apps:

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -105,3 +105,70 @@
                 from django.db import models
                 class Inventory(models.Model):
                     parent = models.ForeignKey('self', on_delete=models.SET_NULL, null=True)
+
+-   case: nullable_subclass_inherits_null_overload
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import Article
+
+        reveal_type(Article().body)            # N: Revealed type is "str"
+        reveal_type(Article().body_nullable)   # N: Revealed type is "str | None"
+        reveal_type(Article().count)           # N: Revealed type is "int"
+        reveal_type(Article().count_nullable)  # N: Revealed type is "int | None"
+    monkeypatch: true
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import TypeVar
+                from django.db import models
+
+                _ST = TypeVar("_ST", contravariant=True)
+                _GT = TypeVar("_GT", covariant=True)
+
+                class HtmlField(models.TextField[_ST, _GT]): ...
+                class IntWrap(models.IntegerField[_ST, _GT]): ...
+
+                class Article(models.Model):
+                    body = HtmlField()
+                    body_nullable = HtmlField(null=True)
+                    count = IntWrap()
+                    count_nullable = IntWrap(null=True)
+
+-   case: direct_field_null_true_does_not_trigger_nullability_check
+    main: |
+        from typing_extensions import reveal_type
+        from django.db import models
+        from django.db.models import OuterRef, Subquery
+        from myapp.models import Article
+
+        field = models.IntegerField(null=True)
+        reveal_type(field)  # N: Revealed type is "django.db.models.fields.IntegerField[float | int | str | django.db.models.expressions.Combinable | None, int | None]"
+        Article.objects.annotate(
+            other_id=Subquery(
+                Article.objects.filter(id=OuterRef("id")).values_list("id", flat=True)[:1],
+                output_field=models.IntegerField(null=True),
+            )
+        )
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class Article(models.Model):
+                    pass
+
+-   case: field_null_true_expression_does_not_trigger_nullability_check
+    main: |
+        from typing_extensions import reveal_type
+        from django.db import models
+
+        def take_field(f: models.Field) -> None:
+            return None
+
+        take_field(models.IntegerField(null=True))
+        take_field(models.IntegerField(null=False))

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -172,3 +172,26 @@
 
         take_field(models.IntegerField(null=True))
         take_field(models.IntegerField(null=False))
+
+-   case: nullable_field_subclass_without_explicit_type_vars
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import Article
+        reveal_type(Article().body)  # N: Revealed type is "str"
+        reveal_type(Article().body_nullable)  # N: Revealed type is "str | None"
+        reveal_type(Article().count_nullable)  # N: Revealed type is "int | None"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class HTMLField(models.TextField): ...
+                class IntWrap(models.IntegerField): ...
+
+                class Article(models.Model):
+                    body = HTMLField()
+                    body_nullable = HTMLField(null=True)
+                    count_nullable = IntWrap(null=True)


### PR DESCRIPTION
# I have made things!

This is very similar to what we do for queryset/manager. 

Without it, this test case would reveal `Any` everywhere

```yml
-   case: nullable_field_subclass_without_explicit_type_vars
    main: |
        from typing_extensions import reveal_type
        from myapp.models import Article
        reveal_type(Article().body)  # N: Revealed type is "str"
        reveal_type(Article().body_nullable)  # N: Revealed type is "str | None"
        reveal_type(Article().count_nullable)  # N: Revealed type is "int | None"
    installed_apps:
        - myapp
    files:
        -   path: myapp/__init__.py
        -   path: myapp/models.py
            content: |
                from django.db import models
                class HTMLField(models.TextField): ...
                class IntWrap(models.IntegerField): ...
                class Article(models.Model):
                    body = HTMLField()
                    body_nullable = HTMLField(null=True)
                    count_nullable = IntWrap(null=True)
``` 




## Related issues

Related to #3317 which made me discover this issue

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
