### PR TITLE
Fix annotate leak across functions

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -606,9 +606,24 @@ def add_as_manager_to_queryset_class(ctx: ClassDefContext) -> None:
     )
 
 
-def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) -> None:
+def _is_omitted_generic(arg: MypyType) -> bool:
+    """True if ``arg`` is the ``Any`` mypy substitutes for an unparametrized generic."""
+    proper_arg = get_proper_type(arg)
+    return isinstance(proper_arg, AnyType) and proper_arg.type_of_any is TypeOfAny.from_omitted_generics
+
+
+def reparametrize_generic_class(
+    ctx: ClassDefContext,
+    base_class_fullname: str,
+    *,
+    bind_explicit_args: bool = False,
+) -> None:
     """
     Add implicit generics to classes that are defined without generic.
+
+    When ``bind_explicit_args`` is True, also reparametrize partially or
+    fully-explicit parametrizations by binding each explicit arg as both
+    the bound and the PEP 696 default of a synthesized covariant TypeVar.
 
     Note that this does not happen if mypy is run with disallow_any_generics = True,
     as not specifying the generic type is then considered an error.
@@ -633,10 +648,31 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
     if parent_class is None or not parent_class.args:
         return
 
-    type_vars = [
-        type_var.copy_modified(id=type_var.id, default=parent_type_var)
-        for type_var, parent_type_var in zip(parent_class.type.defn.type_vars, parent_class.args, strict=True)
-    ]
+    # Bind explicit args only when the direct parent is the canonical base class
+    is_direct_parent = parent_class.type.fullname == base_class_fullname
+    if not (bind_explicit_args and is_direct_parent):
+        if not _is_omitted_generic(parent_class.args[0]):
+            return
+        type_vars = list(parent_class.type.defn.type_vars)
+    else:
+        type_vars = []
+        for type_var, parent_type_var in zip(parent_class.type.defn.type_vars, parent_class.args, strict=True):
+            if _is_omitted_generic(parent_type_var):
+                # Arg was omitted -- reuse the parent's TypeVar so its existing
+                # PEP 696 default (e.g. ``_Row = TypeVar(default=_Model)``) is preserved.
+                type_vars.append(type_var)
+            else:
+                # Arg was supplied explicitly -- synthesize a TypeVar bounded by the
+                # user's arg so the subclass stays effectively concrete in user-facing
+                # contexts (defaults + bound + covariance) while still being generic
+                # enough for the plugin to flow annotation row types through.
+                type_vars.append(
+                    type_var.copy_modified(
+                        id=type_var.id,
+                        upper_bound=parent_type_var,
+                        default=parent_type_var,
+                    )
+                )
 
     # If we end up with placeholders we need to defer so the placeholders are
     # resolved in a future iteration
@@ -654,6 +690,7 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
 def reparametrize_any_queryset_hook(ctx: ClassDefContext) -> None:
     """
     Add implicit generics to QuerySet subclasses that are defined without generic.
+    This is required for `.annotate` / `.values` call to update the typevars accordingly.
 
     Eg.
 
@@ -665,10 +702,20 @@ def reparametrize_any_queryset_hook(ctx: ClassDefContext) -> None:
         _Row = TypeVar('_Row', covariant=True, default=_Model)
         class MyQuerySet(models.QuerySet[_Model, _Row]): ...
 
+    And
+
+        class BookQuerySet(models.QuerySet["Book"]): ...
+
+    is interpreted as:
+
+        _Model = TypeVar('_Model', bound=Book, covariant=True, default=Book)
+        _Row = TypeVar('_Row', bound=Book, covariant=True, default=Book)
+        class BookQuerySet(models.QuerySet[_Model, _Row]): ...
+
     Note that this does not happen if mypy is run with disallow_any_generics = True,
     as not specifying the generic type is then considered an error.
     """
-    reparametrize_generic_class(ctx, fullnames.QUERYSET_CLASS_FULLNAME)
+    reparametrize_generic_class(ctx, fullnames.QUERYSET_CLASS_FULLNAME, bind_explicit_args=True)
 
 
 def reparametrize_any_manager_hook(ctx: ClassDefContext) -> None:

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -633,11 +633,10 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
     if parent_class is None or not parent_class.args:
         return
 
-    model_param = get_proper_type(parent_class.args[0])
-    if not isinstance(model_param, AnyType) or model_param.type_of_any is not TypeOfAny.from_omitted_generics:
-        return
-
-    type_vars = tuple(parent_class.type.defn.type_vars)
+    type_vars = [
+        type_var.copy_modified(id=type_var.id, default=parent_type_var)
+        for type_var, parent_type_var in zip(parent_class.type.defn.type_vars, parent_class.args, strict=True)
+    ]
 
     # If we end up with placeholders we need to defer so the placeholders are
     # resolved in a future iteration
@@ -647,8 +646,8 @@ def reparametrize_generic_class(ctx: ClassDefContext, base_class_fullname: str) 
         else:
             return
 
-    parent_class.args = type_vars
-    class_info.node.defn.type_vars = list(type_vars)
+    parent_class.args = tuple(type_vars)
+    class_info.node.defn.type_vars = type_vars
     class_info.node.add_type_vars()
 
 

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -207,7 +207,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
 
     if flat and named:
         ctx.api.fail("'flat' and 'named' can't be used together", ctx.context)
-        return reparametrize_queryset(default_return_type, [django_model.typ, AnyType(TypeOfAny.from_error)])
+        return default_return_type.copy_modified(args=[django_model.typ, AnyType(TypeOfAny.from_error)])
 
     annotation_types = _get_annotation_field_types(django_model.typ) if django_model.is_annotated else {}
     row_type = get_values_list_row_type(
@@ -218,7 +218,7 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
         flat=flat,
         named=named,
     )
-    ret = reparametrize_queryset(default_return_type, [django_model.typ, row_type])
+    ret = default_return_type.copy_modified(args=[django_model.typ, row_type])
     if not named and (field_lookups := resolve_field_lookups(ctx.args[0], django_context)):
         # For non-named values_list, the row type does not encode column names.
         # Attach selected field names to the returned QuerySet instance so that
@@ -363,23 +363,6 @@ def gather_expression_types(ctx: MethodContext) -> dict[str, MypyType]:
     return result
 
 
-def reparametrize_queryset(instance: Instance, args: list[MypyType]) -> Instance:
-    """Reparametrize a QuerySet instance with new type arguments.
-
-    When the instance's type is generic, the args are applied directly.
-    Otherwise, walks the base class hierarchy to find the closest generic
-    QuerySet ancestor and applies args to that instead.
-    """
-    if instance.type.is_generic():
-        return instance.copy_modified(args=args)
-
-    for i, base in enumerate(instance.type.bases):
-        if base.type.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
-            instance.type.bases[i] = base.copy_modified(args=args)
-
-    return instance
-
-
 def _extract_model_type_var_upper_bound(ctx: MethodContext) -> Instance | None:
     """When the queryset's model type arg is a TypeVar bounded by a Model, return the upper bound."""
     if not isinstance(ctx.type, Instance):
@@ -411,7 +394,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
                 if expression_types:
                     fields_dict = helpers.make_typeddict(api, expression_types)
                     upper_annotated = get_annotated_type(api, upper_bound, fields_dict=fields_dict)
-                    return reparametrize_queryset(default_return_type, [upper_annotated, upper_annotated])
+                    return default_return_type.copy_modified(args=[upper_annotated, upper_annotated])
         return AnyType(TypeOfAny.from_omitted_generics)
 
     default_return_type = get_proper_type(ctx.default_return_type)
@@ -458,7 +441,7 @@ def extract_proper_type_queryset_annotate(ctx: MethodContext, django_context: Dj
             row_type = annotated_type
     else:
         row_type = annotated_type
-    return reparametrize_queryset(default_return_type, [annotated_type, row_type])
+    return default_return_type.copy_modified(args=[annotated_type, row_type])
 
 
 def merge_annotations_from_custom_method(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
@@ -484,7 +467,7 @@ def merge_annotations_from_custom_method(ctx: MethodContext, django_context: Dja
 
     api = helpers.get_typechecker_api(ctx)
     annotated_type = get_annotated_type(api, django_model.typ, fields_dict=new_td)
-    return reparametrize_queryset(default_return_type, [annotated_type, annotated_type])
+    return default_return_type.copy_modified(args=[annotated_type, annotated_type])
 
 
 def resolve_field_lookups(lookup_exprs: Sequence[Expression], django_context: DjangoContext) -> list[str] | None:
@@ -552,14 +535,14 @@ def extract_proper_type_queryset_values(ctx: MethodContext, django_context: Djan
             if django_model.is_annotated:
                 column_types[field_lookup] = AnyType(TypeOfAny.from_omitted_generics)
             else:
-                return reparametrize_queryset(default_return_type, [django_model.typ, AnyType(TypeOfAny.from_error)])
+                return default_return_type.copy_modified(args=[django_model.typ, AnyType(TypeOfAny.from_error)])
         else:
             column_types[field_lookup] = field_lookup_type
 
     # Collect `**expressions` types -- `.values(lower_name=Lower("name"), foo=F("name"))`
     column_types.update(gather_expression_types(ctx))
     row_type = helpers.make_typeddict(ctx.api, column_types)
-    return reparametrize_queryset(default_return_type, [django_model.typ, row_type])
+    return default_return_type.copy_modified(args=[django_model.typ, row_type])
 
 
 def _infer_prefetch_queryset_type(queryset_expr: Expression, api: TypeChecker) -> Instance | None:
@@ -956,7 +939,7 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     else:
         row_type = annotated_model
 
-    return reparametrize_queryset(default_return_type, [annotated_model, row_type])
+    return default_return_type.copy_modified(args=[annotated_model, row_type])
 
 
 def _try_get_field(

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -906,15 +906,15 @@
         from myapp.models.store import Store
         from myapp.models.user import User
         reveal_type(Store().purchases)  # N: Revealed type is "myapp.models.purchase.Purchase_RelatedManager"
-        reveal_type(Store().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
-        reveal_type(Store().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(Store().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
+        reveal_type(Store().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
         reveal_type(Store().purchases.get())  # N: Revealed type is "myapp.models.purchase.Purchase"
-        reveal_type(Store().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(Store().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
         reveal_type(User().purchases)  # N: Revealed type is "myapp.models.purchase.Purchase_RelatedManager"
-        reveal_type(User().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
-        reveal_type(User().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(User().purchases.queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
+        reveal_type(User().purchases.filter())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
         reveal_type(User().purchases.get())  # N: Revealed type is "myapp.models.purchase.Purchase"
-        reveal_type(User().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet"
+        reveal_type(User().purchases.filter().queryset_method())  # N: Revealed type is "myapp.models.querysets.PurchaseQuerySet[myapp.models.purchase.Purchase, myapp.models.purchase.Purchase]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -799,7 +799,7 @@
     from django.db.models import Value
 
     queryset = SomeQuerySet().annotate(hello=Value(True)).filter(is_on_shelf=True).annotate(hi=Value(False))
-    reveal_type(queryset)  # N: Revealed type is "myapp.models.SomeQuerySet"
+    reveal_type(queryset)  # N: Revealed type is "myapp.models.SomeQuerySet[myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})], myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]]"
     reveal_type(queryset.first())  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})] | None"
     reveal_type(queryset.get(pk=1))  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"
     reveal_type(queryset[0])  # N: Revealed type is "myapp.models.Accommodation@AnnotatedWith[TypedDict({'hello': Any, 'hi': Any})]"
@@ -848,7 +848,7 @@
             Book.objects.annotate(dupe_author=F("name"))
 
         def consume() -> "Book | None":
-            book = None
+            book: Book | None = None
             if True:
                 book = Book.objects.filter(name="foo").first()
                 reveal_type(book)  # N: Revealed type is "myapp.models.Book | None"

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -817,6 +817,45 @@
         class SomeQuerySet(models.QuerySet["Accommodation"]):
             pass
 
+- case: annotate_does_not_leak_across_functions
+  main: |
+    from typing_extensions import reveal_type
+    from myapp.models import consume
+    reveal_type(consume())  # N: Revealed type is "myapp.models.Book | None"
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from typing_extensions import reveal_type
+
+        from django.db import models
+        from django.db.models import F
+
+
+        class BookQuerySet(models.QuerySet["Book"]):
+            pass
+
+
+        class Book(models.Model):
+            name = models.CharField(max_length=100)
+            author = models.CharField(max_length=100)
+
+            objects = models.Manager.from_queryset(BookQuerySet)()
+
+        def leak() -> None:
+            Book.objects.annotate(dupe_author=F("name"))
+
+        def consume() -> "Book | None":
+            book = None
+            if True:
+                book = Book.objects.filter(name="foo").first()
+                reveal_type(book)  # N: Revealed type is "myapp.models.Book | None"
+            if not book:
+                book = Book(name="foo", author="bar")
+            return book
+
 - case: custom_queryset_method_with_annotations
   main: |
     from typing_extensions import reveal_type

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -6,7 +6,7 @@
         reveal_type(MyModel.objects.example_list())  # N: Revealed type is "list[myapp.models.MyQuerySet[myapp.models.MyModel]]"
         reveal_type(MyModel.objects.example_simple().just_int())  # N: Revealed type is "int"
         reveal_type(MyModel.objects.example_dict())  # N: Revealed type is "dict[str, myapp.models.MyQuerySet[myapp.models.MyModel]]"
-        reveal_type(MyModelWithoutSelf.objects.method())  # N: Revealed type is "myapp.models.QuerySetWithoutSelf"
+        reveal_type(MyModelWithoutSelf.objects.method())  # N: Revealed type is "myapp.models.QuerySetWithoutSelf[myapp.models.MyModelWithoutSelf, myapp.models.MyModelWithoutSelf]"
 
     installed_apps:
         - myapp
@@ -129,8 +129,8 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
-        reveal_type(MyModel.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
         reveal_type(MyModel.objects.returns_int_sequence())  # N: Revealed type is "typing.Sequence[int]"
     installed_apps:
         - myapp
@@ -156,8 +156,8 @@
         from typing_extensions import reveal_type
         from myapp.models import MyModel1, MyModel2
         kls: type[MyModel1 | MyModel2] = MyModel1
-        reveal_type(kls.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet1 | myapp.models.ModelQuerySet2"
-        reveal_type(kls.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet1 | myapp.models.ModelQuerySet2"
+        reveal_type(kls.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet1[myapp.models.MyModel1, myapp.models.MyModel1] | myapp.models.ModelQuerySet2[myapp.models.MyModel2, myapp.models.MyModel2]"
+        reveal_type(kls.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet1[myapp.models.MyModel1, myapp.models.MyModel1] | myapp.models.ModelQuerySet2[myapp.models.MyModel2, myapp.models.MyModel2]"
         reveal_type(kls.objects.returns_thing())  # N: Revealed type is "int | str"
         reveal_type(kls.objects.get())  # N: Revealed type is "myapp.models.MyModel1 | myapp.models.MyModel2"
     installed_apps:
@@ -195,7 +195,7 @@
         from myapp.models import MyModel, MyModelManager
         reveal_type(MyModelManager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[Any]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -217,7 +217,7 @@
         from myapp.models import MyModel, ManagerFromModelQuerySet
         reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[Any]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
-        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -371,8 +371,8 @@
         from myapp.models import MyModel
         reveal_type(MyModel.objects_1)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects_2)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel.objects_1.all())  # N: Revealed type is "myapp.models.ModelQuerySet"
-        reveal_type(MyModel.objects_2.all())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects_1.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects_2.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -7,7 +7,7 @@
         reveal_type(MyModel.objects.example_simple().just_int())  # N: Revealed type is "int"
         reveal_type(MyModel.objects.example_dict())  # N: Revealed type is "dict[str, myapp.models.MyQuerySet[myapp.models.MyModel]]"
         reveal_type(MyModel.objects.test_custom_manager())  # N: Revealed type is "myapp.models.CustomManagerFromMyQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModelWithoutSelf.objects.method())  # N: Revealed type is "myapp.models.QuerySetWithoutSelf"
+        reveal_type(MyModelWithoutSelf.objects.method())  # N: Revealed type is "myapp.models.QuerySetWithoutSelf[myapp.models.MyModelWithoutSelf, myapp.models.MyModelWithoutSelf]"
     installed_apps:
         - myapp
     files:
@@ -106,12 +106,12 @@
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[myapp.querysets.Custom]"
         reveal_type(MyModel.objects.queryset_method_3())  # N: Revealed type is "str"
         reveal_type(MyModel.objects.queryset_method_4([]))  # N: Revealed type is "None"
-        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet"
-        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -232,12 +232,12 @@
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.querysets.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[myapp.querysets.Custom]"
         reveal_type(MyModel.objects.queryset_method_3())  # N: Revealed type is "str"
         reveal_type(MyModel.objects.queryset_method_4([]))  # N: Revealed type is "None"
-        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet"
-        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet"
+        reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.querysets.ModelQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -324,7 +324,7 @@
         from myapp.models import MyModel1, MyModel2
         kls: type[MyModel1 | MyModel2] = MyModel1
         reveal_type(kls.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel1] | myapp.models.ManagerFromModelQuerySet2[myapp.models.MyModel2]"
-        reveal_type(kls.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet1 | myapp.models.ModelQuerySet2"
+        reveal_type(kls.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet1[myapp.models.MyModel1, myapp.models.MyModel1] | myapp.models.ModelQuerySet2[myapp.models.MyModel2, myapp.models.MyModel2]"
         reveal_type(kls.objects.get())  # N: Revealed type is "myapp.models.MyModel1 | myapp.models.MyModel2"
         reveal_type(kls.objects.queryset_method())  # N: Revealed type is "int | str"
     installed_apps:
@@ -603,10 +603,10 @@
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
         reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
-        reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.custom)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.all().filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.custom().filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
+        reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.custom)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all().filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.custom().filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
         reveal_type(MyModel.objects2)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
         reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.MyManagerFromMyQuerySet"
     installed_apps:
@@ -634,7 +634,7 @@
         from myapp.models import MyModel
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.BaseManagerFromBaseQuerySet"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.BaseModel"
-        reveal_type(MyModel.objects.filter())  # N: Revealed type is "myapp.models.BaseQuerySet"
+        reveal_type(MyModel.objects.filter())  # N: Revealed type is "myapp.models.BaseQuerySet[myapp.models.BaseModel, myapp.models.BaseModel]"
         reveal_type(MyModel.objects.filter().get())  # N: Revealed type is "myapp.models.BaseModel"
     installed_apps:
         - myapp
@@ -661,26 +661,26 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel.objects.alias)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.annotate)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.complex_filter)  # N: Revealed type is "def (filter_obj: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.defer)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def (*fields: str) -> myapp.models.MyQuerySet)"
-        reveal_type(MyModel.objects.difference)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any]) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.distinct)  # N: Revealed type is "def (*field_names: str) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.exclude)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.extra)  # N: Revealed type is "def (select: dict[str, Any] | None =, where: typing.Sequence[str] | None =, params: typing.Sequence[Any] | None =, tables: typing.Sequence[str] | None =, order_by: typing.Sequence[str | django.db.models.expressions.Combinable] | None =, select_params: typing.Sequence[Any] | None =) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.intersection)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any]) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.none)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.only)  # N: Revealed type is "def (*fields: str) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.order_by)  # N: Revealed type is "def (*field_names: str | django.db.models.expressions.Combinable) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.prefetch_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def [_LookupT <: str, _PrefetchedQuerySetT <: django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model] = django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model], _ToAttrT <: str = str] (*lookups: str | django.db.models.query.Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> myapp.models.MyQuerySet)"
-        reveal_type(MyModel.objects.reverse)  # N: Revealed type is "def () -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.select_for_update)  # N: Revealed type is "def (nowait: bool =, skip_locked: bool =, of: typing.Sequence[str] =, no_key: bool =) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.select_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet, def (*fields: str) -> myapp.models.MyQuerySet)"
-        reveal_type(MyModel.objects.union)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any], all: bool =) -> myapp.models.MyQuerySet"
-        reveal_type(MyModel.objects.using)  # N: Revealed type is "def (alias: str | None) -> myapp.models.MyQuerySet"
+        reveal_type(MyModel.objects.alias)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.annotate)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.complex_filter)  # N: Revealed type is "def (filter_obj: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.defer)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel], def (*fields: str) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel])"
+        reveal_type(MyModel.objects.difference)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any]) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.distinct)  # N: Revealed type is "def (*field_names: str) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.exclude)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.extra)  # N: Revealed type is "def (select: dict[str, Any] | None =, where: typing.Sequence[str] | None =, params: typing.Sequence[Any] | None =, tables: typing.Sequence[str] | None =, order_by: typing.Sequence[str | django.db.models.expressions.Combinable] | None =, select_params: typing.Sequence[Any] | None =) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.intersection)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any]) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.none)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.only)  # N: Revealed type is "def (*fields: str) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.order_by)  # N: Revealed type is "def (*field_names: str | django.db.models.expressions.Combinable) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.prefetch_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel], def [_LookupT <: str, _PrefetchedQuerySetT <: django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model] = django.db.models.query.QuerySet[django.db.models.base.Model, django.db.models.base.Model], _ToAttrT <: str = str] (*lookups: str | django.db.models.query.Prefetch[_LookupT, _PrefetchedQuerySetT, _ToAttrT]) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel])"
+        reveal_type(MyModel.objects.reverse)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.select_for_update)  # N: Revealed type is "def (nowait: bool =, skip_locked: bool =, of: typing.Sequence[str] =, no_key: bool =) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.select_related)  # N: Revealed type is "Overload(def (None) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel], def (*fields: str) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel])"
+        reveal_type(MyModel.objects.union)  # N: Revealed type is "def (*other_qs: django.db.models.query.QuerySet[django.db.models.base.Model, Any], all: bool =) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
+        reveal_type(MyModel.objects.using)  # N: Revealed type is "def (alias: str | None) -> myapp.models.MyQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -974,7 +974,7 @@
         reveal_type(Manager[models.Model].from_queryset(NonQSGeneric[int]))
     out: |
         main:12: note: Revealed type is "type[django.db.models.manager.Manager[django.db.models.base.Model]]"
-        main:12: error: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "UnionType[QS1, QS2]"; expected "type[QuerySet[Model, Model]]"  [arg-type]
+        main:12: error: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "UnionType[QS1[Model, Model], QS2[Model, Model]]"; expected "type[QuerySet[Model, Model]]"  [arg-type]
         main:17: note: Revealed type is "type[django.db.models.manager.Manager[django.db.models.base.Model]]"
         main:17: error: Argument 1 to "from_queryset" of "BaseManager" has incompatible type "type[NonQSGeneric[int]]"; expected "type[QuerySet[Model, Model]]"  [arg-type]
 
@@ -982,7 +982,7 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import B
-        reveal_type(B().a_set.filter(field="something"))  # N: Revealed type is "myapp.models.QS"
+        reveal_type(B().a_set.filter(field="something"))  # N: Revealed type is "myapp.models.QS[myapp.models.A, myapp.models.A]"
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_values_list.yml
+++ b/tests/typecheck/managers/querysets/test_values_list.yml
@@ -287,7 +287,7 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import TransactionQuerySet
-        reveal_type(TransactionQuerySet())  # N: Revealed type is "myapp.models.TransactionQuerySet"
+        reveal_type(TransactionQuerySet())  # N: Revealed type is "myapp.models.TransactionQuerySet[myapp.models.Transaction, myapp.models.Transaction]"
         reveal_type(TransactionQuerySet().values())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Transaction, TypedDict({'id': int, 'total': int})]"
         reveal_type(TransactionQuerySet().values_list())  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Transaction, tuple[int, int]]"
     installed_apps:

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -756,7 +756,7 @@
 
         reveal_type(MyModel.populated_manager_from_populated_queryset)  # N: Revealed type is "myapp.models.PopulatedManagerFromPopulatedQuerySet"
         reveal_type(MyModel.populated_manager_from_populated_queryset.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel.populated_manager_from_populated_queryset.filter())  # N: Revealed type is "myapp.models.PopulatedQuerySet"
+        reveal_type(MyModel.populated_manager_from_populated_queryset.filter())  # N: Revealed type is "myapp.models.PopulatedQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
 
         reveal_type(MyModel.generic_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
         reveal_type(MyModel.generic_manager.get())  # N: Revealed type is "myapp.models.MyModel"
@@ -768,7 +768,7 @@
 
         reveal_type(MyModel.generic_manager_from_populated_queryset)  # N: Revealed type is "myapp.models.ManagerFromPopulatedQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.generic_manager_from_populated_queryset.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel.generic_manager_from_populated_queryset.filter())  # N: Revealed type is "myapp.models.PopulatedQuerySet"
+        reveal_type(MyModel.generic_manager_from_populated_queryset.filter())  # N: Revealed type is "myapp.models.PopulatedQuerySet[myapp.models.MyModel, myapp.models.MyModel]"
 
     installed_apps:
         - myapp


### PR DESCRIPTION
# I have made things!

This tries this approach https://github.com/typeddjango/django-stubs/issues/3324#issuecomment-4295539146

I think this is more correct.
cc @delfick , it fixes your bug (See test`annotate_does_not_leak_across_functions`) and also the one #3271 was trying to address (see `custom_queryset_with_annotations_issue_1049`)

A bunch of tests are failing, I expect it's mostly snapshots changing but I need to check more.
Opening to get initial feedback

## Related issues
Fixes #3324

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
