### PR TITLE
Remove explicit `--strict` (we set `strict=true` in mypy.ini already)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,15 @@ jobs:
         run: uv sync --no-dev --group tests
 
       - name: Run mypy on plugin code
-        run: uv run mypy --strict mypy_django_plugin
+        run: uv run mypy mypy_django_plugin
       - name: Run mypy on ext code
-        run: uv run mypy --strict ext
+        run: uv run mypy ext
       - name: Run mypy on scripts and utils
-        run: uv run mypy --strict scripts
+        run: uv run mypy scripts
       - name: Run mypy on stubs
         run: uv run mypy --cache-dir=/dev/null --no-incremental django-stubs
       - name: Run mypy on the test cases
-        run: uv run mypy --strict tests
+        run: uv run mypy tests
 
   test:
     timeout-minutes: 15

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ lint:
 
 # Run all checks before submitting a PR
 [group('dev')]
-pre-mr-check: lint ty pyrefly mypy stubtest pyright ext-test test
+pre-mr-check: lint typecheck-all stubtest ext-test test
 
 # Remove mypy cache
 [group('dev')]
@@ -26,11 +26,11 @@ clean:
 # Run mypy on plugin, ext, scripts, stubs and tests
 [group('typecheck')]
 mypy:
-    uv run mypy --strict ext
-    uv run mypy --strict scripts
-    uv run mypy --strict mypy_django_plugin
+    uv run mypy ext
+    uv run mypy scripts
+    uv run mypy mypy_django_plugin
     uv run mypy --cache-dir=/dev/null --no-incremental django-stubs
-    uv run mypy --strict tests
+    uv run mypy tests
 
 # Run pyright on test cases
 [group('typecheck')]
@@ -46,6 +46,10 @@ pyrefly:
 [group('typecheck')]
 ty:
     uv run ty check tests/assert_type
+
+# Run all typechecker on test cases
+[group('typecheck')]
+typecheck-all: pyrefly ty pyright mypy
 
 # Run pytest tests
 [group('test')]

--- a/justfile
+++ b/justfile
@@ -26,11 +26,8 @@ clean:
 # Run mypy on plugin, ext, scripts, stubs and tests
 [group('typecheck')]
 mypy:
-    uv run mypy ext
-    uv run mypy scripts
-    uv run mypy mypy_django_plugin
+    uv run mypy ext scripts mypy_django_plugin tests
     uv run mypy --cache-dir=/dev/null --no-incremental django-stubs
-    uv run mypy tests
 
 # Run pyright on test cases
 [group('typecheck')]


### PR DESCRIPTION
Also adds a just receipe to run every typechekers on the `tests/assert_type` folder

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
