### PR TITLE
Extract `analyze_member_access` helper into helpers module

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -6,8 +6,8 @@ from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy import checker
 from mypy.checker import TypeChecker
-from mypy.maptype import map_instance_to_supertype
 from mypy.checkmember import analyze_member_access as _mypy_analyze_member_access
+from mypy.maptype import map_instance_to_supertype
 from mypy.mro import calculate_mro
 from mypy.nodes import (
     GDEF,

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -7,6 +7,7 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from mypy import checker
 from mypy.checker import TypeChecker
 from mypy.maptype import map_instance_to_supertype
+from mypy.checkmember import analyze_member_access as _mypy_analyze_member_access
 from mypy.mro import calculate_mro
 from mypy.nodes import (
     GDEF,
@@ -57,9 +58,12 @@ from mypy.types import (
 )
 from mypy.types import Type as MypyType
 from mypy.typevars import fill_typevars, fill_typevars_with_any
+from mypy.version import __version__ as mypy_version
 from typing_extensions import Self
 
 from mypy_django_plugin.lib import fullnames
+
+mypy_version_info = tuple(map(int, mypy_version.partition("+")[0].split(".")))
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
@@ -788,4 +792,32 @@ def merge_extra_attrs(
         attrs=new_attrs or {},
         immutable=new_immutable,
         mod_name=None,
+    )
+
+
+def analyze_member_access(
+    name: str,
+    typ: MypyType,
+    context: Context,
+    *,
+    is_lvalue: bool,
+    is_super: bool,
+    is_operator: bool,
+    original_type: MypyType,
+    chk: TypeChecker,
+) -> MypyType:
+    # TODO: [mypy 1.16+] Remove this workaround for passing `msg` to `analyze_member_access()`.
+    extra: dict[str, Any] = {}
+    if mypy_version_info < (1, 16):
+        extra["msg"] = chk.msg
+    return _mypy_analyze_member_access(
+        name,
+        typ,
+        context,
+        is_lvalue=is_lvalue,
+        is_super=is_super,
+        is_operator=is_operator,
+        original_type=original_type,
+        chk=chk,
+        **extra,
     )

--- a/mypy_django_plugin/transformers/functional.py
+++ b/mypy_django_plugin/transformers/functional.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from mypy.checkmember import analyze_member_access
 from mypy.errorcodes import ATTR_DEFINED
 from mypy.nodes import CallExpr, MemberExpr
 from mypy.types import AnyType, Instance, TypeOfAny
 from mypy.types import Type as MypyType
-from mypy.version import __version__ as mypy_version
 
 from mypy_django_plugin.lib import helpers
 
 if TYPE_CHECKING:
     from mypy.plugin import AttributeContext
-
-mypy_version_info = tuple(map(int, mypy_version.partition("+")[0].split(".")))
 
 
 def resolve_str_promise_attribute(ctx: AttributeContext) -> MypyType:
@@ -30,12 +26,7 @@ def resolve_str_promise_attribute(ctx: AttributeContext) -> MypyType:
     assert str_info is not None
     str_type = Instance(str_info, [])
 
-    # TODO: [mypy 1.16+] Remove this workaround for passing `msg` to `analyze_member_access()`.
-    extra: dict[str, Any] = {}
-    if mypy_version_info < (1, 16):
-        extra["msg"] = ctx.api.msg
-
-    return analyze_member_access(
+    return helpers.analyze_member_access(
         method_name,
         str_type,
         ctx.context,
@@ -45,5 +36,4 @@ def resolve_str_promise_attribute(ctx: AttributeContext) -> MypyType:
         is_operator=False,
         original_type=ctx.type,
         chk=helpers.get_typechecker_api(ctx),
-        **extra,
     )


### PR DESCRIPTION
# I have made things!

Minor refactoring encapsulating the mypy compat workaround, I'll need this util for #3317

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
