### PR TITLE
Add ASGI application overload to path() and re_path() in urls/conf.pyi

### DIFF
--- a/django-stubs/urls/conf.pyi
+++ b/django-stubs/urls/conf.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from types import ModuleType
 from typing import Any, TypeAlias, overload
 
@@ -9,6 +9,14 @@ from ..http.response import HttpResponseBase
 
 _URLConf: TypeAlias = str | ModuleType | Sequence[_AnyURL]
 _IncludedURLConf: TypeAlias = tuple[Sequence[URLResolver | URLPattern], str | None, str | None]
+_ASGIApp: TypeAlias = Callable[
+    [
+        Mapping[str, Any],
+        Callable[[], Awaitable[Mapping[str, Any]]],
+        Callable[[Mapping[str, Any]], Awaitable[None]],
+    ],
+    Coroutine[Any, Any, None],
+]
 
 def include(arg: _URLConf | tuple[_URLConf, str], namespace: str | None = None) -> _IncludedURLConf: ...
 
@@ -24,6 +32,13 @@ def path(
 def path(
     route: _StrOrPromise,
     view: Callable[..., Coroutine[Any, Any, HttpResponseBase]],
+    kwargs: dict[str, Any] | None = None,
+    name: str | None = None,
+) -> URLPattern: ...
+@overload
+def path(
+    route: _StrOrPromise,
+    view: _ASGIApp,
     kwargs: dict[str, Any] | None = None,
     name: str | None = None,
 ) -> URLPattern: ...
@@ -51,6 +66,13 @@ def re_path(
 def re_path(
     route: _StrOrPromise,
     view: Callable[..., Coroutine[Any, Any, HttpResponseBase]],
+    kwargs: dict[str, Any] | None = None,
+    name: str | None = None,
+) -> URLPattern: ...
+@overload
+def re_path(
+    route: _StrOrPromise,
+    view: _ASGIApp,
     kwargs: dict[str, Any] | None = None,
     name: str | None = None,
 ) -> URLPattern: ...


### PR DESCRIPTION
## Add ASGI application overload to `path()` and `re_path()`                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
### What Changed
                                                                                                                                                                                                                                                                               
Added a new `_ASGIApp` type alias and a corresponding `@overload` to both `path()` and `re_path()` in `django-stubs/urls/conf.pyi`.
                                                                                                                                                                                                                                                                               
**`_ASGIApp`** is defined as:
```python
_ASGIApp: TypeAlias = Callable[
    [
        Mapping[str, Any],
        Callable[[], Awaitable[Mapping[str, Any]]],
        Callable[[Mapping[str, Any]], Awaitable[None]],
    ],
    Coroutine[Any, Any, None],
]
```
This precisely models the ASGI 3 callable contract:  `(scope, receive, send) -> Coroutine[Any, Any, None]`.

Both path() and re_path() now have an additional overload:
```python
@overload
def path(
    route: _StrOrPromise,
    view: _ASGIApp,
    kwargs: dict[str, Any] | None = None,
    name: str | None = None,
) -> URLPattern: ...
```
`Awaitable` and `Mapping` were also added to the `collections.abc` import line to support the new type alias.

---
Why This Change Is Needed

Django Channels is a widely-used first-party extension to Django for WebSocket and long-lived connection support. When configuring WebSocket URL routing with `channels.routing.URLRouter`, developers follow the pattern recommended in the official Django Channels documentation:

```python
from django.urls import path
from myapp.consumers import MyConsumer

websocket_urlpatterns = [
    path("ws/progress/<str:task_id>/", MyConsumer.as_asgi()),
]
```

`Consumer.as_asgi()` returns an ASGI callable — an async function with the signature `(scope, receive, send) -> None`. This return type is `Coroutine[Any, Any, None]`, not `Coroutine[Any, Any, HttpResponseBase]`.

The existing overloads in `conf.pyi` only accept:
- Sync Django views: `Callable[..., HttpResponseBase]`
- Async Django views: `Callable[..., Coroutine[Any, Any, HttpResponseBase]]`
- `include()` tuples
- URL sequences

None of these match the ASGI callable shape. As a result, any project using django-stubs alongside Django Channels gets a false positive type warning on every WebSocket path() entry, with no compliant way to suppress it.

---
What This Fixes

- Eliminates the spurious Unexpected type(s): `(str, _ASGIApplicationProtocol)` warning raised by `Pylance`, `mypy`, and other type checkers when passing a `Consumer.as_asgi()` result to `path()` or `re_path()`
- Removes the need for `# type: ignore[arg-type]` workarounds in Django Channels projects, which would otherwise be the only escape hatch
- Aligns the stubs with the pattern explicitly recommended in the official Django Channels documentation

---
Future Scope and Improvements

- Channels-specific stubs package: As Django Channels matures, a dedicated `django-channels-stubs` package (similar to `djangorestframework-stubs`) could provide richer typing for consumers, channel layers, and middleware. The `_ASGIApp` alias introduced here could serve as the shared boundary type between both packages.
- URLRouter typing: `channels.routing.URLRouter.__init__` currently accepts an untyped routes argument. With `_ASGIApp`  established as a known type in the stubs ecosystem, a future effort could type `URLRouter` to accept `Sequence[URLPattern]` where the callback is `_ASGIApp | ViewCallable`, giving end-to-end type coverage for WebSocket routing.
- Broader ASGI support: The `_ASGIApp` alias precisely models the ASGI 3 specification rather than being channels-specific. This opens the door for typing ASGI middleware, lifespan handlers, and other ASGI-native Django patterns if they are passed through `path()` in future frameworks.

---
Scalability Improvements

The `_ASGIApp` alias is defined at the type alias level, not as a Protocol subclass, keeping it lightweight for the type checker. Because it is a `TypeAlias` rather than a runtime object, it carries zero import cost in production. The alias is reused identically across both `path()` and `re_path()`, so any future revision to the ASGI callable contract (e.g., if scope becomes more precisely typed) requires a change in exactly one place.

---