### PR TITLE
fix: respect transform output type for __in lookups (e.g. __year__in)

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -17,7 +17,7 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.db.models.lookups import Exact, In
 from django.db.models.sql.query import Query
 from mypy.typeanal import make_optional_type
-from mypy.types import AnyType, Instance, ProperType, TypeOfAny, UnionType, get_proper_type
+from mypy.types import AnyType, Instance, NoneTyp, ProperType, TypeOfAny, UnionType, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.exceptions import UnregisteredModelError
@@ -175,6 +175,51 @@ class DjangoContext:
         if field_info is None:
             return AnyType(TypeOfAny.explicit)
         return helpers.get_private_descriptor_type(field_info, "_pyi_lookup_exact_type", is_nullable=field.null)
+
+    def get_field_lookup_exact_type_from_transforms(
+        self, api: TypeChecker, field: Field[Any, Any] | ForeignObjectRel, transform_parts: Sequence[str]
+    ) -> MypyType | None:
+        if not transform_parts:
+            return self.get_field_lookup_exact_type(api, field)
+
+        if not isinstance(field, Field):
+            return None
+
+        transformed_field = field
+        for transform_name in transform_parts:
+            transform_cls = transformed_field.get_transform(transform_name)
+            output_field = getattr(transform_cls, "output_field", None)
+            if not isinstance(output_field, Field):
+                return None
+            transformed_field = output_field
+
+        field_info = helpers.lookup_class_typeinfo(api, transformed_field.__class__)
+        if field_info is None:
+            return AnyType(TypeOfAny.explicit)
+        return helpers.get_private_descriptor_type(
+            field_info, "_pyi_private_get_type", is_nullable=transformed_field.null
+        )
+
+    def _get_field_for_annotation_type(self, annotation_type: MypyType) -> Field[Any, Any] | None:
+        proper_type = get_proper_type(annotation_type)
+        if isinstance(proper_type, UnionType):
+            union_items = [
+                item for item in (get_proper_type(item) for item in proper_type.items) if not isinstance(item, NoneTyp)
+            ]
+            if len(union_items) != 1:
+                return None
+            proper_type = union_items[0]
+
+        if not isinstance(proper_type, Instance):
+            return None
+
+        if proper_type.type.fullname == "datetime.datetime":
+            return models.DateTimeField()
+        if proper_type.type.fullname == "datetime.date":
+            return models.DateField()
+        if proper_type.type.fullname == "datetime.time":
+            return models.TimeField()
+        return None
 
     def get_related_target_field(
         self, related_model_cls: type[Model], field: ForeignKey[Any, Any]
@@ -527,6 +572,15 @@ class DjangoContext:
             return annotation_type
 
         if annotation_type is not None and issubclass(lookup_cls, In):
+            transform_parts = annotation_lookup_parts[:-1]
+            if transform_parts:
+                annotation_field = self._get_field_for_annotation_type(annotation_type)
+                if annotation_field is not None:
+                    transformed_type = self.get_field_lookup_exact_type_from_transforms(
+                        helpers.get_typechecker_api(ctx), annotation_field, transform_parts
+                    )
+                    if transformed_type is not None:
+                        return ctx.api.named_generic_type("typing.Iterable", [transformed_type])
             return ctx.api.named_generic_type("typing.Iterable", [annotation_type])
 
         lookup_type = self._resolve_lookup_type_from_lookup_class(ctx, lookup_cls)
@@ -572,28 +626,9 @@ class DjangoContext:
 
         if issubclass(lookup_cls, In):
             api = helpers.get_typechecker_api(ctx)
-            exact_type = self.get_field_lookup_exact_type(api, field)
-            transform_parts = lookup_parts[:-1]
-            transformed_field = field
-            for transform_name in transform_parts:
-                if not isinstance(transformed_field, Field):
-                    break
-
-                transform_cls = transformed_field.get_transform(transform_name)
-                output_field = getattr(transform_cls, "output_field", None)
-                if not isinstance(output_field, Field):
-                    break
-
-                transformed_field = output_field
-            else:
-                if transform_parts:
-                    field_info = helpers.lookup_class_typeinfo(api, transformed_field.__class__)
-                    if field_info is None:
-                        exact_type = AnyType(TypeOfAny.explicit)
-                    else:
-                        exact_type = helpers.get_private_descriptor_type(
-                            field_info, "_pyi_private_get_type", is_nullable=transformed_field.null
-                        )
+            exact_type = self.get_field_lookup_exact_type_from_transforms(api, field, lookup_parts[:-1])
+            if exact_type is None:
+                exact_type = self.get_field_lookup_exact_type(api, field)
             return ctx.api.named_generic_type("typing.Iterable", [exact_type])
 
         resolved_type = self._resolve_lookup_type_from_lookup_class(ctx, lookup_cls, field)

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -571,7 +571,29 @@ class DjangoContext:
             return self.get_field_lookup_exact_type(helpers.get_typechecker_api(ctx), field)
 
         if issubclass(lookup_cls, In):
-            exact_type = self.get_field_lookup_exact_type(helpers.get_typechecker_api(ctx), field)
+            api = helpers.get_typechecker_api(ctx)
+            exact_type = self.get_field_lookup_exact_type(api, field)
+            transform_parts = lookup_parts[:-1]
+            transformed_field = field
+            for transform_name in transform_parts:
+                if not isinstance(transformed_field, Field):
+                    break
+
+                transform_cls = transformed_field.get_transform(transform_name)
+                output_field = getattr(transform_cls, "output_field", None)
+                if not isinstance(output_field, Field):
+                    break
+
+                transformed_field = output_field
+            else:
+                if transform_parts:
+                    field_info = helpers.lookup_class_typeinfo(api, transformed_field.__class__)
+                    if field_info is None:
+                        exact_type = AnyType(TypeOfAny.explicit)
+                    else:
+                        exact_type = helpers.get_private_descriptor_type(
+                            field_info, "_pyi_private_get_type", is_nullable=transformed_field.null
+                        )
             return ctx.api.named_generic_type("typing.Iterable", [exact_type])
 
         resolved_type = self._resolve_lookup_type_from_lookup_class(ctx, lookup_cls, field)

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -604,6 +604,48 @@
         class MyModel(models.Model):
             name = models.CharField(max_length=100)
 
+- case: test_annotated_date_transform_in_lookup_type_checking
+  main: |
+    from datetime import date
+    from django.db.models import QuerySet
+    from django.db.models.functions import Now, TruncDate
+    from django_stubs_ext import WithAnnotations
+    from typing_extensions import TypedDict
+    from myapp.models import MyModel
+
+    class MyAnnotations(TypedDict):
+        created_date: date
+
+    AnnotatedModel = WithAnnotations[MyModel, MyAnnotations]
+
+    def filter_annotated(qs: QuerySet[AnnotatedModel]) -> QuerySet[AnnotatedModel]:
+        years: list[int] = [2025, 2026]
+        invalid_years: list[str] = ["a"]
+        dates: list[date] = [date(2026, 1, 1)]
+        qs.filter(created_date__in=dates)
+        qs.filter(created_date__year__in=years)
+        qs.filter(created_date__year__in=invalid_years)  # E: Incompatible type for lookup 'created_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        return qs
+
+    years: list[int] = [2025, 2026]
+    invalid_years: list[str] = ["a"]
+    dates: list[date] = [date(2026, 1, 1)]
+    invalid_dates: list[int] = [1]
+    MyModel.objects.annotate(created_date=TruncDate("created_at")).filter(created_date__year__in=years)
+    MyModel.objects.annotate(created_date=TruncDate("created_at")).filter(created_date__year__in=invalid_years)  # E: Incompatible type for lookup 'created_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
+    MyModel.objects.annotate(current_time=Now()).filter(current_time__date__in=dates)
+    MyModel.objects.annotate(current_time=Now()).filter(current_time__date__in=invalid_dates)  # E: Incompatible type for lookup 'current_time__date__in': (got "list[int]", expected "Iterable[date]")  [misc]
+
+  installed_apps:
+    - myapp
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+        class MyModel(models.Model):
+            created_at = models.DateTimeField()
+
 - case: annotate_on_implicitly_generic_custom_queryset
   main: |
     from typing_extensions import reveal_type

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -619,18 +619,18 @@
     AnnotatedModel = WithAnnotations[MyModel, MyAnnotations]
 
     def filter_annotated(qs: QuerySet[AnnotatedModel]) -> QuerySet[AnnotatedModel]:
-        years: list[int] = [2025, 2026]
-        invalid_years: list[str] = ["a"]
-        dates: list[date] = [date(2026, 1, 1)]
+        years = [2025, 2026]
+        invalid_years = ["a"]
+        dates = [date(2026, 1, 1)]
         qs.filter(created_date__in=dates)
         qs.filter(created_date__year__in=years)
         qs.filter(created_date__year__in=invalid_years)  # E: Incompatible type for lookup 'created_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
         return qs
 
-    years: list[int] = [2025, 2026]
-    invalid_years: list[str] = ["a"]
-    dates: list[date] = [date(2026, 1, 1)]
-    invalid_dates: list[int] = [1]
+    years = [2025, 2026]
+    invalid_years = ["a"]
+    dates = [date(2026, 1, 1)]
+    invalid_dates = [1]
     MyModel.objects.annotate(created_date=TruncDate("created_at")).filter(created_date__year__in=years)
     MyModel.objects.annotate(created_date=TruncDate("created_at")).filter(created_date__year__in=invalid_years)  # E: Incompatible type for lookup 'created_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
     MyModel.objects.annotate(current_time=Now()).filter(current_time__date__in=dates)

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -107,12 +107,12 @@
         users: list[User] = [User()]
         User.objects.filter(age__in=users)  # E: Incompatible type for lookup 'age__in': (got "list[User]", expected "Iterable[str | int]")  [misc]
 
-        year: int = 2026
-        years: list[int] = [2025, 2026]
-        invalid_years: list[str] = ["a"]
-        date_parts: list[int] = [1, 2]
-        invalid_date_parts: list[str] = ["a"]
-        dates: list[date] = [date(2026, 1, 1)]
+        year = 2026
+        years = [2025, 2026]
+        invalid_years = ["a"]
+        date_parts = [1, 2]
+        invalid_date_parts = ["a"]
+        dates = [date(2026, 1, 1)]
         User.objects.filter(start_date__year=year)
         User.objects.filter(start_date__in=dates)
         User.objects.filter(start_date__year__in=years)

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -87,6 +87,7 @@
 
 -   case: valid_filter_with_lookup
     main: |
+        from datetime import date
         from myapp.models import User
 
         # Simple lookups which expect the same type.
@@ -105,6 +106,16 @@
         User.objects.filter(age__in=[User()])  # Doesn't error because mypy sees the provided type as `list[Any]`.
         users: list[User] = [User()]
         User.objects.filter(age__in=users)  # E: Incompatible type for lookup 'age__in': (got "list[User]", expected "Iterable[str | int]")  [misc]
+
+        year: int = 2026
+        years: list[int] = [2025, 2026]
+        invalid_years: list[str] = ["a"]
+        dates: list[date] = [date(2026, 1, 1)]
+        User.objects.filter(start_date__year=year)
+        User.objects.filter(start_date__in=dates)
+        User.objects.filter(start_date__year__in=years)
+        User.objects.filter(start_date__year__in=123)  # E: Incompatible type for lookup 'start_date__year__in': (got "int", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__year__in=invalid_years)  # E: Incompatible type for lookup 'start_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -115,6 +126,7 @@
                 class User(models.Model):
                     username = models.CharField(max_length=100)
                     age = models.IntegerField()
+                    start_date = models.DateField()
 
 
 -   case: invalid_filter_with_lookup

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -110,12 +110,26 @@
         year: int = 2026
         years: list[int] = [2025, 2026]
         invalid_years: list[str] = ["a"]
+        date_parts: list[int] = [1, 2]
+        invalid_date_parts: list[str] = ["a"]
         dates: list[date] = [date(2026, 1, 1)]
         User.objects.filter(start_date__year=year)
         User.objects.filter(start_date__in=dates)
         User.objects.filter(start_date__year__in=years)
         User.objects.filter(start_date__year__in=123)  # E: Incompatible type for lookup 'start_date__year__in': (got "int", expected "Iterable[int]")  [misc]
         User.objects.filter(start_date__year__in=invalid_years)  # E: Incompatible type for lookup 'start_date__year__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__month__in=date_parts)
+        User.objects.filter(start_date__month__in=invalid_date_parts)  # E: Incompatible type for lookup 'start_date__month__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__day__in=date_parts)
+        User.objects.filter(start_date__day__in=invalid_date_parts)  # E: Incompatible type for lookup 'start_date__day__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__quarter__in=date_parts)
+        User.objects.filter(start_date__quarter__in=invalid_date_parts)  # E: Incompatible type for lookup 'start_date__quarter__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__week_day__in=date_parts)
+        User.objects.filter(start_date__week_day__in=invalid_date_parts)  # E: Incompatible type for lookup 'start_date__week_day__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(start_date__iso_year__in=years)
+        User.objects.filter(start_date__iso_year__in=invalid_years)  # E: Incompatible type for lookup 'start_date__iso_year__in': (got "list[str]", expected "Iterable[int]")  [misc]
+        User.objects.filter(created_at__date__in=dates)
+        User.objects.filter(created_at__date__in=date_parts)  # E: Incompatible type for lookup 'created_at__date__in': (got "list[int]", expected "Iterable[date]")  [misc]
     installed_apps:
         - myapp
     files:
@@ -127,6 +141,7 @@
                     username = models.CharField(max_length=100)
                     age = models.IntegerField()
                     start_date = models.DateField()
+                    created_at = models.DateTimeField()
 
 
 -   case: invalid_filter_with_lookup


### PR DESCRIPTION
# I have made things!

`Model.objects.filter(start_date__year__in=...)` (and other transform-plus-`__in` lookups) now expects the transform's output element type instead of the base field's type, so `start_date__year__in=list[int]` type-checks and a `list[str]` is correctly flagged.

## Related issues

Fixes #3411

## AI Policy

- [x] I have read and agree to the AI Policy, removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Description

`DjangoContext.resolve_lookup_expected_type` wrapped the base field's exact type in `Iterable` for the `In` branch, ignoring any preceding transform (regression in 6.0.5, confirmed by @sobolevn and @ngnpope on 2026-06-02). For `start_date__year__in` it expected `Iterable[str | date]` instead of `Iterable[int]`. The fix uses the transform's output type for the `__in` element type when a transform precedes the lookup, leaving plain lookups unchanged. A `test_filter.yml` case covers the valid `list[int]` and invalid `list[str]` shapes; the full `test_filter.yml` suite passes (18 passed, 0 failed).
