### PR TITLE
Fix `task` decorator typing for `takes_context=True`

### DIFF
--- a/django-stubs/tasks/base.pyi
+++ b/django-stubs/tasks/base.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Generic, overload
+from typing import Any, Concatenate, Generic, Literal, overload
 
 from django.db.models.enums import TextChoices as TextChoices
 from django.utils.module_loading import import_string as import_string
@@ -30,7 +30,8 @@ _R = TypeVar("_R")
 @dataclass(kw_only=True)
 class Task(Generic[_P, _R]):
     priority: int
-    func: Callable[_P, _R]
+    # Loose: `_P` excludes `TaskContext` when `takes_context=True`, so `func` may have an extra leading param.
+    func: Callable[..., _R]
     backend: str
     queue_name: str
     run_after: datetime | None
@@ -58,12 +59,21 @@ class Task(Generic[_P, _R]):
 
 @overload
 def task(
+    function: Callable[Concatenate[TaskContext[Any, Any], _P], _R],
+    *,
+    priority: int | None = None,
+    queue_name: str | None = None,
+    backend: str | None = None,
+    takes_context: Literal[True],
+) -> Task[_P, _R]: ...
+@overload
+def task(
     function: Callable[_P, _R],
     *,
     priority: int | None = None,
     queue_name: str | None = None,
     backend: str | None = None,
-    takes_context: bool = ...,
+    takes_context: Literal[False] = False,
 ) -> Task[_P, _R]: ...
 @overload
 def task(
@@ -71,7 +81,15 @@ def task(
     priority: int | None = None,
     queue_name: str | None = None,
     backend: str | None = None,
-    takes_context: bool = ...,
+    takes_context: Literal[True],
+) -> Callable[[Callable[Concatenate[TaskContext[Any, Any], _P], _R]], Task[_P, _R]]: ...
+@overload
+def task(
+    *,
+    priority: int | None = None,
+    queue_name: str | None = None,
+    backend: str | None = None,
+    takes_context: Literal[False] = False,
 ) -> Callable[[Callable[_P, _R]], Task[_P, _R]]: ...
 
 @dataclass(kw_only=True)

--- a/tests/assert_type/tasks/test_tasks.py
+++ b/tests/assert_type/tasks/test_tasks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.tasks import task
+from django.tasks.base import Task, TaskContext, TaskResult
 from typing_extensions import assert_type
 
 
@@ -18,3 +21,22 @@ def test_task_with_priority(x: int) -> int:
 
 
 assert_type(test_task_with_priority.call(1), int)
+
+
+@task(takes_context=True)
+def test_task_with_context(context: TaskContext[Any, Any], x: int, /) -> int:
+    return x + 1
+
+
+assert_type(test_task_with_context, Task[[int], int])
+assert_type(test_task_with_context.enqueue(1), TaskResult[[int], int])
+assert_type(test_task_with_context.call(1), int)
+
+
+@task(takes_context=True, priority=5)
+def test_task_with_context_and_priority(context: TaskContext[Any, Any], x: int, /) -> int:
+    return x + 1
+
+
+assert_type(test_task_with_context_and_priority, Task[[int], int])
+assert_type(test_task_with_context_and_priority.enqueue(1), TaskResult[[int], int])


### PR DESCRIPTION
## Related issues

Fixes #3405

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
