### PR TITLE
Expose Aggregate kwargs on subclass __init__ stubs

### DIFF
--- a/django-stubs/contrib/postgres/aggregates/general.pyi
+++ b/django-stubs/contrib/postgres/aggregates/general.pyi
@@ -1,9 +1,12 @@
+from collections.abc import Sequence
 from typing import Any, ClassVar
 
 from django.contrib.postgres.fields import ArrayField
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Aggregate, BooleanField, JSONField, TextField
 from django.db.models.expressions import BaseExpression, Combinable
+from django.db.models.query import _OrderByFieldName
+from django.db.models.query_utils import Q
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import Self, override
 
@@ -51,7 +54,18 @@ class JSONBAgg(OrderableAggMixin, Aggregate):
 
 class StringAgg(OrderableAggMixin, Aggregate):
     output_field: ClassVar[TextField]
-    def __init__(self, expression: BaseExpression | Combinable | str, delimiter: Any, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: BaseExpression | Combinable | str,
+        delimiter: Any,
+        *,
+        distinct: bool = False,
+        filter: Q | None = None,
+        default: Any | None = None,
+        ordering: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
+        order_by: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
+        **extra: Any,
+    ) -> None: ...
     @override
     def resolve_expression(
         self,

--- a/django-stubs/contrib/postgres/aggregates/mixins.pyi
+++ b/django-stubs/contrib/postgres/aggregates/mixins.pyi
@@ -3,6 +3,7 @@ from typing import Any, ClassVar
 
 from django.db.models.expressions import BaseExpression, Combinable
 from django.db.models.query import _OrderByFieldName
+from django.db.models.query_utils import Q
 from typing_extensions import override
 
 class OrderableAggMixin:
@@ -10,6 +11,9 @@ class OrderableAggMixin:
     def __init__(
         self,
         *expressions: BaseExpression | Combinable | str,
+        distinct: bool = False,
+        filter: Q | None = None,
+        default: Any | None = None,
         ordering: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
         **extra: Any,

--- a/django-stubs/db/models/aggregates.pyi
+++ b/django-stubs/db/models/aggregates.pyi
@@ -6,6 +6,7 @@ from django.db.models.expressions import Combinable, Func
 from django.db.models.fields import IntegerField
 from django.db.models.functions.mixins import FixDurationInputMixin, NumericOutputFieldMixin
 from django.db.models.query import _OrderByFieldName
+from django.db.models.query_utils import Q
 from django.db.models.sql.compiler import SQLCompiler, _AsSqlType
 from typing_extensions import override
 
@@ -19,7 +20,7 @@ class Aggregate(Func):
         self,
         *expressions: Any,
         distinct: bool = False,
-        filter: Any | None = None,
+        filter: Q | None = None,
         default: Any | None = None,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] | None = None,
         **extra: Any,
@@ -41,16 +42,41 @@ class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate): ...
 
 class Count(Aggregate):
     output_field: ClassVar[IntegerField]
-    def __init__(self, expression: Any, filter: Any | None = None, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: Combinable | str,
+        filter: Q | None = None,
+        *,
+        distinct: bool = False,
+        **extra: Any,
+    ) -> None: ...
 
 class Max(Aggregate): ...
 class Min(Aggregate): ...
 
 class StdDev(NumericOutputFieldMixin, Aggregate):
-    def __init__(self, expression: Any, sample: bool = False, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: Combinable | str,
+        sample: bool = False,
+        *,
+        filter: Q | None = None,
+        default: Any | None = None,
+        **extra: Any,
+    ) -> None: ...
 
 class StringAgg(Aggregate):
-    def __init__(self, expression: Combinable | str, delimiter: str | Combinable, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: Combinable | str,
+        delimiter: str | Combinable,
+        *,
+        distinct: bool = False,
+        filter: Q | None = None,
+        default: Any | None = None,
+        order_by: _OrderByFieldName | Sequence[_OrderByFieldName] | None = None,
+        **extra: Any,
+    ) -> None: ...
     def as_oracle(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
     def as_mysql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper, **extra_context: Any) -> _AsSqlType: ...
     @override
@@ -59,6 +85,14 @@ class StringAgg(Aggregate):
 class Sum(FixDurationInputMixin, Aggregate): ...
 
 class Variance(NumericOutputFieldMixin, Aggregate):
-    def __init__(self, expression: Any, sample: bool = False, **extra: Any) -> None: ...
+    def __init__(
+        self,
+        expression: Combinable | str,
+        sample: bool = False,
+        *,
+        filter: Q | None = None,
+        default: Any | None = None,
+        **extra: Any,
+    ) -> None: ...
 
 __all__ = ["Aggregate", "AnyValue", "Avg", "Count", "Max", "Min", "StdDev", "StringAgg", "Sum", "Variance"]

--- a/tests/assert_type/contrib/postgres/test_aggregates.py
+++ b/tests/assert_type/contrib/postgres/test_aggregates.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import F
+from django.db.models import F, Q
 
+# ArrayAgg: order_by accepts single str/Combinable or sequence of either
 ArrayAgg("title", order_by="title")
 ArrayAgg("title", order_by="-title")
 ArrayAgg("title", order_by=F("title"))
 ArrayAgg("title", order_by=F("title").desc())
 ArrayAgg("title", order_by=["-title", F("title")])
 ArrayAgg("title", order_by=("-title", F("title").desc()))
+# Aggregate kwargs forwarded through OrderableAggMixin
+ArrayAgg("title", distinct=True, filter=Q(active=True), order_by="-title", default=[])
+ArrayAgg("title", order_by=123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+ArrayAgg("title", order_by=[123])  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+ArrayAgg("title", filter=F("a"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+ArrayAgg("title", filter="active")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]

--- a/tests/assert_type/db/models/test_aggregates.py
+++ b/tests/assert_type/db/models/test_aggregates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db.models import F
+from django.db.models import Count, F, Q, StdDev, StringAgg, Variance
 from django.db.models.aggregates import Aggregate
 
 Aggregate("title", order_by="title")
@@ -10,3 +10,28 @@ Aggregate("title", order_by=F("title").desc())
 Aggregate("title", order_by=["-title", F("title")])
 Aggregate("title", order_by=("-title", F("title").desc()))
 Aggregate("title", order_by=None)
+
+# Count: filter is positional-or-keyword (unique to Count)
+Count("id", distinct=True)
+Count("id", filter=Q(active=True))
+Count("id", Q(active=True))  # filter as positional
+Count(123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+Count("id", filter="active")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+Count("id", filter=F("a"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+
+# StdDev: second positional is `sample: bool`, not filter; filter/default are keyword-only
+StdDev("score", filter=Q(active=True), default=0)
+StdDev([])  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+StdDev("score", Q(active=True))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+
+# Variance: same shape as StdDev
+Variance("score", filter=Q(active=True), default=0)
+Variance({})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+
+# StringAgg: full Aggregate kwarg surface (distinct, filter, default, order_by)
+StringAgg("title", delimiter=",", order_by="title")
+StringAgg("title", delimiter=",", order_by=F("title"))
+StringAgg("title", delimiter=",", order_by=["-title", F("title")])
+StringAgg("title", delimiter=",", distinct=True, filter=Q(active=True), order_by="-title", default="")
+StringAgg("title", delimiter=",", filter=F("a"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+StringAgg("title", delimiter=",", order_by=123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
See https://github.com/typeddjango/django-stubs/pull/3357#discussion_r3194693967

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
