### PR TITLE
Ban `typing.TypeVar` in favor of `typing_extensions.TypeVar`

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, overload
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression, Combinable
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeVar
 
 _ModelAdmin = TypeVar("_ModelAdmin", bound=ModelAdmin[Any])
 _F = TypeVar("_F", bound=Callable[..., Any])

--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar, cast, type_check_only
+from typing import Any, ClassVar, Generic, Literal, TypeAlias, cast, type_check_only
 
 from django import forms
 from django.contrib.admin.filters import FieldListFilter, ListFilter
@@ -33,7 +33,7 @@ from django.urls.resolvers import URLPattern
 from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _StrOrPromise
 from django.utils.safestring import SafeString
-from typing_extensions import Self, TypedDict, override
+from typing_extensions import Self, TypedDict, TypeVar, override
 
 IS_POPUP_VAR: str
 TO_FIELD_VAR: str

--- a/django-stubs/contrib/admin/sites.pyi
+++ b/django-stubs/contrib/admin/sites.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias
 from weakref import WeakSet
 
 from django.apps.config import AppConfig
@@ -14,6 +14,7 @@ from django.http.response import HttpResponse, HttpResponseBase
 from django.template.response import TemplateResponse
 from django.urls import URLPattern, URLResolver
 from django.utils.functional import LazyObject, _StrOrPromise
+from typing_extensions import TypeVar
 
 all_sites: WeakSet[AdminSite]
 

--- a/django-stubs/contrib/admin/utils.pyi
+++ b/django-stubs/contrib/admin/utils.pyi
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Literal, TypeVar, overload, type_check_only
+from typing import Any, Literal, overload, type_check_only
 from uuid import UUID
 
 from _typeshed import Unused
@@ -16,7 +16,7 @@ from django.forms.forms import BaseForm, Form
 from django.forms.formsets import BaseFormSet
 from django.http.request import HttpRequest
 from django.utils.datastructures import _IndexableCollection
-from typing_extensions import TypedDict, override
+from typing_extensions import TypedDict, TypeVar, override
 
 _T = TypeVar("_T")
 

--- a/django-stubs/contrib/admin/views/decorators.pyi
+++ b/django-stubs/contrib/admin/views/decorators.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Callable
-from typing import TypeVar, overload
+from typing import overload
 
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable)
 

--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -1,10 +1,11 @@
 from collections.abc import Iterable
-from typing import Any, ClassVar, Literal, TypeVar, overload
+from typing import Any, ClassVar, Literal, overload
 
 from django.db import models
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable
 from django.db.models.fields import BooleanField
+from typing_extensions import TypeVar
 
 _T = TypeVar("_T", bound=Model)
 

--- a/django-stubs/contrib/auth/decorators.pyi
+++ b/django-stubs/contrib/auth/decorators.pyi
@@ -1,9 +1,10 @@
 from collections.abc import Awaitable, Callable, Iterable
-from typing import TypeVar, overload
+from typing import overload
 
 from django.contrib.auth.models import _AnyUser
 from django.http.response import HttpResponseBase
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeVar
 
 _VIEW = TypeVar("_VIEW", bound=Callable[..., HttpResponseBase | Awaitable[HttpResponseBase]])
 

--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, ClassVar, Literal, TypeAlias, TypeVar
+from typing import Any, ClassVar, Literal, TypeAlias
 
 from django.contrib.auth.base_user import AbstractBaseUser as AbstractBaseUser
 from django.contrib.auth.base_user import BaseUserManager as BaseUserManager
@@ -10,7 +10,7 @@ from django.db.models import QuerySet
 from django.db.models.base import Model
 from django.db.models.manager import EmptyManager
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Never, Self
+from typing_extensions import Never, Self, TypeVar
 
 # This is our "placeholder" type the mypy plugin refines to configured 'AUTH_USER_MODEL'
 # wherever it is used as a type. The most recognised example of this is (probably)

--- a/django-stubs/contrib/auth/views.pyi
+++ b/django-stubs/contrib/auth/views.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any
 
 from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm, PasswordResetForm, SetPasswordForm
 from django.contrib.auth.models import _User, _UserModel
@@ -8,7 +8,7 @@ from django.http.response import HttpResponse, HttpResponseRedirect
 from django.utils.functional import _StrOrPromise
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 UserModel = _UserModel
 _AuthForm = TypeVar("_AuthForm", bound=AuthenticationForm, default=AuthenticationForm)

--- a/django-stubs/contrib/contenttypes/forms.pyi
+++ b/django-stubs/contrib/contenttypes/forms.pyi
@@ -1,8 +1,8 @@
-from typing import Any, TypeVar
+from typing import Any
 
 from django.db.models import Model
 from django.forms.models import BaseModelFormSet, ModelForm
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _M = TypeVar("_M", bound=Model)
 _ModelFormT = TypeVar("_ModelFormT", bound=ModelForm)

--- a/django-stubs/contrib/contenttypes/prefetch.pyi
+++ b/django-stubs/contrib/contenttypes/prefetch.pyi
@@ -1,8 +1,8 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from django.db.models import Model, Prefetch
 from django.db.models.query import QuerySet
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 # The type of the lookup passed to Prefetch(...)
 # This will be specialized to a `LiteralString` in the plugin for further processing and validation

--- a/django-stubs/contrib/gis/admin/options.pyi
+++ b/django-stubs/contrib/gis/admin/options.pyi
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar
+from typing import Any
 
 from django.contrib.admin import ModelAdmin
 from django.contrib.gis.forms import OSMWidget
@@ -6,6 +6,7 @@ from django.db.models import Model
 from django.db.models.fields import Field
 from django.forms.fields import Field as FormField
 from django.http.request import HttpRequest
+from typing_extensions import TypeVar
 
 _ModelT = TypeVar("_ModelT", bound=Model)
 

--- a/django-stubs/contrib/gis/db/models/fields.pyi
+++ b/django-stubs/contrib/gis/db/models/fields.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, NamedTuple, TypeVar
+from typing import Any, NamedTuple
 
 from django.contrib.gis import forms
 from django.contrib.gis.geos import (
@@ -18,7 +18,7 @@ from django.db.models.expressions import Combinable, Expression
 from django.db.models.fields import NOT_PROVIDED, Field, _ErrorMessagesMapping
 from django.utils.choices import _Choices
 from django.utils.functional import _StrOrPromise
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 # __set__ value type
 _ST = TypeVar("_ST")

--- a/django-stubs/contrib/messages/views.pyi
+++ b/django-stubs/contrib/messages/views.pyi
@@ -1,8 +1,9 @@
-from typing import Generic, TypeVar
+from typing import Generic
 
 from django.forms.forms import BaseForm
 from django.http.response import HttpResponse
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=BaseForm)
 

--- a/django-stubs/contrib/postgres/fields/array.pyi
+++ b/django-stubs/contrib/postgres/fields/array.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar
 
 from _typeshed import Unused
 from django.contrib.postgres.utils import CheckPostgresInstalledMixin
@@ -13,7 +13,7 @@ from django.db.models.fields.mixins import CheckFieldDefaultMixin
 from django.db.models.lookups import Transform
 from django.utils.choices import _Choices
 from django.utils.functional import _StrOrPromise
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 # __set__ value type
 _ST = TypeVar("_ST")

--- a/django-stubs/contrib/postgres/fields/ranges.pyi
+++ b/django-stubs/contrib/postgres/fields/ranges.pyi
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Literal, TypeVar
+from typing import Any, ClassVar, Literal
 
 from _typeshed import Unused
 from django.contrib.postgres import forms
@@ -8,7 +8,7 @@ from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import PostgresOperatorLookup
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range  # type: ignore[import-untyped]
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 class RangeBoundary(models.Expression):
     lower: str

--- a/django-stubs/contrib/sessions/backends/db.pyi
+++ b/django-stubs/contrib/sessions/backends/db.pyi
@@ -1,8 +1,9 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from django.contrib.sessions.backends.base import SessionBase
 from django.contrib.sessions.base_session import AbstractBaseSession
 from django.utils.functional import cached_property
+from typing_extensions import TypeVar
 
 _ST = TypeVar("_ST", bound=AbstractBaseSession, default=AbstractBaseSession)
 

--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -1,9 +1,9 @@
 from datetime import datetime
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar
 
 from django.contrib.sessions.backends.base import SessionBase
 from django.db import models
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 _T = TypeVar("_T", bound=AbstractBaseSession)
 

--- a/django-stubs/contrib/sessions/models.pyi
+++ b/django-stubs/contrib/sessions/models.pyi
@@ -1,6 +1,5 @@
-from typing import TypeVar
-
 from django.contrib.sessions.base_session import AbstractBaseSession, BaseSessionManager
+from typing_extensions import TypeVar
 
 _T = TypeVar("_T", bound=Session)
 

--- a/django-stubs/contrib/sitemaps/__init__.pyi
+++ b/django-stubs/contrib/sitemaps/__init__.pyi
@@ -1,13 +1,13 @@
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from django.contrib.sites.models import Site
 from django.contrib.sites.requests import RequestSite
 from django.core.paginator import Paginator
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _ItemT = TypeVar("_ItemT")
 

--- a/django-stubs/contrib/sitemaps/views.pyi
+++ b/django-stubs/contrib/sitemaps/views.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TypeVar
 
 from django.contrib.sitemaps import Sitemap
 from django.http.request import HttpRequest
 from django.template.response import TemplateResponse
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable)
 

--- a/django-stubs/contrib/sites/managers.pyi
+++ b/django-stubs/contrib/sites/managers.pyi
@@ -1,6 +1,5 @@
-from typing import TypeVar
-
 from django.db import models
+from typing_extensions import TypeVar
 
 _T = TypeVar("_T", bound=models.Model)
 

--- a/django-stubs/contrib/syndication/views.pyi
+++ b/django-stubs/contrib/syndication/views.pyi
@@ -1,9 +1,10 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.utils.feedgenerator import Enclosure, SyndicationFeed
+from typing_extensions import TypeVar
 
 def add_domain(domain: str, url: str, secure: bool = ...) -> str: ...
 

--- a/django-stubs/core/checks/registry.pyi
+++ b/django-stubs/core/checks/registry.pyi
@@ -1,8 +1,9 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Protocol, TypeVar, overload, type_check_only
+from typing import Any, Protocol, overload, type_check_only
 
 from django.apps.config import AppConfig
 from django.core.checks.messages import CheckMessage
+from typing_extensions import TypeVar
 
 class Tags:
     admin: str

--- a/django-stubs/core/handlers/asgi.pyi
+++ b/django-stubs/core/handlers/asgi.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from logging import Logger
-from typing import IO, Any, TypeAlias, TypeVar
+from typing import IO, Any, TypeAlias
 
 from django.core.files import uploadedfile
 from django.core.handlers import base
@@ -9,7 +9,7 @@ from django.http.response import HttpResponseBase
 from django.urls.resolvers import ResolverMatch, URLResolver
 from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _ReceiveCallback: TypeAlias = Callable[[], Awaitable[Mapping[str, Any]]]
 

--- a/django-stubs/core/paginator.pyi
+++ b/django-stubs/core/paginator.pyi
@@ -1,9 +1,9 @@
 from collections.abc import AsyncIterator, Iterable, Iterator, Sequence, Sized
-from typing import ClassVar, Generic, Protocol, TypeVar, overload, type_check_only
+from typing import ClassVar, Generic, Protocol, overload, type_check_only
 
 from django.db.models.fields import _ErrorMessagesDict
 from django.utils.functional import _StrPromise, cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 class UnorderedObjectListWarning(RuntimeWarning): ...
 class InvalidPage(Exception): ...

--- a/django-stubs/db/backends/sqlite3/base.pyi
+++ b/django-stubs/db/backends/sqlite3/base.pyi
@@ -2,10 +2,10 @@ from collections.abc import Callable, Iterable
 from datetime import date, datetime
 from sqlite3 import dbapi2 as Database
 from types import ModuleType
-from typing import Any, TypeVar
+from typing import Any
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 from .client import DatabaseClient
 from .creation import DatabaseCreation

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, TypeVar, overload
+from typing import Any, ClassVar, Final, overload
 
 from django.core.checks.messages import CheckMessage
 from django.core.exceptions import MultipleObjectsReturned as BaseMultipleObjectsReturned
@@ -9,7 +9,7 @@ from django.db.models import BaseConstraint, Field, QuerySet
 from django.db.models.manager import Manager
 from django.db.models.options import Options
 from django.db.models.utils import AltersData
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 _Self = TypeVar("_Self", bound=Model)
 

--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -1,10 +1,10 @@
 import enum
 import sys
-from typing import Any, Literal, TypeVar, overload, type_check_only
+from typing import Any, Literal, overload, type_check_only
 
 from _typeshed import ConvertibleToInt
 from django.utils.functional import _StrOrPromise
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 if sys.version_info >= (3, 11):
     from enum import EnumType, IntEnum, StrEnum

--- a/django-stubs/db/models/expressions.pyi
+++ b/django-stubs/db/models/expressions.pyi
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from decimal import Decimal
 from enum import Enum
-from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeAlias
 
 from django.core.exceptions import FieldError
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -14,7 +14,7 @@ from django.db.models.sql.compiler import SQLCompiler, _AsSqlType, _ParamsT
 from django.db.models.sql.query import Query
 from django.utils.deconstruct import _Deconstructible
 from django.utils.functional import cached_property
-from typing_extensions import Never, Self, override
+from typing_extensions import Never, Self, TypeVar, override
 
 _OutputField = TypeVar("_OutputField", bound=Field, default=Field)
 _Numeric: TypeAlias = float | Decimal

--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import date, time, timedelta
 from datetime import datetime as real_datetime
-from typing import Any, ClassVar, Generic, Literal, Protocol, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, ClassVar, Generic, Literal, Protocol, TypeAlias, overload, type_check_only
 
 from django import forms
 from django.core import validators  # due to weird mypy.stubtest error
@@ -18,7 +18,7 @@ from django.db.models.sql.compiler import SQLCompiler, _AsSqlType, _ParamsT
 from django.utils.choices import BlankChoiceIterator, _Choice, _ChoiceNamedGroup, _ChoicesCallable, _ChoicesInput
 from django.utils.datastructures import DictWrapper
 from django.utils.functional import _Getter, _StrOrPromise, cached_property
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 class Empty: ...
 class NOT_PROVIDED: ...

--- a/django-stubs/db/models/fields/files.pyi
+++ b/django-stubs/db/models/fields/files.pyi
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Callable, Iterable
-from typing import Any, Protocol, TypeVar, overload, type_check_only
+from typing import Any, Protocol, overload, type_check_only
 
 from django.core import validators  # due to weird mypy.stubtest error
 from django.core.files.base import File
@@ -14,7 +14,7 @@ from django.db.models.utils import AltersData
 from django.utils._os import _PathCompatible
 from django.utils.choices import _Choices
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 class FieldFile(File, AltersData):
     instance: Model

--- a/django-stubs/db/models/fields/json.pyi
+++ b/django-stubs/db/models/fields/json.pyi
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Callable
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Model, lookups
@@ -9,7 +9,7 @@ from django.db.models.fields import TextField
 from django.db.models.lookups import FieldGetDbPrepValueMixin, PostgresOperatorLookup, Transform
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 from . import Field
 from .mixins import CheckFieldDefaultMixin

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Generic, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, overload
 from uuid import UUID
 
 from django import forms
@@ -23,7 +23,7 @@ from django.db.models.query_utils import FilteredRelation, PathInfo, Q
 from django.db.models.sql.where import WhereNode
 from django.utils.choices import _Choices
 from django.utils.functional import _StrOrPromise, cached_property
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 RECURSIVE_RELATIONSHIP_CONSTANT: Literal["self"]
 

--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, Generic, TypeVar, overload, type_check_only
+from typing import Any, Generic, overload, type_check_only
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.base import Model
@@ -10,7 +10,7 @@ from django.db.models.manager import BaseManager, Manager
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import DeferredAttribute
 from django.utils.functional import cached_property
-from typing_extensions import Never, Self, override
+from typing_extensions import Never, Self, TypeVar, override
 
 _M = TypeVar("_M", bound=Model)
 _F = TypeVar("_F", bound=Field)

--- a/django-stubs/db/models/lookups.pyi
+++ b/django-stubs/db/models/lookups.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal
 
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.expressions import Combinable, Expression, Func
@@ -8,7 +8,7 @@ from django.db.models.query_utils import RegisterLookupMixin
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType, _ParamT
 from django.utils.datastructures import OrderedSet
 from django.utils.functional import cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _T = TypeVar("_T", default=Any)
 

--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -1,12 +1,12 @@
 import datetime
 from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Generic, Literal, NoReturn, TypeVar, overload
+from typing import Any, Generic, Literal, NoReturn, overload
 
 from django.core.checks.messages import CheckMessage
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable, OrderBy
 from django.db.models.query import Prefetch, QuerySet, RawQuerySet, _LookupT, _PrefetchedQuerySetT, _ToAttrT
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 _T = TypeVar("_T", bound=Model, covariant=True)
 

--- a/django-stubs/db/models/options.pyi
+++ b/django-stubs/db/models/options.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, Generic, TypeAlias, TypeVar, overload
+from typing import Any, Generic, TypeAlias, overload
 
 from django.apps.config import AppConfig
 from django.apps.registry import Apps
@@ -14,6 +14,7 @@ from django.db.models.query import _OrderByFieldName
 from django.db.models.query_utils import PathInfo
 from django.utils.datastructures import ImmutableList, _ListOrTuple
 from django.utils.functional import _StrOrPromise, cached_property
+from typing_extensions import TypeVar
 
 PROXY_PARENTS: object
 EMPTY_RELATION_TREE: Any

--- a/django-stubs/db/models/query_utils.pyi
+++ b/django-stubs/db/models/query_utils.pyi
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, ClassVar, Literal, NamedTuple, TypeVar
+from typing import Any, ClassVar, Literal, NamedTuple
 
 from _typeshed import Incomplete
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -15,6 +15,7 @@ from django.db.models.sql.query import Query
 from django.db.models.sql.where import WhereNode
 from django.utils import tree
 from django.utils.functional import cached_property
+from typing_extensions import TypeVar
 
 logger: logging.Logger
 

--- a/django-stubs/db/transaction.pyi
+++ b/django-stubs/db/transaction.pyi
@@ -1,9 +1,10 @@
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import Any, TypeVar, overload
+from typing import Any, overload
 
 from django.db import ProgrammingError
+from typing_extensions import TypeVar
 
 class TransactionManagementError(ProgrammingError): ...
 

--- a/django-stubs/db/utils.pyi
+++ b/django-stubs/db/utils.pyi
@@ -1,13 +1,13 @@
 from collections.abc import Callable, Iterable
 from types import TracebackType
-from typing import Any, TypeVar
+from typing import Any
 
 from django.apps import AppConfig
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Model
 from django.utils.connection import BaseConnectionHandler
 from django.utils.functional import cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 DEFAULT_DB_ALIAS: str
 DJANGO_VERSION_PICKLE_KEY: str

--- a/django-stubs/dispatch/dispatcher.pyi
+++ b/django-stubs/dispatch/dispatcher.pyi
@@ -1,7 +1,9 @@
 import threading
 from collections.abc import Callable, MutableMapping
 from logging import Logger
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias
+
+from typing_extensions import TypeVar
 
 _AnyHashable: TypeAlias = Any
 

--- a/django-stubs/forms/models.pyi
+++ b/django-stubs/forms/models.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Collection, Container, Iterator, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import Any, ClassVar, Generic, Literal, TypeAlias, overload
 from uuid import UUID
 
 from django.db import models
@@ -18,7 +18,7 @@ from django.forms.widgets import Widget
 from django.utils.choices import BaseChoiceIterator, CallableChoiceIterator, _ChoicesCallable, _ChoicesInput
 from django.utils.datastructures import _PropertyDescriptor
 from django.utils.functional import _StrOrPromise
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 ALL_FIELDS: Literal["__all__"]
 

--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -1,7 +1,7 @@
 import datetime
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
-from typing import Any, BinaryIO, Literal, NoReturn, Protocol, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, BinaryIO, Literal, NoReturn, Protocol, TypeAlias, overload, type_check_only
 
 from django.contrib.auth.models import _AnyUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -10,7 +10,7 @@ from django.core.files import uploadedfile, uploadhandler
 from django.urls import ResolverMatch
 from django.utils.datastructures import CaseInsensitiveMapping, ImmutableList, MultiValueDict
 from django.utils.functional import cached_property
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 RAISE_ERROR: object
 host_validation_re: Pattern[str]

--- a/django-stubs/http/response.pyi
+++ b/django-stubs/http/response.pyi
@@ -3,11 +3,11 @@ from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator, Ma
 from http.cookies import SimpleCookie
 from io import BytesIO
 from json import JSONEncoder
-from typing import Any, Literal, NoReturn, TypeVar, overload, type_check_only
+from typing import Any, Literal, NoReturn, overload, type_check_only
 
 from django.utils.datastructures import CaseInsensitiveMapping, _PropertyDescriptor
 from django.utils.functional import _StrOrPromise, cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 class BadHeaderError(ValueError): ...
 

--- a/django-stubs/shortcuts.pyi
+++ b/django-stubs/shortcuts.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Literal, Protocol, TypeVar, overload, type_check_only
+from typing import Any, Literal, Protocol, overload, type_check_only
 
 from django.db.models import Manager, QuerySet
 from django.db.models.base import Model
 from django.http import HttpRequest
 from django.http.response import HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.utils.functional import _StrOrPromise
+from typing_extensions import TypeVar
 
 def render(
     request: HttpRequest | None,

--- a/django-stubs/tasks/base.pyi
+++ b/django-stubs/tasks/base.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Generic, overload
 
 from django.db.models.enums import TextChoices as TextChoices
 from django.utils.module_loading import import_string as import_string
 from django.utils.translation import pgettext_lazy as pgettext_lazy
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, TypeVar
 
 from .backends.base import BaseTaskBackend
 from .exceptions import TaskResultMismatch as TaskResultMismatch

--- a/django-stubs/template/context_processors.pyi
+++ b/django-stubs/template/context_processors.pyi
@@ -1,8 +1,8 @@
 from collections.abc import Callable
-from typing import TypeVar
 
 from django.http.request import HttpRequest
 from django.utils.functional import SimpleLazyObject
+from typing_extensions import TypeVar
 
 _R = TypeVar("_R", bound=HttpRequest)
 

--- a/django-stubs/template/library.pyi
+++ b/django-stubs/template/library.pyi
@@ -1,9 +1,10 @@
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence, Sized
-from typing import Any, TypeVar, overload
+from typing import Any, overload
 
 from django.template.base import FilterExpression, Parser
 from django.template.context import Context
 from django.utils.safestring import SafeString
+from typing_extensions import TypeVar
 
 from .base import Node, NodeList, Template
 

--- a/django-stubs/test/client.pyi
+++ b/django-stubs/test/client.pyi
@@ -5,7 +5,7 @@ from io import BytesIO, IOBase
 from json import JSONEncoder
 from re import Pattern
 from types import TracebackType
-from typing import Any, Generic, Literal, NoReturn, TypeAlias, TypedDict, TypeVar, type_check_only
+from typing import Any, Generic, Literal, NoReturn, TypeAlias, TypedDict, type_check_only
 
 from asgiref.typing import ASGIVersions
 from django.contrib.auth.models import _User
@@ -19,7 +19,7 @@ from django.template.base import Template
 from django.test.utils import ContextList
 from django.urls import ResolverMatch
 from django.utils.functional import _StrOrPromise, cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 BOUNDARY: str
 MULTIPART_CONTENT: str

--- a/django-stubs/test/selenium.pyi
+++ b/django-stubs/test/selenium.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias
 
 from django.test import LiveServerTestCase
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/utils/asyncio.pyi
+++ b/django-stubs/utils/asyncio.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar, overload
+from typing import Any, overload
+
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable[..., Any])
 

--- a/django-stubs/utils/choices.pyi
+++ b/django-stubs/utils/choices.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from typing import Any, Protocol, TypeAlias, TypeVar, type_check_only
+from typing import Any, Protocol, TypeAlias, type_check_only
 
 from django.db.models import Choices
+from typing_extensions import TypeVar
 
 _Choice: TypeAlias = tuple[Any, Any]
 _ChoiceNamedGroup: TypeAlias = tuple[str, Iterable[_Choice]]

--- a/django-stubs/utils/copy.pyi
+++ b/django-stubs/utils/copy.pyi
@@ -1,4 +1,6 @@
-from typing import Any, Protocol, TypeVar, type_check_only
+from typing import Any, Protocol, type_check_only
+
+from typing_extensions import TypeVar
 
 _RT_co = TypeVar("_RT_co", covariant=True)
 

--- a/django-stubs/utils/datastructures.pyi
+++ b/django-stubs/utils/datastructures.pyi
@@ -1,8 +1,8 @@
 from collections.abc import Collection, Iterable, Iterator, Mapping, MutableMapping, MutableSet
-from typing import Any, Generic, NoReturn, Protocol, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, Generic, NoReturn, Protocol, TypeAlias, overload, type_check_only
 
 from _typeshed import Incomplete
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 _K = TypeVar("_K")
 _V = TypeVar("_V")

--- a/django-stubs/utils/deconstruct.pyi
+++ b/django-stubs/utils/deconstruct.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, overload, type_check_only
+from typing import Any, overload, type_check_only
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 # Contains additions from a class being decorated with '@deconstructible'
 @type_check_only

--- a/django-stubs/utils/decorators.pyi
+++ b/django-stubs/utils/decorators.pyi
@@ -1,9 +1,10 @@
 from collections.abc import Callable, Iterable
-from typing import Any, Protocol, TypeAlias, TypeVar, type_check_only
+from typing import Any, Protocol, TypeAlias, type_check_only
 
 from django.http.response import HttpResponseBase
 from django.utils.deprecation import MiddlewareMixin
 from django.views.generic.base import View
+from typing_extensions import TypeVar
 
 @type_check_only
 class _MiddlewareClass(Protocol):

--- a/django-stubs/utils/deprecation.pyi
+++ b/django-stubs/utils/deprecation.pyi
@@ -1,8 +1,9 @@
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, ClassVar, Protocol, TypeAlias, TypeVar, type_check_only
+from typing import Any, ClassVar, Protocol, TypeAlias, type_check_only
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable[..., Any])
 

--- a/django-stubs/utils/encoding.pyi
+++ b/django-stubs/utils/encoding.pyi
@@ -1,8 +1,9 @@
 import datetime
 from decimal import Decimal
-from typing import Any, Literal, TypeGuard, TypeVar, overload
+from typing import Any, Literal, TypeGuard, overload
 
 from django.utils.functional import Promise
+from typing_extensions import TypeVar
 
 class DjangoUnicodeDecodeError(UnicodeDecodeError): ...
 

--- a/django-stubs/utils/formats.pyi
+++ b/django-stubs/utils/formats.pyi
@@ -3,7 +3,9 @@ from collections.abc import Iterator
 from datetime import date, time
 from datetime import datetime as builtin_datetime
 from decimal import Decimal
-from typing import Any, TypeVar, overload
+from typing import Any, overload
+
+from typing_extensions import TypeVar
 
 ISO_INPUT_FORMATS: dict[str, list[str]]
 FORMAT_SETTINGS: frozenset[str]

--- a/django-stubs/utils/functional.pyi
+++ b/django-stubs/utils/functional.pyi
@@ -2,10 +2,10 @@ from collections.abc import Callable, Iterable, Iterator
 
 # Mypy has special handling for functools.cached_property, reuse typeshed's definition instead of defining our own
 from functools import cached_property as cached_property
-from typing import Any, Generic, Protocol, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, Generic, Protocol, SupportsIndex, TypeAlias, overload, type_check_only
 
 from django.db.models.base import Model
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 _T = TypeVar("_T")
 

--- a/django-stubs/utils/regex_helper.pyi
+++ b/django-stubs/utils/regex_helper.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Iterator, Mapping
 from re import Pattern
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 ESCAPE_MAPPINGS: Mapping[str, str | None]
 

--- a/django-stubs/utils/safestring.pyi
+++ b/django-stubs/utils/safestring.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeAlias, TypeVar, overload
+from typing import Any, TypeAlias, overload
 
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeVar, override
 
 _SD = TypeVar("_SD", bound=SafeData)
 

--- a/django-stubs/utils/text.pyi
+++ b/django-stubs/utils/text.pyi
@@ -3,11 +3,11 @@ from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from html.parser import HTMLParser
 from io import BytesIO
 from re import Pattern
-from typing import Any, ClassVar, TypeVar, overload
+from typing import Any, ClassVar, overload
 
 from django.db.models.base import Model
 from django.utils.functional import SimpleLazyObject, _StrOrPromise, _StrPromise, cached_property
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _StrOrPromiseT = TypeVar("_StrOrPromiseT", bound=_StrOrPromise)
 _StrOrPromiseOrNoneT = TypeVar("_StrOrPromiseOrNoneT", bound=_StrOrPromise | None)

--- a/django-stubs/utils/translation/trans_real.pyi
+++ b/django-stubs/utils/translation/trans_real.pyi
@@ -4,10 +4,10 @@ from gettext import NullTranslations
 from re import Pattern
 
 # switch to tuple once https://github.com/python/mypy/issues/11098 is fixed
-from typing import Any, Literal, Protocol, TypeAlias, TypeVar, type_check_only
+from typing import Any, Literal, Protocol, TypeAlias, type_check_only
 
 from django.http.request import HttpRequest
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 CONTEXT_SEPARATOR: Literal["\x04"]
 LANGUAGE_CODE_MAX_LENGTH: int

--- a/django-stubs/views/decorators/cache.pyi
+++ b/django-stubs/views/decorators/cache.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/clickjacking.pyi
+++ b/django-stubs/views/decorators/clickjacking.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/common.pyi
+++ b/django-stubs/views/decorators/common.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/csp.pyi
+++ b/django-stubs/views/decorators/csp.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable, Collection, Mapping
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/csrf.pyi
+++ b/django-stubs/views/decorators/csrf.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
 from django.middleware.csrf import CsrfViewMiddleware
+from typing_extensions import TypeVar
 
 csrf_protect: Callable[[_F], _F]
 

--- a/django-stubs/views/decorators/debug.pyi
+++ b/django-stubs/views/decorators/debug.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/gzip.pyi
+++ b/django-stubs/views/decorators/gzip.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _C = TypeVar("_C", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/http.pyi
+++ b/django-stubs/views/decorators/http.pyi
@@ -1,6 +1,8 @@
 from collections.abc import Callable, Container
 from datetime import datetime
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/decorators/vary.pyi
+++ b/django-stubs/views/decorators/vary.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 

--- a/django-stubs/views/generic/dates.pyi
+++ b/django-stubs/views/generic/dates.pyi
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Sequence
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias
 
 from django.db import models
 from django.db.models.query import QuerySet, _OrderByFieldName
@@ -10,7 +10,7 @@ from django.utils.functional import _Getter
 from django.views.generic.base import View
 from django.views.generic.detail import BaseDetailView, SingleObjectTemplateResponseMixin
 from django.views.generic.list import MultipleObjectMixin, MultipleObjectTemplateResponseMixin
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _M = TypeVar("_M", bound=models.Model)
 _DatedItems: TypeAlias = tuple[_IndexableCollection[datetime.date] | None, _IndexableCollection[_M], dict[str, Any]]

--- a/django-stubs/views/generic/detail.pyi
+++ b/django-stubs/views/generic/detail.pyi
@@ -1,8 +1,9 @@
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Generic, overload
 
 from django.db import models
 from django.http import HttpRequest, HttpResponse
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
+from typing_extensions import TypeVar
 
 _M = TypeVar("_M", bound=models.Model)
 

--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal
 
 from django.db import models
 from django.forms.forms import BaseForm
@@ -8,7 +8,7 @@ from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _StrOrPromise
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _FormT = TypeVar("_FormT", bound=BaseForm)
 _ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm)

--- a/django-stubs/views/generic/list.pyi
+++ b/django-stubs/views/generic/list.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Sequence
-from typing import Any, Generic, Protocol, TypeVar, overload, type_check_only
+from typing import Any, Generic, Protocol, overload, type_check_only
 
 from django.core.paginator import Page, Paginator, _SupportsPagination
 from django.db.models import Model, QuerySet
 from django.db.models.query import _OrderByFieldName
 from django.http import HttpRequest, HttpResponse
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 _M = TypeVar("_M", bound=Model)
 

--- a/ext/django_stubs_ext/annotations.py
+++ b/ext/django_stubs_ext/annotations.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any, Generic, TypeVar
+from typing import Annotated, Any, Generic
 
 from django.db.models.base import Model
+from typing_extensions import TypeVar
 
 # Really, we would like to use TypedDict as a bound, but it's not possible
 _Annotations = TypeVar("_Annotations", covariant=True, bound=Mapping[str, Any])

--- a/ext/django_stubs_ext/db/models/manager.py
+++ b/ext/django_stubs_ext/db/models/manager.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
     from django.db.models.fields.related_descriptors import RelatedManager as RelatedManager
 
 else:
-    from typing import Protocol, TypeVar
+    from typing import Protocol
+
+    from typing_extensions import TypeVar
 
     _T = TypeVar("_T")
     _Through = TypeVar("_Through")

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic
 
 from django import VERSION
 from django.contrib.admin import ModelAdmin
@@ -30,7 +30,7 @@ from django.utils.functional import LazyObject, classproperty
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeletionMixin, FormMixin
 from django.views.generic.list import MultipleObjectMixin
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ ignore = [
 "_typeshed.Self".msg = "Use typing_extensions.Self (PEP 673) instead. If you type a metaclass, add a noqa"
 "typing.assert_type".msg = "Only available in Python 3.11 and above. Use `typing_extensions.assert_type` instead."
 "typing.Self".msg = "Only available in Python 3.11 and above. Use `typing_extensions.Self` instead."
+"typing.TypeVar".msg = "Only support the `default` parameter in Python 3.13 and above. Use `typing_extensions.TypeVar` instead."
 
 [tool.ruff.lint.isort]
 known-first-party = ["django_stubs_ext", "mypy_django_plugin"]

--- a/tests/assert_type/db/models/test_enums.py
+++ b/tests/assert_type/db/models/test_enums.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal
 
 from django.db.models import Choices, IntegerChoices, Model, TextChoices
 from django.utils.functional import _StrOrPromise, _StrPromise
 from django.utils.translation import gettext_lazy as _
-from typing_extensions import assert_type, override
+from typing_extensions import TypeVar, assert_type, override
 
 # Choices in a separate model to test that the plugin resolves types correctly.
 from tests.assert_type.db.models import _enums as imported
@@ -96,7 +96,6 @@ class VoidChoices(BaseEmptyChoices):
 
 # Choice type that has been aliased to test that the plugin resolves types correctly.
 CompassPoint = imported.Direction
-
 
 # Choice type that has been aliased by type to test that the plugin resolves types correctly.
 Award: type[TextChoices] = Medal
@@ -310,7 +309,6 @@ assert_type([member.value for choices in x3 for member in choices], list[bytes |
 assert_type(  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
     [member.value for choices in x3 for member in choices], list[Any]
 )
-
 
 # Assertions for choices objects defined and aliased in a model.
 assert_type(DeckModel.Suit.choices, list[tuple[int, _StrPromise]])  # pyright: ignore[reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]

--- a/tests/assert_type/db/models/test_managers.py
+++ b/tests/assert_type/db/models/test_managers.py
@@ -6,10 +6,9 @@ caused 'Must not defer during final iteration' crash in mypy.
 
 from __future__ import annotations
 
-from typing import TypeVar
-
 from django.db import models
 from django.db.models.query import QuerySet
+from typing_extensions import TypeVar
 
 T = TypeVar("T", bound="MyModel")
 

--- a/tests/assert_type/forms/test_fields_choices.py
+++ b/tests/assert_type/forms/test_fields_choices.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from django import forms
 from django.db import models
+from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence


### PR DESCRIPTION
# I have made things!

We declare a dependency on [typing_extensions](https://typing-extensions.readthedocs.io/en/latest/#) so this ensure `default=...` works with all supported python.
I've added a banned-api ruff rule to ensure if cannot regress

## Related issues
Had issue in [ci](https://github.com/typeddjango/django-stubs/actions/runs/25234008376/job/73996032755?pr=3317) for #3317 which made me think of this 

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
