### PR TITLE
Enable `unused-ignore` code in pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ pyright = [
 ]
 pyrefly = [
   "pyrefly==1.0.0",
+  "psycopg2-binary"
 ]
 ty = [
   "ty==0.0.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,8 @@ reportMissingModuleSource = "none"
 [tool.pyrefly]
 # Respect only `# pyrefly: ignore` (ignore `# type: ignore`)
 enabled-ignores = ["pyrefly"]
+[tool.pyrefly.errors]
+unused-ignore = true
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/tests/assert_type/db/models/test_constraints.py
+++ b/tests/assert_type/db/models/test_constraints.py
@@ -6,7 +6,7 @@ from django.db.models.functions import Lower
 UniqueConstraint(Lower("name").desc(), "category", name="unique_lower_name_category")
 UniqueConstraint(fields=["name"], name="unique_name")
 # There's no overload case for passing both expression and 'fields'
-UniqueConstraint(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]
+UniqueConstraint(  # type: ignore[call-overload]
     Lower("name"),
     fields=["name"],  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
     name="unique_mess",

--- a/tests/assert_type/db/test_connection.py
+++ b/tests/assert_type/db/test_connection.py
@@ -10,7 +10,7 @@ with connection.cursor() as cursor:
     cursor.execute("SELECT %s", [123])
 
 # psycopg2 composable SQL
-from psycopg2.sql import SQL, Identifier  # type: ignore[import-untyped] # pyrefly: ignore[missing-import]
+from psycopg2.sql import SQL, Identifier  # type: ignore[import-untyped]
 
 with connection.cursor() as cursor:
     cursor.execute(SQL("INSERT INTO {} VALUES (%s)").format(Identifier("my_table")), [123])

--- a/tests/assert_type/utils/test_decorators.py
+++ b/tests/assert_type/utils/test_decorators.py
@@ -18,17 +18,13 @@ from typing_extensions import assert_type, override
 if TYPE_CHECKING:
     from django.http.request import HttpRequest
 
-decorator = decorator_from_middleware(
-    CacheMiddleware  # pyrefly: ignore[bad-argument-type]
-)
+decorator = decorator_from_middleware(CacheMiddleware)
 assert_type(
     decorator,
     Callable[[Callable[..., HttpResponseBase]], Callable[..., HttpResponseBase]],
 )
 
-factory = decorator_from_middleware_with_args(
-    CacheMiddleware  # pyrefly: ignore[bad-argument-type]
-)
+factory = decorator_from_middleware_with_args(CacheMiddleware)
 assert_type(
     factory,
     Callable[..., Callable[[Callable[..., HttpResponseBase]], Callable[..., HttpResponseBase]]],

--- a/tests/assert_type/utils/test_functional.py
+++ b/tests/assert_type/utils/test_functional.py
@@ -17,7 +17,7 @@ class Foo:
     def attr(self) -> list[str]:
         raise NotImplementedError
 
-    @cached_property  # type: ignore[misc]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+    @cached_property  # type: ignore[misc]  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type]
     def attr2(self, arg2: str) -> list[str]:
         raise NotImplementedError
 
@@ -58,7 +58,7 @@ assert_type(s + "bar", str)
 assert_type("foo" + s, str)
 assert_type(s % "asd", str)
 
-s.nonsense  # type: ignore[attr-defined]  # pyrefly: ignore[no-attribute]
+s.nonsense  # type: ignore[attr-defined]
 
 
 def test_str_or_promise(f2: StrOrPromise) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -320,6 +320,7 @@ dev = [
     { name = "ty" },
 ]
 pyrefly = [
+    { name = "psycopg2-binary" },
     { name = "pyrefly" },
 ]
 pyright = [
@@ -377,7 +378,10 @@ dev = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "ty", specifier = "==0.0.35" },
 ]
-pyrefly = [{ name = "pyrefly", specifier = "==1.0.0" }]
+pyrefly = [
+    { name = "psycopg2-binary" },
+    { name = "pyrefly", specifier = "==1.0.0" },
+]
 pyright = [{ name = "pyright", specifier = "==1.1.409" }]
 tests = [
     { name = "django", marker = "python_full_version < '3.12'", specifier = "==5.2.14" },


### PR DESCRIPTION
# I have made things!
This is surprisingly not the default compared to the other typechecker.
It's really important in type assertion tests otherwise we miss regression

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
