### PR TITLE
Accept single str/Combinable for Aggregate.order_by

### DIFF
--- a/django-stubs/contrib/postgres/aggregates/mixins.pyi
+++ b/django-stubs/contrib/postgres/aggregates/mixins.pyi
@@ -10,8 +10,8 @@ class OrderableAggMixin:
     def __init__(
         self,
         *expressions: BaseExpression | Combinable | str,
-        ordering: Sequence[_OrderByFieldName] = ...,
-        order_by: Sequence[_OrderByFieldName] = ...,
+        ordering: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
+        order_by: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
         **extra: Any,
     ) -> None: ...
     @override

--- a/django-stubs/db/models/aggregates.pyi
+++ b/django-stubs/db/models/aggregates.pyi
@@ -21,7 +21,7 @@ class Aggregate(Func):
         distinct: bool = False,
         filter: Any | None = None,
         default: Any | None = None,
-        order_by: Sequence[_OrderByFieldName] | None = None,
+        order_by: _OrderByFieldName | Sequence[_OrderByFieldName] | None = None,
         **extra: Any,
     ) -> None: ...
     @property

--- a/tests/assert_type/contrib/postgres/test_aggregates.py
+++ b/tests/assert_type/contrib/postgres/test_aggregates.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import F
+
+ArrayAgg("title", order_by="title")
+ArrayAgg("title", order_by="-title")
+ArrayAgg("title", order_by=F("title"))
+ArrayAgg("title", order_by=F("title").desc())
+ArrayAgg("title", order_by=["-title", F("title")])
+ArrayAgg("title", order_by=("-title", F("title").desc()))

--- a/tests/assert_type/db/models/test_aggregates.py
+++ b/tests/assert_type/db/models/test_aggregates.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from django.db.models import F
+from django.db.models.aggregates import Aggregate
+
+Aggregate("title", order_by="title")
+Aggregate("title", order_by="-title")
+Aggregate("title", order_by=F("title"))
+Aggregate("title", order_by=F("title").desc())
+Aggregate("title", order_by=["-title", F("title")])
+Aggregate("title", order_by=("-title", F("title").desc()))
+Aggregate("title", order_by=None)


### PR DESCRIPTION
# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

Django's `OrderByList.from_param` accepts a single string, a single expression, or a list/tuple of either. The stubs only typed the sequence form, so passing a single expression like ArrayAgg("title", order_by=F("title")) was rejected by mypy even though it is valid Django code. Fixed it by widening the accepted types accordingly.


## Related issues
Fixes https://github.com/typeddjango/django-stubs/issues/3356

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
