### PR TITLE
Type-check defaults and create_defaults dict literals

### DIFF
--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mypy.nodes import DictExpr, StrExpr
+from mypy.nodes import ARG_NAMED, DictExpr, StrExpr
 from mypy.types import AnyType, Instance, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
@@ -81,6 +81,8 @@ def _typecheck_defaults_kwarg(
 
     for idx in defaults_positions:
         if not ctx.args[idx]:
+            continue
+        if ctx.arg_kinds[idx][0] != ARG_NAMED:
             continue
         dict_expr = ctx.args[idx][0]
         if not isinstance(dict_expr, DictExpr):

--- a/mypy_django_plugin/transformers/orm_lookups.py
+++ b/mypy_django_plugin/transformers/orm_lookups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mypy.nodes import DictExpr, StrExpr
 from mypy.types import AnyType, Instance, ProperType, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
@@ -54,7 +55,55 @@ def typecheck_queryset_filter(ctx: MethodContext, django_context: DjangoContext)
             error_message=f"Incompatible type for lookup {lookup_kwarg!r}:",
         )
 
+    _typecheck_defaults_kwarg(ctx, django_model, django_context)
+
     return ctx.default_return_type
+
+
+def _typecheck_defaults_kwarg(
+    ctx: MethodContext, django_model: helpers.DjangoModel, django_context: DjangoContext
+) -> None:
+    """
+    Validate `defaults=` and `create_defaults=` dict literals passed to
+    `get_or_create` / `update_or_create` against the model's field setter
+    types. Only literal `DictExpr` arguments with string-literal keys are
+    checked; any other shape is silently skipped to avoid false positives.
+    """
+    defaults_positions = [
+        idx for idx, name in enumerate(ctx.callee_arg_names) if name in ("defaults", "create_defaults")
+    ]
+    if not defaults_positions:
+        return
+
+    api = helpers.get_typechecker_api(ctx)
+    expected_types = django_context.get_expected_types(api, django_model.cls, method="create")
+    model_name = django_model.cls.__name__
+
+    for idx in defaults_positions:
+        if not ctx.args[idx]:
+            continue
+        dict_expr = ctx.args[idx][0]
+        if not isinstance(dict_expr, DictExpr):
+            continue
+
+        for key_expr, value_expr in dict_expr.items:
+            if not isinstance(key_expr, StrExpr):
+                continue
+            key_name = key_expr.value
+            if key_name not in expected_types:
+                ctx.api.fail(
+                    f'Unexpected attribute "{key_name}" for model "{model_name}"',
+                    key_expr,
+                )
+                continue
+
+            actual_type = api.get_expression_type(value_expr)
+            helpers.check_types_compatible(
+                ctx,
+                expected_type=expected_types[key_name],
+                actual_type=actual_type,
+                error_message=f'Incompatible type for "{key_name}" of "{model_name}"',
+            )
 
 
 def resolve_combinable_type(combinable_type: Instance, django_context: DjangoContext) -> ProperType:

--- a/tests/typecheck/managers/querysets/test_get_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_get_or_create.yml
@@ -32,3 +32,34 @@
                 from django.db import models
                 class MyModel(models.Model):
                     num = models.IntegerField()
+
+-   case: get_or_create_typechecks_defaults
+    main: |
+        from myapp.models import MyModel
+
+        # Unknown key in defaults is rejected
+        MyModel.objects.get_or_create(num=1, defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+
+        # Incompatible value type in defaults is rejected
+        MyModel.objects.get_or_create(num=1, defaults={"num": MyModel()})  # E: Incompatible type for "num" of "MyModel" (got "MyModel", expected "float | int | str | Combinable")  [misc]
+
+        # Valid defaults: no errors
+        MyModel.objects.get_or_create(num=1, defaults={"num": 2, "name": "hello"})
+
+        # Non-literal defaults variable is silently accepted (no false positives)
+        some_defaults: dict[str, object] = {"unknown_field": True}
+        MyModel.objects.get_or_create(num=1, defaults=some_defaults)
+
+        # Async variant shares the same validation
+        async def main() -> None:
+            await MyModel.objects.aget_or_create(num=1, defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    num = models.IntegerField()
+                    name = models.CharField(max_length=100)

--- a/tests/typecheck/managers/querysets/test_get_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_get_or_create.yml
@@ -58,6 +58,11 @@
         # `defaults=` dict literal is validated.
         MyModel.objects.get_or_create(num=1, **{"defaults": {"unknown_field": True}})
 
+        # `**other_fields` inside a `defaults=` dict literal: literal keys are
+        # still validated, the unpacked portion is skipped.
+        other_fields = {"num": 2}
+        MyModel.objects.get_or_create(num=1, defaults={"unknown_field": True, **other_fields})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+
         # Async variant shares the same validation
         async def main() -> None:
             await MyModel.objects.aget_or_create(num=1, defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]

--- a/tests/typecheck/managers/querysets/test_get_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_get_or_create.yml
@@ -50,6 +50,14 @@
         some_defaults: dict[str, object] = {"unknown_field": True}
         MyModel.objects.get_or_create(num=1, defaults=some_defaults)
 
+        # `**kwargs` variable unpacking is silently accepted
+        kwargs = {"defaults": {"unknown_field": True}}
+        MyModel.objects.get_or_create(num=1, **kwargs)
+
+        # `**dict_literal` unpacking is also silently accepted; only a direct
+        # `defaults=` dict literal is validated.
+        MyModel.objects.get_or_create(num=1, **{"defaults": {"unknown_field": True}})
+
         # Async variant shares the same validation
         async def main() -> None:
             await MyModel.objects.aget_or_create(num=1, defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]

--- a/tests/typecheck/managers/querysets/test_update_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_update_or_create.yml
@@ -60,6 +60,20 @@
             create_defaults={"unknown_in_create_defaults": True},  # E: Unexpected attribute "unknown_in_create_defaults" for model "MyModel"  [misc]
         )
 
+        # `**kwargs` variable unpacking is silently accepted
+        kwargs = {
+            "defaults": {"unknown_field": True},
+            "create_defaults": {"unknown_field": True},
+        }
+        MyModel.objects.update_or_create(num=1, **kwargs)
+
+        # `**dict_literal` unpacking is also silently accepted; only a direct
+        # `defaults=` / `create_defaults=` dict literal is validated.
+        MyModel.objects.update_or_create(
+            num=1,
+            **{"defaults": {"unknown_field": True}, "create_defaults": {"unknown_field": True}},
+        )
+
         # Async variant shares the same validation
         async def main() -> None:
             await MyModel.objects.aupdate_or_create(

--- a/tests/typecheck/managers/querysets/test_update_or_create.yml
+++ b/tests/typecheck/managers/querysets/test_update_or_create.yml
@@ -30,3 +30,49 @@
                 from django.db import models
                 class MyModel(models.Model):
                     num = models.IntegerField()
+
+-   case: update_or_create_typechecks_defaults
+    main: |
+        from myapp.models import MyModel
+
+        # Unknown key in defaults is rejected
+        MyModel.objects.update_or_create(num=1, defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+
+        # Incompatible value type in defaults is rejected
+        MyModel.objects.update_or_create(num=1, defaults={"num": MyModel()})  # E: Incompatible type for "num" of "MyModel" (got "MyModel", expected "float | int | str | Combinable")  [misc]
+
+        # Valid defaults: no errors
+        MyModel.objects.update_or_create(num=1, defaults={"num": 2, "name": "hello"})
+
+        # Unknown key in create_defaults is rejected
+        MyModel.objects.update_or_create(num=1, create_defaults={"unknown_field": True})  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+
+        # Incompatible value type in create_defaults is rejected
+        MyModel.objects.update_or_create(num=1, create_defaults={"num": MyModel()})  # E: Incompatible type for "num" of "MyModel" (got "MyModel", expected "float | int | str | Combinable")  [misc]
+
+        # Valid create_defaults: no errors
+        MyModel.objects.update_or_create(num=1, create_defaults={"num": 3, "name": "hi"})
+
+        # Both defaults and create_defaults validated in a single call
+        MyModel.objects.update_or_create(
+            num=1,
+            defaults={"unknown_in_defaults": True},  # E: Unexpected attribute "unknown_in_defaults" for model "MyModel"  [misc]
+            create_defaults={"unknown_in_create_defaults": True},  # E: Unexpected attribute "unknown_in_create_defaults" for model "MyModel"  [misc]
+        )
+
+        # Async variant shares the same validation
+        async def main() -> None:
+            await MyModel.objects.aupdate_or_create(
+                num=1,
+                defaults={"unknown_field": True},  # E: Unexpected attribute "unknown_field" for model "MyModel"  [misc]
+            )
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class MyModel(models.Model):
+                    num = models.IntegerField()
+                    name = models.CharField(max_length=100)


### PR DESCRIPTION
Extends the existing kwargs validation for (a)get_or_create and (a)update_or_create to check values passed via defaults= and create_defaults=. Unknown keys and incompatible value types are reported against the model's create setter types.

Only literal DictExpr arguments with string-literal keys are checked; any other shape (e.g. a variable of type dict[str, object]) is skipped to avoid false positives.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
