### PR TITLE
Fix only pk validation for abstract models

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1238,7 +1238,7 @@ def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> Mypy
 def _validate_defer_only_fields(
     ctx: MethodContext, model_cls: type[Model], field_names: list[str], *, is_defer: bool
 ) -> None:
-    if not is_defer and model_cls._meta.abstract and "pk" in field_names:
+    if not is_defer and model_cls._meta.abstract:
         # Abstract models do not have a primary key field, but Query.add_immediate_loading()
         # assumes that one exists when resolving the "pk" alias.
         field_names = [field_name for field_name in field_names if field_name != "pk"]

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1238,6 +1238,11 @@ def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> Mypy
 def _validate_defer_only_fields(
     ctx: MethodContext, model_cls: type[Model], field_names: list[str], *, is_defer: bool
 ) -> None:
+    if not is_defer and model_cls._meta.pk is None and "pk" in field_names:
+        # Abstract models do not have a primary key field, but Query.add_immediate_loading()
+        # assumes that one exists when resolving the "pk" alias.
+        field_names = [field_name for field_name in field_names if field_name != "pk"]
+
     query = Query(model_cls)
     query.add_deferred_loading(field_names) if is_defer else query.add_immediate_loading(field_names)
 

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1238,7 +1238,7 @@ def validate_order_by(ctx: MethodContext, django_context: DjangoContext) -> Mypy
 def _validate_defer_only_fields(
     ctx: MethodContext, model_cls: type[Model], field_names: list[str], *, is_defer: bool
 ) -> None:
-    if not is_defer and model_cls._meta.pk is None and "pk" in field_names:
+    if not is_defer and model_cls._meta.abstract and "pk" in field_names:
         # Abstract models do not have a primary key field, but Query.add_immediate_loading()
         # assumes that one exists when resolving the "pk" alias.
         field_names = [field_name for field_name in field_names if field_name != "pk"]

--- a/tests/typecheck/managers/querysets/test_defer_only.yml
+++ b/tests/typecheck/managers/querysets/test_defer_only.yml
@@ -218,6 +218,32 @@
                     tags = models.ManyToManyField(Tag)
 
 
+-   case: only_pk_on_abstract_model_no_crash
+    installed_apps:
+        - myapp
+    main: |
+        from django.db.models import QuerySet
+        from myapp.models import AbstractArticle
+        from typing import reveal_type
+
+        def test(qs: QuerySet[AbstractArticle]) -> None:
+            reveal_type(qs.only("pk"))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.AbstractArticle, myapp.models.AbstractArticle]"
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class AbstractArticle(models.Model):
+                    title = models.CharField(max_length=200)
+
+                    class Meta:
+                        abstract = True
+
+                class Article(AbstractArticle):
+                    pass
+
+
 -   case: only_invalid_fields
     installed_apps:
         - myapp

--- a/tests/typecheck/managers/querysets/test_defer_only.yml
+++ b/tests/typecheck/managers/querysets/test_defer_only.yml
@@ -224,7 +224,7 @@
     main: |
         from django.db.models import QuerySet
         from myapp.models import AbstractArticle
-        from typing import reveal_type
+        from typing_extensions import reveal_type
 
         def test(qs: QuerySet[AbstractArticle]) -> None:
             reveal_type(qs.only("pk"))  # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.AbstractArticle, myapp.models.AbstractArticle]"


### PR DESCRIPTION

## Related issues
<!--
Mark what issues this Pull Request closes or references.
I haven't created an issue for this fixed bug to avoid some noise, but I can if that's required. 
-->
Basically, when a model is abstract, it has no `pk`, so the call to `self.get_meta().pk.name` inside `add_immediate_loading` fails. Test in  `tests/typecheck/managers/querysets/test_defer_only.yml has minimal example to reproduce. I've manually checked that it fails for Django 4 / 5 / 6. 


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
