### PR TITLE
Re-enable `empty-body` error code for mypy and ty

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,6 @@ strict = true
 strict_equality_for_none = true
 warn_unreachable = true
 
-disable_error_code = empty-body
 enable_error_code =
     deprecated,
     exhaustive-match,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,6 @@ error-on-warning = true
 # Respect only `# ty: ignore` (ignore `# type: ignore`)
 respect-type-ignore-comments = false
 
-[tool.ty.rules]
-empty-body = "ignore"
-
 [tool.codespell]
 ignore-words-list = "aadd,acount,asend,indentity,nam"
 

--- a/tests/assert_type/contrib/admin/test_decorators.py
+++ b/tests/assert_type/contrib/admin/test_decorators.py
@@ -12,22 +12,27 @@ if TYPE_CHECKING:
 
 class DisplayModel(models.Model):
     @admin.display
-    def display_bare(self) -> str: ...
+    def display_bare(self) -> str:
+        raise NotImplementedError
 
     @admin.display(ordering="field", description="Something", empty_value="...")
-    def display_fancy(self) -> bool: ...
+    def display_fancy(self) -> bool:
+        raise NotImplementedError
 
     @property
     @admin.display
-    def display_property(self) -> str: ...
+    def display_property(self) -> str:
+        raise NotImplementedError
 
 
 @admin.display
-def freestanding_display_bare(obj: DisplayModel) -> str: ...
+def freestanding_display_bare(obj: DisplayModel) -> str:
+    raise NotImplementedError
 
 
 @admin.display(boolean=True)
-def freestanding_display_fancy(obj: DisplayModel) -> bool: ...
+def freestanding_display_fancy(obj: DisplayModel) -> bool:
+    raise NotImplementedError
 
 
 @admin.register(DisplayModel, DisplayModel, site=None)
@@ -43,10 +48,12 @@ class DisplayModelAdmin(admin.ModelAdmin[DisplayModel]):
     ]
 
     @admin.display
-    def admin_display_bare(self, obj: DisplayModel) -> str: ...
+    def admin_display_bare(self, obj: DisplayModel) -> str:
+        raise NotImplementedError
 
     @admin.display(boolean=True, ordering="field", description="Something")
-    def admin_display_fancy(self, obj: DisplayModel) -> bool: ...
+    def admin_display_fancy(self, obj: DisplayModel) -> bool:
+        raise NotImplementedError
 
 
 # 'boolean' and 'empty_value' are mutually exclusive arguments
@@ -84,25 +91,29 @@ class ActionModel(models.Model): ...
 @admin.action
 def freestanding_action_bare(
     modeladmin: ActionModelAdmin, request: HttpRequest, queryset: QuerySet[ActionModel]
-) -> None: ...
+) -> None:
+    raise NotImplementedError
 
 
 @admin.action(description="Some text here", permissions=["test"])
 def freestanding_action_fancy(
     modeladmin: ActionModelAdmin, request: HttpRequest, queryset: QuerySet[ActionModel]
-) -> None: ...
+) -> None:
+    raise NotImplementedError
 
 
 @admin.action
 def freestanding_action_http_response(
     modeladmin: ActionModelAdmin, request: HttpRequest, queryset: QuerySet[ActionModel]
-) -> HttpResponse: ...
+) -> HttpResponse:
+    raise NotImplementedError
 
 
 @admin.action
 def freestanding_action_file_response(
     modeladmin: ActionModelAdmin, request: HttpRequest, queryset: QuerySet[ActionModel]
-) -> FileResponse: ...
+) -> FileResponse:
+    raise NotImplementedError
 
 
 @admin.register(ActionModel)
@@ -117,13 +128,17 @@ class ActionModelAdmin(admin.ModelAdmin[ActionModel]):
     ]
 
     @admin.action
-    def method_action_bare(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> None: ...
+    def method_action_bare(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> None:
+        raise NotImplementedError
 
     @admin.action(description="Some text here", permissions=["test"])
-    def method_action_fancy(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> None: ...
+    def method_action_fancy(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> None:
+        raise NotImplementedError
 
     @admin.action(description="Some text here", permissions=["test"])
-    def method_action_http_response(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> HttpResponse: ...
+    def method_action_http_response(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> HttpResponse:
+        raise NotImplementedError
 
     @admin.action(description="Some text here", permissions=["test"])
-    def method_action_file_response(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> FileResponse: ...
+    def method_action_file_response(self, request: HttpRequest, queryset: QuerySet[ActionModel]) -> FileResponse:
+        raise NotImplementedError

--- a/tests/assert_type/contrib/auth/test_decorators.py
+++ b/tests/assert_type/contrib/auth/test_decorators.py
@@ -13,8 +13,10 @@ lazy_url = reverse_lazy("namespace:url")
 
 
 @user_passes_test(lambda user: user.is_active, login_url=reversed_url)
-def my_view1(request: HttpRequest) -> HttpResponse: ...
+def my_view1(request: HttpRequest) -> HttpResponse:
+    raise NotImplementedError
 
 
 @user_passes_test(lambda user: user.is_active, login_url=lazy_url)
-def my_view2(request: HttpRequest) -> HttpResponse: ...
+def my_view2(request: HttpRequest) -> HttpResponse:
+    raise NotImplementedError

--- a/tests/assert_type/core/test_checks.py
+++ b/tests/assert_type/core/test_checks.py
@@ -25,18 +25,21 @@ assert_type(check_foo.tags, Sequence[str])
 
 
 @register
-def check_bar(*, app_configs: Sequence[AppConfig] | None, **kwargs: Any) -> list[CheckMessage]: ...
+def check_bar(*, app_configs: Sequence[AppConfig] | None, **kwargs: Any) -> list[CheckMessage]:
+    raise NotImplementedError
 
 
 assert_type(check_bar.tags, Sequence[str])
 
 
 @register
-def check_baz(**kwargs: Any) -> list[CheckMessage]: ...
+def check_baz(**kwargs: Any) -> list[CheckMessage]:
+    raise NotImplementedError
 
 
 assert_type(check_baz.tags, Sequence[str])
 
 
 @register()  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-specialization]  # ty: ignore[invalid-argument-type]
-def wrong_args(bla: int) -> list[CheckMessage]: ...
+def wrong_args(bla: int) -> list[CheckMessage]:
+    raise NotImplementedError

--- a/tests/assert_type/db/test_transaction.py
+++ b/tests/assert_type/db/test_transaction.py
@@ -35,7 +35,8 @@ assert_type(func2(1), list[object])
 
 # non_atomic_requests bare preserves function type
 @non_atomic_requests
-def view_func(request: HttpRequest) -> HttpResponse: ...
+def view_func(request: HttpRequest) -> HttpResponse:
+    raise NotImplementedError
 
 
 assert_type(view_func(HttpRequest()), HttpResponse)
@@ -43,7 +44,8 @@ assert_type(view_func(HttpRequest()), HttpResponse)
 
 # non_atomic_requests with extra args
 @non_atomic_requests
-def view_func2(request: HttpRequest, arg: str) -> HttpResponse: ...
+def view_func2(request: HttpRequest, arg: str) -> HttpResponse:
+    raise NotImplementedError
 
 
 assert_type(view_func2(HttpRequest(), "test"), HttpResponse)

--- a/tests/assert_type/urls/test_conf.py
+++ b/tests/assert_type/urls/test_conf.py
@@ -30,8 +30,12 @@ assert_type(path("login/", LoginView.as_view(), name="login1"), URLPattern)
 assert_type(path(_("login/"), LoginView.as_view(), name="login2"), URLPattern)
 
 
-def v1() -> HttpResponse: ...
-async def v2() -> HttpResponse: ...
+def v1() -> HttpResponse:
+    raise NotImplementedError
+
+
+async def v2() -> HttpResponse:
+    raise NotImplementedError
 
 
 assert_type(path("v1/", v1), URLPattern)
@@ -58,7 +62,8 @@ assert_type(static("/media/"), list[URLPattern])
 assert_type(static("/media/", document_root="/tmp/media"), list[URLPattern])
 
 
-def custom_serve(request: object, path: str) -> HttpResponse: ...
+def custom_serve(request: object, path: str) -> HttpResponse:
+    raise NotImplementedError
 
 
 assert_type(static("/media/", view=custom_serve), list[URLPattern])

--- a/tests/assert_type/utils/test_functional.py
+++ b/tests/assert_type/utils/test_functional.py
@@ -14,10 +14,12 @@ if TYPE_CHECKING:
 # cached_property: class vs instance attributes
 class Foo:
     @cached_property
-    def attr(self) -> list[str]: ...
+    def attr(self) -> list[str]:
+        raise NotImplementedError
 
     @cached_property  # type: ignore[misc]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
-    def attr2(self, arg2: str) -> list[str]: ...
+    def attr2(self, arg2: str) -> list[str]:
+        raise NotImplementedError
 
 
 f = Foo()
@@ -29,7 +31,8 @@ f.attr.func  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAcce
 class Bar(Foo):
     @property
     @override
-    def attr(self) -> list[str]: ...  # pyright: ignore[reportIncompatibleVariableOverride]
+    def attr(self) -> list[str]:  # pyright: ignore[reportIncompatibleVariableOverride]
+        raise NotImplementedError
 
 
 # May be overridden by ClassVar
@@ -41,7 +44,8 @@ class Quux(Foo):
 class Baz(Quux):
     @cached_property
     @override
-    def attr(self) -> list[str]: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleVariableOverride]  # pyrefly: ignore[bad-override]  # ty: ignore[invalid-attribute-override]
+    def attr(self) -> list[str]:  # type: ignore[override]  # pyright: ignore[reportIncompatibleVariableOverride]  # pyrefly: ignore[bad-override]  # ty: ignore[invalid-attribute-override]
+        raise NotImplementedError
 
 
 # str promise proxy
@@ -63,10 +67,12 @@ def test_str_or_promise(f2: StrOrPromise) -> None:
     assert_type("asd" + f2, str)
 
 
-def foo(content: str) -> None: ...
+def foo(content: str) -> None:
+    raise NotImplementedError
 
 
-def bar(content: Promise) -> None: ...
+def bar(content: Promise) -> None:
+    raise NotImplementedError
 
 
 foo(s)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
@@ -82,7 +88,8 @@ assert_type(copy.deepcopy(lazy_user), SimpleLazyObject[User])
 
 class Bam:
     @classproperty
-    def attr(cls: Any) -> str: ...
+    def attr(cls: Any) -> str:
+        raise NotImplementedError
 
 
 assert_type(Bam.attr, str)

--- a/tests/assert_type/views/test_decorators.py
+++ b/tests/assert_type/views/test_decorators.py
@@ -12,7 +12,8 @@ from typing_extensions import assert_type
         "report-uri": "/path/to/reports-endpoint/",
     }
 )
-def my_view(request: HttpRequest) -> HttpResponse: ...
+def my_view(request: HttpRequest) -> HttpResponse:
+    raise NotImplementedError
 
 
 @csp_report_only_override(
@@ -22,7 +23,8 @@ def my_view(request: HttpRequest) -> HttpResponse: ...
         "report-uri": "/path/to/reports-endpoint/",
     }
 )
-def my_view2(request: HttpRequest) -> HttpResponse: ...
+def my_view2(request: HttpRequest) -> HttpResponse:
+    raise NotImplementedError
 
 
 assert_type(my_view(HttpRequest()), HttpResponse)

--- a/tests/typecheck/contrib/auth/test_auth.yml
+++ b/tests/typecheck/contrib/auth/test_auth.yml
@@ -18,7 +18,8 @@
 
         def check_user(user: MyUser | AnonymousUser) -> bool: return True
         @user_passes_test(check_user)
-        def view(request: HttpRequest) -> HttpResponse: ...
+        def view(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth", "myapp")
         AUTH_USER_MODEL = "myapp.MyUser"
@@ -50,7 +51,8 @@
 
         def check_user(user: User | AnonymousUser) -> bool: return True
         @user_passes_test(check_user)
-        def view(request: HttpRequest) -> HttpResponse: ...
+        def view(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth", "myapp")
     files:
@@ -82,7 +84,8 @@
 
         def check_user(user: AbstractBaseUser | AnonymousUser) -> bool: return True
         @user_passes_test(check_user)
-        def view(request: HttpRequest) -> HttpResponse: ...
+        def view(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "myapp")
     files:

--- a/tests/typecheck/contrib/auth/test_decorators.yml
+++ b/tests/typecheck/contrib/auth/test_decorators.yml
@@ -10,33 +10,39 @@
         # Bare:
 
         @login_required
-        def view_func1(request: HttpRequest) -> HttpResponse: ...
+        def view_func1(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func1)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 
         @login_required
-        async def view_func2(request: HttpRequest) -> HttpResponse: ...
+        async def view_func2(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func2)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 
         # Fancy:
 
         @login_required(redirect_field_name='a', login_url='b')
-        def view_func3(request: WSGIRequest, arg: str) -> HttpResponse: ...
+        def view_func3(request: WSGIRequest, arg: str) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func3)  # N: Revealed type is "def (request: django.core.handlers.wsgi.WSGIRequest, arg: str) -> django.http.response.HttpResponse"
 
         @login_required(redirect_field_name='a', login_url='b')
-        async def view_func4(request: ASGIRequest, arg: str) -> HttpResponse: ...
+        async def view_func4(request: ASGIRequest, arg: str) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func4)  # N: Revealed type is "def (request: django.core.handlers.asgi.ASGIRequest, arg: str) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 
         # This is non-conventional usage, but covered in Django tests, so we allow it.
 
-        def view_func5(request: HttpRequest) -> HttpResponse: ...
+        def view_func5(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         wrapped_view = login_required(view_func5, redirect_field_name='a', login_url='b')
         reveal_type(wrapped_view)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 
         # Wrong:
 
         @login_required()  # E: Value of type variable "_VIEW" of function cannot be "Callable[[Any], str]"  [type-var]
-        def view_func6(request: Any) -> str: ...
+        def view_func6(request: Any) -> str:
+            raise NotImplementedError
 
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth", "myapp")
@@ -61,15 +67,18 @@
         from django.http import HttpRequest, HttpResponse
 
         @login_required
-        def view_func1(request: HttpRequest) -> HttpResponse: ...
+        def view_func1(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func1)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 
         @login_required
-        async def view_func2(request: HttpRequest) -> HttpResponse: ...
+        async def view_func2(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func2)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 
         @login_required()  # E: Value of type variable "_VIEW" of function cannot be "Callable[[Any], str]"  [type-var]
-        def view_func3(request: Any) -> str: ...
+        def view_func3(request: Any) -> str:
+            raise NotImplementedError
 
 
 -   case: user_passes_test
@@ -79,20 +88,24 @@
         from django.http import HttpRequest, HttpResponse
 
         @user_passes_test(lambda u: u.is_authenticated and u.is_active)
-        def view_func1(request: HttpRequest) -> HttpResponse: ...
+        def view_func1(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func1)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 
         @user_passes_test(lambda u: u.get_username().startswith('super'))
-        async def view_func2(request: HttpRequest) -> HttpResponse: ...
+        async def view_func2(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func2)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 
         # Wrong:
 
         @user_passes_test  # E: Argument 1 to "user_passes_test" has incompatible type "Callable[[HttpRequest], HttpResponse]"; expected "Callable[[User | AnonymousUser], bool]"  [arg-type]
-        def view_func3(request: HttpRequest) -> HttpResponse: ...
+        def view_func3(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
 
         @user_passes_test(lambda u: u.get_username().startswith('super'))  # E: Value of type variable "_VIEW" of function cannot be "Callable[[str], str]"  [type-var]
-        def view_func4(request: str) -> str: ...
+        def view_func4(request: str) -> str:
+            raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth")
 
@@ -104,19 +117,23 @@
         from django.http import HttpRequest, HttpResponse
 
         @permission_required('polls.can_vote')
-        def view_func1(request: HttpRequest) -> HttpResponse: ...
+        def view_func1(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func1)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> django.http.response.HttpResponse"
 
         @permission_required(['polls.can_vote', 'polls.can_close'], login_url='/abc')
-        async def view_func2(request: HttpRequest) -> HttpResponse: ...
+        async def view_func2(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
         reveal_type(view_func2)  # N: Revealed type is "def (request: django.http.request.HttpRequest) -> typing.Coroutine[Any, Any, django.http.response.HttpResponse]"
 
         # Wrong:
 
         @permission_required('polls.can_vote')  # E: Value of type variable "_VIEW" of function cannot be "Callable[[Any], str]"  [type-var]
-        def view_func3(request: Any) -> str: ...
+        def view_func3(request: Any) -> str:
+            raise NotImplementedError
 
         @permission_required  # E: Argument 1 to "permission_required" has incompatible type "Callable[[HttpRequest], HttpResponse]"; expected "Iterable[str] | str"  [arg-type]
-        def view_func4(request: HttpRequest) -> HttpResponse: ...
+        def view_func4(request: HttpRequest) -> HttpResponse:
+            raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ("django.contrib.contenttypes", "django.contrib.auth")

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -786,7 +786,7 @@
                 from django.db.models.manager import Manager
                 class TransactionQuerySet(models.QuerySet):
                     def custom(self) -> None:
-                        pass
+                        raise NotImplementedError
 
                 def TransactionManager() -> Manager:
                     return Manager.from_queryset(TransactionQuerySet)()
@@ -887,13 +887,13 @@
                     pass
                 class OrderManager(models.Manager):
                     def manager_method(self) -> int:
-                        pass
+                        raise NotImplementedError
                 class Order(models.Model):
                     objects = OrderManager()
                     user = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='orders')
                 class ProductQueryset(models.QuerySet):
                     def queryset_method(self) -> int:
-                        pass
+                        raise NotImplementedError
                 ProductManager = models.Manager.from_queryset(ProductQueryset)
                 class Product(models.Model):
                     objects = ProductManager()
@@ -1144,7 +1144,8 @@
                     explicit_descriptor: ClassVar[ReverseManyToOneDescriptor["MyModel"]]
 
                 class CustomManager(models.Manager["MyModel"]):
-                    def custom_method(self) -> int: ...
+                    def custom_method(self) -> int:
+                        raise NotImplementedError
 
                 class MyModel(models.Model):
                     rel = models.ForeignKey(
@@ -1640,7 +1641,8 @@
                     authors = models.ManyToManyField(Author)
 
                 class OtherQuerySet(models.QuerySet["Other"]):
-                    def custom(self) -> Self: ...
+                    def custom(self) -> Self:
+                        raise NotImplementedError
 
                 OtherManager = models.Manager.from_queryset(OtherQuerySet)
                 class Other(models.Model):

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -27,7 +27,8 @@
         func2(unannotated_user)
         func2(annotated_user)
 
-        def func3(user: WithAnnotations) -> None: ...
+        def func3(user: WithAnnotations) -> None:
+            raise NotImplementedError
 
         # With no arguments to 'WithAnnotations' it should become 'Any'
         reveal_type(func3)  # N: Revealed type is "def (user: Any)"
@@ -186,7 +187,7 @@
         annotated_user = qs.get()
 
         def animals_only(param: Animal) -> None:
-            pass
+            raise NotImplementedError
         animals_only(annotated_user) # E: Argument 1 to "animals_only" has incompatible type "User@AnnotatedWith[TypedDict({'id__count': int})]"; expected "Animal"  [arg-type]
 
         def users_allowed(param: User) -> None:
@@ -790,7 +791,7 @@
     AnnotatedModel = WithAnnotations[MyModel, MyAnnotations]
 
     def get_qs() -> QuerySet[AnnotatedModel]:
-        ...
+        raise NotImplementedError
 
     qs = get_qs()
 

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -21,12 +21,16 @@
                 M = TypeVar("M", bound=models.Model, covariant=True)
 
                 class BaseQuerySet(models.QuerySet[M]):
-                    def example_dict(self) -> dict[str, Self]: ...
+                    def example_dict(self) -> dict[str, Self]:
+                        raise NotImplementedError
 
                 class MyQuerySet(BaseQuerySet[M]):
-                    def example_simple(self) -> Self: ...
-                    def example_list(self) -> list[Self]: ...
-                    def just_int(self) -> int: ...
+                    def example_simple(self) -> Self:
+                        raise NotImplementedError
+                    def example_list(self) -> list[Self]:
+                        raise NotImplementedError
+                    def just_int(self) -> int:
+                        raise NotImplementedError
 
                 class MyModel(models.Model):
                     objects = MyQuerySet.as_manager()
@@ -270,32 +274,46 @@
               T_2 = TypeVar("T_2", bound=models.Model)
 
               class SomeMixin:
-                  def example_mixin(self, a: T) -> T: ...
+                  def example_mixin(self, a: T) -> T:
+                      raise NotImplementedError
 
               class OtherMixin(models.QuerySet[T]):
-                  def example_other_mixin(self) -> T: ...
-                  def example_union(self) -> T | list[T]: ...
+                  def example_other_mixin(self) -> T:
+                      raise NotImplementedError
+                  def example_union(self) -> T | list[T]:
+                      raise NotImplementedError
 
               class _MyModelQuerySet(OtherMixin[T], models.QuerySet[T], Generic[T]):
-                  def example(self) -> T: ...
-                  def override(self) -> T: ...
-                  def override2(self) -> T: ...
-                  def dummy_override(self) -> int: ...
-                  def test_sub_self(self) -> Self: ...
+                  def example(self) -> T:
+                      raise NotImplementedError
+                  def override(self) -> T:
+                      raise NotImplementedError
+                  def override2(self) -> T:
+                      raise NotImplementedError
+                  def dummy_override(self) -> int:
+                      raise NotImplementedError
+                  def test_sub_self(self) -> Self:
+                      raise NotImplementedError
 
               class _MyModelQuerySet2(SomeMixin, _MyModelQuerySet[T_2]):
-                  def example_2(self) -> T_2: ...
+                  def example_2(self) -> T_2:
+                      raise NotImplementedError
                   @typing_override
-                  def override(self) -> T_2: ...
+                  def override(self) -> T_2:
+                      raise NotImplementedError
                   @typing_override
-                  def override2(self) -> T_2: ...
+                  def override2(self) -> T_2:
+                      raise NotImplementedError
                   @typing_override
-                  def dummy_override(self) -> T_2: ...  # type: ignore[override]
-                  def test_self(self) -> Self: ...
+                  def dummy_override(self) -> T_2:  # type: ignore[override]
+                      raise NotImplementedError
+                  def test_self(self) -> Self:
+                      raise NotImplementedError
 
               class MyModelQuerySet(_MyModelQuerySet2["MyModel"]):
                   @typing_override
-                  def override(self) -> "MyModel": ...
+                  def override(self) -> "MyModel":
+                      raise NotImplementedError
 
               class MyModel(models.Model):
                   objects = MyModelQuerySet.as_manager()
@@ -343,20 +361,34 @@
 
                 class BaseQuerySet(models.QuerySet[_CTE], Generic[_CTE]):
 
-                    def example(self) -> _CTE: ...
-                    def example_list(self) -> list[_CTE]: ...
-                    def example_type(self) -> type[_CTE]: ...
-                    def example_tuple_simple(self) -> tuple[_CTE]: ...
-                    def example_tuple_list(self) -> tuple[_CTE, ...]: ...
-                    def example_tuple_double(self) -> tuple[int, _CTE]: ...
-                    def example_class(self) -> Example[_CTE]: ...
-                    def example_type_class(self) -> type[Example[_CTE]]: ...
-                    def example_collection(self) -> Collection[_CTE]: ...
-                    def example_set(self) -> set[_CTE]: ...
-                    def example_dict(self) -> dict[str, _CTE]: ...
-                    def example_list_dict(self) -> list[dict[str, _CTE]]: ...
-                    def example_t(self, a: T) -> T: ...
-                    def example_arg(self, a: _CTE, b: str) -> _CTE: ...
+                    def example(self) -> _CTE:
+                        raise NotImplementedError
+                    def example_list(self) -> list[_CTE]:
+                        raise NotImplementedError
+                    def example_type(self) -> type[_CTE]:
+                        raise NotImplementedError
+                    def example_tuple_simple(self) -> tuple[_CTE]:
+                        raise NotImplementedError
+                    def example_tuple_list(self) -> tuple[_CTE, ...]:
+                        raise NotImplementedError
+                    def example_tuple_double(self) -> tuple[int, _CTE]:
+                        raise NotImplementedError
+                    def example_class(self) -> Example[_CTE]:
+                        raise NotImplementedError
+                    def example_type_class(self) -> type[Example[_CTE]]:
+                        raise NotImplementedError
+                    def example_collection(self) -> Collection[_CTE]:
+                        raise NotImplementedError
+                    def example_set(self) -> set[_CTE]:
+                        raise NotImplementedError
+                    def example_dict(self) -> dict[str, _CTE]:
+                        raise NotImplementedError
+                    def example_list_dict(self) -> list[dict[str, _CTE]]:
+                        raise NotImplementedError
+                    def example_t(self, a: T) -> T:
+                        raise NotImplementedError
+                    def example_arg(self, a: _CTE, b: str) -> _CTE:
+                        raise NotImplementedError
 
 
                 class MyModelQuerySet(BaseQuerySet["MyModel"]):

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -21,15 +21,20 @@
                 M = TypeVar("M", covariant=True, bound=models.Model)
 
                 class CustomManager(Manager[M]):
-                    def test_custom_manager(self) -> Self: ...
+                    def test_custom_manager(self) -> Self:
+                        raise NotImplementedError
 
                 class BaseQuerySet(models.QuerySet[M]):
-                    def example_dict(self) -> dict[str, Self]: ...
+                    def example_dict(self) -> dict[str, Self]:
+                        raise NotImplementedError
 
                 class MyQuerySet(BaseQuerySet[M]):
-                    def example_simple(self) -> Self: ...
-                    def example_list(self) -> list[Self]: ...
-                    def just_int(self) -> int: ...
+                    def example_simple(self) -> Self:
+                        raise NotImplementedError
+                    def example_list(self) -> list[Self]:
+                        raise NotImplementedError
+                    def just_int(self) -> int:
+                        raise NotImplementedError
 
                 NewManager = CustomManager.from_queryset(MyQuerySet)
 
@@ -173,7 +178,8 @@
 
                 class _MyModelQuerySet(models.QuerySet[_CTE]):
 
-                    def example(self) -> _CTE: ...
+                    def example(self) -> _CTE:
+                        raise NotImplementedError
 
                 class MyModelQuerySet(_MyModelQuerySet["MyModel"]): ...
 
@@ -211,7 +217,8 @@
 
                 class _MyModelQuerySet(models.QuerySet[_CTE]):
 
-                    def example(self) -> _CTE: ...
+                    def example(self) -> _CTE:
+                        raise NotImplementedError
 
                 class MyModelQuerySet(_MyModelQuerySet["MyModel"]):
                     ...
@@ -555,10 +562,12 @@
                         return 'hello'
 
                     @overload
-                    def overloaded_method(self, arg: int) -> int: ...
+                    def overloaded_method(self, arg: int) -> int:
+                        raise NotImplementedError
 
                     @overload
-                    def overloaded_method(self, arg: str) -> str: ...
+                    def overloaded_method(self, arg: str) -> str:
+                        raise NotImplementedError
 
                     def overloaded_method(self, arg: int | str) -> int | str:
                         return arg
@@ -622,7 +631,7 @@
 
                 class MyQuerySet(models.QuerySet["MyModel"]):
                     def custom(self) -> "MyQuerySet":
-                        pass
+                        raise NotImplementedError
 
                 class MyModel(models.Model):
                     objects = MyManager.from_queryset(MyQuerySet)()
@@ -649,7 +658,7 @@
 
                 class BaseQuerySet(models.QuerySet["BaseModel"]):
                     def custom(self) -> "BaseQuerySet":
-                        pass
+                        raise NotImplementedError
 
                 class BaseModel(models.Model):
                     objects = BaseManager.from_queryset(BaseQuerySet)()

--- a/tests/typecheck/managers/querysets/test_prefetch_related.yml
+++ b/tests/typecheck/managers/querysets/test_prefetch_related.yml
@@ -266,15 +266,19 @@
                     tags = models.ManyToManyField(to=Tag, related_name="articles", blank=True)
 
                     @property
-                    def my_property(self) -> int: ...
+                    def my_property(self) -> int:
+                        raise NotImplementedError
 
-                    def my_method(self) -> int: ...
+                    def my_method(self) -> int:
+                        raise NotImplementedError
 
                     @staticmethod
-                    def my_staticmethod() -> int: ...
+                    def my_staticmethod() -> int:
+                        raise NotImplementedError
 
                     @classmethod
-                    def my_classmethod(cls) -> int:  ...
+                    def my_classmethod(cls) -> int:
+                        raise NotImplementedError
 
 -   case: raw_queryset_prefetch_related_signatures
     main: |

--- a/tests/typecheck/managers/querysets/test_union_type.yml
+++ b/tests/typecheck/managers/querysets/test_union_type.yml
@@ -22,7 +22,7 @@
 
                 class MyQuerySet(models.QuerySet):
                     def my_method(self) -> MyQuerySet:
-                      pass
+                      raise NotImplementedError
 
                 UserManager = models.Manager.from_queryset(MyQuerySet)
                 class User(models.Model):

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -148,7 +148,7 @@
 
                 class UserManager(models.Manager['MyUser']):
                     def get_or_404(self) -> 'MyUser':
-                        pass
+                        raise NotImplementedError
 
                 class MyUser(models.Model):
                     objects = UserManager()
@@ -424,9 +424,9 @@
                 from django.db import models
                 class MyManager(models.Manager):
                     def get_instance(self) -> int:
-                        pass
+                        raise NotImplementedError
                     def get_instance_untyped(self, name: str):  # type: ignore[no-untyped-def]
-                        pass
+                        raise NotImplementedError
                 class User(models.Model):
                     objects = MyManager()
                 class ChildUser(models.Model):
@@ -722,7 +722,7 @@
                 class MyModel(models.Model):
                     class MyManager(models.Manager):
                         def get_instance(self) -> int:
-                            pass
+                            raise NotImplementedError
                     objects = MyManager()
 
 -   case: test_typechecks_filter_methods_of_queryset_type

--- a/tests/typecheck/models/test_inheritance.yml
+++ b/tests/typecheck/models/test_inheritance.yml
@@ -24,7 +24,7 @@
     main: |
         from myapp.models import A, B, C
         def service(a: A) -> int:
-            pass
+            raise NotImplementedError
         b_instance = B()
         service(b_instance)  # E: Argument 1 to "service" has incompatible type "B"; expected "A"  [arg-type]
         a_instance = A()
@@ -42,7 +42,6 @@
                     pass
                 class B(models.Model):
                     b_attr = 1
-                    pass
                 class C(A):
                     pass
 
@@ -64,7 +63,6 @@
                 from django.db import models
                 class B(models.Model):
                     b_attr = 1
-                    pass
 
 
 -   case: fields_recognized_if_base_model_is_subclass_of_models_model

--- a/tests/typecheck/models/test_init.yml
+++ b/tests/typecheck/models/test_init.yml
@@ -20,7 +20,7 @@
     main: |
         from myapp.models import MyUser
         def func(i: int) -> MyUser:
-            pass
+            raise NotImplementedError
         func("hello")  # E: Argument 1 to "func" has incompatible type "str"; expected "int"  [arg-type]
     installed_apps:
         - myapp

--- a/tests/typecheck/views/generic/test_list.yml
+++ b/tests/typecheck/views/generic/test_list.yml
@@ -12,7 +12,7 @@
 
             @override
             def get_queryset(self) -> QuerySet[MyModel]:
-                ...
+                raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ('myapp',)
     files:
@@ -38,7 +38,7 @@
 
             @override
             def get_queryset(self) -> QuerySet[MyModel]:
-                ...
+                raise NotImplementedError
     custom_settings: |
         INSTALLED_APPS = ('myapp',)
     files:


### PR DESCRIPTION
# I have made things!

Empty function bodies are unsound - they implicitly return `None` which makes them incompatible with non-`None` return types. This follows along with the approach taken in other projects such as these:

- https://github.com/python/typing/pull/2134
- https://github.com/sbdchd/django-types/pull/339


Instead of using `...` or `pass`, use `raise NotImplementedError`.

## Related issues
<!--
Mark what issues this Pull Request closes or references.

Example. Fixes #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

N/A

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
