### PR TITLE
Allow aggregate filters to use expressions

### DIFF
--- a/django-stubs/contrib/postgres/aggregates/general.pyi
+++ b/django-stubs/contrib/postgres/aggregates/general.pyi
@@ -60,7 +60,7 @@ class StringAgg(OrderableAggMixin, Aggregate):
         delimiter: Any,
         *,
         distinct: bool = False,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         ordering: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,

--- a/django-stubs/contrib/postgres/aggregates/mixins.pyi
+++ b/django-stubs/contrib/postgres/aggregates/mixins.pyi
@@ -12,7 +12,7 @@ class OrderableAggMixin:
         self,
         *expressions: BaseExpression | Combinable | str,
         distinct: bool = False,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         ordering: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] = ...,

--- a/django-stubs/db/models/aggregates.pyi
+++ b/django-stubs/db/models/aggregates.pyi
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Any, ClassVar
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models.expressions import Combinable, Func
+from django.db.models.expressions import BaseExpression, Combinable, Func
 from django.db.models.fields import IntegerField
 from django.db.models.functions.mixins import FixDurationInputMixin, NumericOutputFieldMixin
 from django.db.models.query import _OrderByFieldName
@@ -20,7 +20,7 @@ class Aggregate(Func):
         self,
         *expressions: Any,
         distinct: bool = False,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] | None = None,
         **extra: Any,
@@ -45,7 +45,7 @@ class Count(Aggregate):
     def __init__(
         self,
         expression: Combinable | str,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         *,
         distinct: bool = False,
         **extra: Any,
@@ -60,7 +60,7 @@ class StdDev(NumericOutputFieldMixin, Aggregate):
         expression: Combinable | str,
         sample: bool = False,
         *,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         **extra: Any,
     ) -> None: ...
@@ -72,7 +72,7 @@ class StringAgg(Aggregate):
         delimiter: str | Combinable,
         *,
         distinct: bool = False,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         order_by: _OrderByFieldName | Sequence[_OrderByFieldName] | None = None,
         **extra: Any,
@@ -90,7 +90,7 @@ class Variance(NumericOutputFieldMixin, Aggregate):
         expression: Combinable | str,
         sample: bool = False,
         *,
-        filter: Q | None = None,
+        filter: Q | BaseExpression | None = None,
         default: Any | None = None,
         **extra: Any,
     ) -> None: ...

--- a/tests/assert_type/contrib/postgres/test_aggregates.py
+++ b/tests/assert_type/contrib/postgres/test_aggregates.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
+
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import F, Q
+from django.db.models import BooleanField, Exists, ExpressionWrapper, F, Model, Q, QuerySet
+from django.db.models.lookups import GreaterThan
+
+queryset = cast("QuerySet[Model]", object())
 
 # ArrayAgg: order_by accepts single str/Combinable or sequence of either
 ArrayAgg("title", order_by="title")
@@ -12,6 +17,9 @@ ArrayAgg("title", order_by=["-title", F("title")])
 ArrayAgg("title", order_by=("-title", F("title").desc()))
 # Aggregate kwargs forwarded through OrderableAggMixin
 ArrayAgg("title", distinct=True, filter=Q(active=True), order_by="-title", default=[])
+ArrayAgg("title", filter=Exists(queryset))
+ArrayAgg("title", filter=GreaterThan(F("id"), 0))
+ArrayAgg("title", filter=ExpressionWrapper(Exists(queryset), output_field=BooleanField()))
 ArrayAgg("title", order_by=123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
 ArrayAgg("title", order_by=[123])  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
 ArrayAgg("title", filter=F("a"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]

--- a/tests/assert_type/db/models/test_aggregates.py
+++ b/tests/assert_type/db/models/test_aggregates.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
-from django.db.models import Count, F, Q, StdDev, StringAgg, Variance
+from typing import cast
+
+from django.db.models import (
+    BooleanField,
+    Count,
+    Exists,
+    ExpressionWrapper,
+    F,
+    Model,
+    Q,
+    QuerySet,
+    StdDev,
+    StringAgg,
+    Variance,
+)
 from django.db.models.aggregates import Aggregate
+from django.db.models.lookups import GreaterThan
 
 Aggregate("title", order_by="title")
 Aggregate("title", order_by="-title")
@@ -11,9 +26,14 @@ Aggregate("title", order_by=["-title", F("title")])
 Aggregate("title", order_by=("-title", F("title").desc()))
 Aggregate("title", order_by=None)
 
+queryset = cast("QuerySet[Model]", object())
+
 # Count: filter is positional-or-keyword (unique to Count)
 Count("id", distinct=True)
 Count("id", filter=Q(active=True))
+Count("id", filter=Exists(queryset))
+Count("id", filter=GreaterThan(F("id"), 0))
+Count("id", filter=ExpressionWrapper(Exists(queryset), output_field=BooleanField()))
 Count("id", Q(active=True))  # filter as positional
 Count(123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
 Count("id", filter="active")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]

--- a/tests/typecheck/managers/querysets/test_aggregate.yml
+++ b/tests/typecheck/managers/querysets/test_aggregate.yml
@@ -1,0 +1,22 @@
+-   case: aggregate_filter_accepts_exists_expression
+    main: |
+        from django.db.models import Count, Exists, OuterRef
+        from myapp.models import Blog, Entry
+
+        Blog.objects.aggregate(
+            entry_count=Count("id", filter=Exists(Entry.objects.filter(blog_id=OuterRef("id")))),
+        )
+
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Blog(models.Model):
+                    name = models.CharField(max_length=100)
+
+                class Entry(models.Model):
+                    blog = models.ForeignKey(Blog, on_delete=models.CASCADE)


### PR DESCRIPTION
Django accepts expressions such as `Exists(...)` as aggregate filters `(e.g Count(..., filter=Exists(..))`, but the stubs typed these parameters as Q | None, causing false-positive arg-type errors.

I used `BaseExpression` which looked like the right base class, because `Lookup`, `ExpressionWrapper` and `Subquery` can all be used as `filter` argument. 

I created a new yaml test file because I was not sure where to put this

## AI Policy
- [X] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
