### PR TITLE
Replace typing.TypeVar with typing_extensions.TypeVar in yml fixtures…

### DIFF
--- a/tests/typecheck/db/models/test_fields_choices.yml
+++ b/tests/typecheck/db/models/test_fields_choices.yml
@@ -29,10 +29,9 @@
 - case: db_models_valid_choices
   main: |
     from collections.abc import Callable, Mapping, Sequence
-    from typing import TypeVar
 
     from django.db import models
-    from typing_extensions import assert_type
+    from typing_extensions import TypeVar, assert_type
 
     _T = TypeVar("_T")
 

--- a/tests/typecheck/fields/test_custom_fields.yml
+++ b/tests/typecheck/fields/test_custom_fields.yml
@@ -34,7 +34,8 @@
                 from django.db import models
                 from django.db.models import fields
 
-                from typing import Any, Generic, TypeVar
+                from typing import Any, Generic
+                from typing_extensions import TypeVar
 
                 _ST = TypeVar("_ST", contravariant=True)
                 _GT = TypeVar("_GT", covariant=True)

--- a/tests/typecheck/fields/test_nullable.yml
+++ b/tests/typecheck/fields/test_nullable.yml
@@ -122,7 +122,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 _ST = TypeVar("_ST", contravariant=True)

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -102,7 +102,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 _ST = TypeVar("_ST", contravariant=True)
@@ -842,7 +842,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import Any, TypeVar
+                from typing import Any
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 _ST = TypeVar("_ST", contravariant=True)
@@ -1022,8 +1023,7 @@
 -   case: many_to_many_field_can_be_used_in_alias
     main: |
         from collections.abc import Sequence
-        from typing import TypeVar
-        from typing_extensions import TypeAlias
+        from typing_extensions import TypeAlias, TypeVar
         from django.db import models
         T = TypeVar("T", bound=models.Model)
         ManyToManyFieldAlias: TypeAlias = models.ManyToManyField[T, T]

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -15,8 +15,8 @@
         -   path: myapp/models.py
             content: |
                 from django.db import models
-                from typing import ClassVar, TypeVar
-                from typing_extensions import Self
+                from typing import ClassVar
+                from typing_extensions import Self, TypeVar
 
                 M = TypeVar("M", bound=models.Model, covariant=True)
 
@@ -69,7 +69,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 M = TypeVar("M", bound=models.Model, covariant=True)
@@ -262,9 +262,9 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-              from typing import Generic, TypeVar
+              from typing import Generic
               from django.db import models
-              from typing_extensions import Self, override as typing_override
+              from typing_extensions import Self, TypeVar, override as typing_override
 
               T = TypeVar("T", bound=models.Model)
               T_2 = TypeVar("T_2", bound=models.Model)
@@ -331,7 +331,8 @@
             content: |
                 from __future__ import annotations
                 from collections.abc import Collection
-                from typing import Generic, TypeVar
+                from typing import Generic
+                from typing_extensions import TypeVar
 
                 from django.db import models
 

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -16,8 +16,7 @@
             content: |
                 from django.db import models
                 from django.db.models.manager import Manager
-                from typing import TypeVar
-                from typing_extensions import Self
+                from typing_extensions import Self, TypeVar
 
                 M = TypeVar("M", covariant=True, bound=models.Model)
 
@@ -87,7 +86,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
                 from django.db.models.manager import Manager
 
@@ -162,8 +161,9 @@
         -   path: myapp/__init__.py
         -   path: myapp/querysets.py
             content: |
-                from typing import TypeVar, TYPE_CHECKING
+                from typing import TYPE_CHECKING
 
+                from typing_extensions import TypeVar
                 from django.db import models
                 from django.db.models.manager import Manager
                 if TYPE_CHECKING:
@@ -199,8 +199,9 @@
         -   path: myapp/__init__.py
         -   path: myapp/querysets.py
             content: |
-                from typing import TypeVar, TYPE_CHECKING
+                from typing import TYPE_CHECKING
 
+                from typing_extensions import TypeVar
                 from django.db import models
                 from django.db.models.manager import Manager
                 if TYPE_CHECKING:
@@ -893,8 +894,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar, ClassVar
-                from typing_extensions import Self
+                from typing import ClassVar
+                from typing_extensions import Self, TypeVar
                 from django.db import models
                 from django.db.models.manager import Manager
 
@@ -954,8 +955,8 @@
 
 -   case: test_queryset_arg_as_unsupported_expressions
     main: |
-        from typing import Generic, TypeVar
-        from typing_extensions import TypeAlias, reveal_type
+        from typing import Generic
+        from typing_extensions import TypeAlias, TypeVar, reveal_type
         from django.db import models
         from django.db.models.manager import Manager
 
@@ -1019,7 +1020,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
                 from django.db.models.manager import Manager
 

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -44,8 +44,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import Generic, TypeVar
-                from typing_extensions import reveal_type
+                from typing import Generic
+                from typing_extensions import TypeVar, reveal_type
                 from django.db import models
 
                 _T = TypeVar('_T', bound=models.Model)
@@ -71,8 +71,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import Generic, TypeVar
-                from typing_extensions import reveal_type
+                from typing import Generic
+                from typing_extensions import TypeVar, reveal_type
                 from django.db import models
 
                 _T = TypeVar('_T', bound=models.Model)
@@ -97,7 +97,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
                 _T = TypeVar('_T', bound=models.Model)
                 class CustomManager(models.Manager[_T]):
@@ -116,7 +116,7 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import TypeVar
+                from typing_extensions import TypeVar
                 from django.db import models
                 from django_stubs_ext.db.models import TypedModelMeta
 
@@ -259,7 +259,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import Generic, TypeVar
+                from typing import Generic
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 T1 = TypeVar("T1", bound="AbstractBase1")
@@ -646,8 +647,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import ClassVar, TypeVar
-                from typing_extensions import Self
+                from typing import ClassVar
+                from typing_extensions import Self, TypeVar
                 from django.db import models
 
                 T = TypeVar("T", bound="MyModel")
@@ -678,12 +679,13 @@
     out: |
         main:3: note: Revealed type is "myapp.models.MySubManager"
         main:4: note: Revealed type is "Any"
-        myapp/models:9: error: Missing type arguments for generic type "MyManager"  [type-arg]
+        myapp/models:10: error: Missing type arguments for generic type "MyManager"  [type-arg]
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
-                from typing import ClassVar, TypeVar
+                from typing import ClassVar
+                from typing_extensions import TypeVar
                 from django.db import models
 
                 T = TypeVar("T", bound="MyModel")

--- a/tests/typecheck/models/test_abstract.yml
+++ b/tests/typecheck/models/test_abstract.yml
@@ -81,7 +81,8 @@
 - case: test_abstract_model_type_cannot_be_used_as_runtime_arg
   main: |
       from myapp.models import Abstract, Concrete, LiteralAbstract
-      from typing import Generic, TypeVar, overload
+      from typing import Generic, overload
+      from typing_extensions import TypeVar
 
       Abstract()  # E: Cannot instantiate abstract class "Abstract" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
       LiteralAbstract()  # E: Cannot instantiate abstract class "LiteralAbstract" with abstract attributes "DoesNotExist", "MultipleObjectsReturned" and "NotUpdated"  [abstract]
@@ -183,8 +184,8 @@
     -   path: myapp/__init__.py
     -   path: myapp/models.py
         content: |
-            from typing import Protocol, TypeVar
-            from typing_extensions import reveal_type
+            from typing import Protocol
+            from typing_extensions import TypeVar, reveal_type
             from django.db import models
             from django_stubs_ext.db.models import TypedModelMeta
 

--- a/tests/typecheck/models/test_inheritance.yml
+++ b/tests/typecheck/models/test_inheritance.yml
@@ -128,8 +128,8 @@
 
                 from django.db.models import Model
                 from django.db.models.manager import Manager
-                from typing import ClassVar, Generic, TypeVar
-                from typing_extensions import Self
+                from typing import ClassVar, Generic
+                from typing_extensions import Self, TypeVar
 
                 M = TypeVar("M", bound=Model, covariant=True)
 


### PR DESCRIPTION
# I have made things!
follow-up to #3350 for some I missed because ruff does not run in yml tests


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
