### PR TITLE
Pin to pre-commit python to `3.13` to avoid codespell issue with `3.12`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+  python: "3.13"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0


### PR DESCRIPTION
# I have made things!
This is to avoid a crash you can get with codespell + python 3.12

```python
Traceback (most recent call last):
  File "/home/thibaut/.cache/pre-commit/repo36k0ype2/py_env-python3/bin/codespell", line 3, in <module>
    from codespell_lib import _script_main
  File "/home/thibaut/.cache/pre-commit/repo36k0ype2/py_env-python3/lib/python3.12/site-packages/codespell_lib/__init__.py", line 1, in <module>
    from ._codespell import _script_main, main
  File "/home/thibaut/.cache/pre-commit/repo36k0ype2/py_env-python3/lib/python3.12/site-packages/codespell_lib/_codespell.py", line 21, in <module>
    import ctypes
  File "/usr/lib/python3.12/ctypes/__init__.py", line 8, in <module>
    from _ctypes import Union, Structure, Array
ImportError: /usr/lib/python3.12/lib-dynload/_ctypes.cpython-312-x86_64-linux-gnu.so: undefined symbol: _PyErr_SetLocaleString
```


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
