### PR TITLE
Resolve default_alias for positional Aggregate in annotate()

### DIFF
--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -58,6 +58,7 @@ QUERYDICT_CLASS_FULLNAME = "django.http.request.QueryDict"
 COMBINABLE_EXPRESSION_FULLNAME = "django.db.models.expressions.Combinable"
 F_EXPRESSION_FULLNAME = "django.db.models.expressions.F"
 FUNC_EXPRESSION_FULLNAME = "django.db.models.expressions.Func"
+AGGREGATE_CLASS_FULLNAME = "django.db.models.aggregates.Aggregate"
 
 ANY_ATTR_ALLOWED_CLASS_FULLNAME = "django_stubs_ext.AnyAttrAllowed"
 TYPED_MODEL_META_FULLNAME = "django_stubs_ext.db.models.TypedModelMeta"

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -18,12 +18,14 @@ from mypy.errorcodes import NO_REDEF
 from mypy.nodes import (
     ARG_NAMED,
     ARG_NAMED_OPT,
+    ARG_POS,
     ARG_STAR,
     CallExpr,
     Decorator,
     Expression,
     ListExpr,
     SetExpr,
+    StrExpr,
     TupleExpr,
     Var,
 )
@@ -227,20 +229,48 @@ def extract_proper_type_queryset_values_list(ctx: MethodContext, django_context:
     return ret
 
 
+def _aggregate_default_alias(expr: Expression, expr_type: MypyType) -> str | None:
+    """Mirror `Aggregate.default_alias`: ``<source_expression>__<aggregate_name_lower>``.
+
+    Django generates a default alias only for aggregates with a single source
+    expression that has a `name`; complex expressions raise at runtime, so the
+    plugin matches that and returns ``None`` for anything else.
+
+    See https://docs.djangoproject.com/en/dev/topics/db/aggregation/#generating-aggregates-for-each-item-in-a-queryset
+    """
+    if not (
+        isinstance(expr, CallExpr)
+        and isinstance(proper := get_proper_type(expr_type), Instance)
+        and proper.type.has_base(fullnames.AGGREGATE_CLASS_FULLNAME)
+    ):
+        return None
+    source: Expression | None = None
+    for arg, kind in zip(expr.args, expr.arg_kinds, strict=False):
+        if kind != ARG_POS:
+            continue
+        if source is not None:
+            return None
+        source = arg
+    # TODO: consider switching to `helpers.resolve_string_attribute_value` once
+    # `gather_kwargs` threads `django_context` through — that would also handle
+    # `Count(NAME_CONST)` and `Count(settings.X)`.
+    if not isinstance(source, StrExpr):
+        return None
+    return f"{source.value}__{proper.type.name.lower()}"
+
+
 def gather_kwargs(ctx: MethodContext) -> dict[str, MypyType] | None:
-    num_args = len(ctx.arg_kinds)
-    kwargs = {}
+    kwargs: dict[str, MypyType] = {}
     named = (ARG_NAMED, ARG_NAMED_OPT)
-    for i in range(num_args):
-        if not ctx.arg_kinds[i]:
-            continue
-        if any(kind not in named for kind in ctx.arg_kinds[i]):
-            # Only named arguments supported
-            continue
-        for j in range(len(ctx.arg_names[i])):
-            name = ctx.arg_names[i][j]
-            assert name is not None
-            kwargs[name] = ctx.arg_types[i][j]
+    for slot in zip(ctx.arg_kinds, ctx.arg_types, ctx.arg_names, ctx.args, strict=False):
+        for kind, arg_type, name, arg in zip(*slot, strict=False):
+            if kind in named:
+                assert name is not None
+                kwargs[name] = arg_type
+            elif kind == ARG_POS:
+                alias = _aggregate_default_alias(arg, arg_type)
+                if alias is not None:
+                    kwargs[alias] = arg_type
     return kwargs
 
 

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -152,14 +152,20 @@
                     username = models.CharField(max_length=100)
 
 
--   case: annotate_no_field_name
+-   case: annotate_positional_aggregate_uses_default_alias
     main: |
         from typing_extensions import reveal_type
         from myapp.models import User
         from django.db.models import Count
 
-        qs = User.objects.annotate(Count('id'))
-        reveal_type(qs) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.User, myapp.models.User]"
+        # Positional Aggregate gets Django's default_alias: <field>__<name_lower>.
+        user = User.objects.annotate(Count('id')).get()
+        reveal_type(user.id__count)  # N: Revealed type is "int"
+
+        # Multiple positional aggregates produce multiple default aliases.
+        multi = User.objects.annotate(Count('id'), Count('username')).get()
+        reveal_type(multi.id__count)        # N: Revealed type is "int"
+        reveal_type(multi.username__count)  # N: Revealed type is "int"
 
     installed_apps:
         - myapp
@@ -181,8 +187,7 @@
 
         def animals_only(param: Animal) -> None:
             pass
-        # Make sure that the type is still checked when no annotation was produced
-        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "User"; expected "Animal"  [arg-type]
+        animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "User@AnnotatedWith[TypedDict({'id__count': int})]"; expected "Animal"  [arg-type]
 
         def users_allowed(param: User) -> None:
             # But this function accepts only the original User type, so any attr access is not allowed within this function


### PR DESCRIPTION
`QuerySet.annotate(Count("field"))` lost its annotation in the plugin because `gather_kwargs` only collected named arguments. Mirror Django's Aggregate.default_alias (`<source>__<name_lower>`) for positional aggregates with a single string source so the resulting attribute is typed.

## Related issues

Fixes https://github.com/typeddjango/django-stubs/issues/2382

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
