### PR TITLE
Fix `mark_safe` to accept `StrOrPromise`

### DIFF
--- a/django-stubs/utils/safestring.pyi
+++ b/django-stubs/utils/safestring.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any, TypeAlias, overload
 
+from django.utils.functional import _StrOrPromise
 from typing_extensions import Self, TypeVar, override
 
 _SD = TypeVar("_SD", bound=SafeData)
@@ -24,4 +25,4 @@ def mark_safe(s: _SD) -> _SD: ...
 @overload
 def mark_safe(s: _C) -> _C: ...
 @overload
-def mark_safe(s: str) -> SafeString: ...
+def mark_safe(s: _StrOrPromise) -> SafeString: ...

--- a/tests/assert_type/utils/test_safestring.py
+++ b/tests/assert_type/utils/test_safestring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.utils.safestring import SafeString, mark_safe
+from django.utils.translation import gettext_lazy
 from typing_extensions import assert_type
 
 s = "hello"
@@ -14,6 +15,11 @@ assert_type(s, str)
 ms = mark_safe(s)
 ms += mark_safe(s)
 assert_type(ms, SafeString)
+
+
+# mark_safe accepts lazy strings
+lazy_s = gettext_lazy("hello")
+assert_type(mark_safe(lazy_s), SafeString)
 
 
 # mark_safe as decorator preserves function type


### PR DESCRIPTION
# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

## Related issues
Fixes #3391

## AI Policy
- [X] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
