### PR TITLE
Typecheck save()/asave() update_fields against model fields

### DIFF
--- a/mypy_django_plugin/lib/field_validation.py
+++ b/mypy_django_plugin/lib/field_validation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import FieldDoesNotExist
+
+if TYPE_CHECKING:
+    from django.db.models.base import Model
+    from django.db.models.options import _AnyField
+    from mypy.plugin import MethodContext
+
+
+def try_get_field(
+    ctx: MethodContext, model_cls: type[Model], field_name: str, *, resolve_pk: bool = False
+) -> _AnyField | None:
+    opts = model_cls._meta
+    resolved_name = opts.pk.name if resolve_pk and field_name == "pk" else field_name
+    try:
+        return opts.get_field(resolved_name)
+    except FieldDoesNotExist as e:
+        ctx.api.fail(str(e), ctx.context)
+        return None
+
+
+def check_field_concrete(ctx: MethodContext, field: _AnyField, field_name: str, method: str) -> bool:
+    if not field.concrete or field.many_to_many:
+        ctx.api.fail(f'"{method}()" can only be used with concrete fields. Got "{field_name}"', ctx.context)
+        return False
+    return True
+
+
+def check_field_not_pk(
+    ctx: MethodContext,
+    model_cls: type[Model],
+    field: _AnyField,
+    field_name: str,
+    method: str,
+    *,
+    attr_name: str | None = None,
+) -> bool:
+    opts = model_cls._meta
+    all_pk_fields = set(getattr(opts, "pk_fields", [opts.pk]))
+    for parent in getattr(opts, "all_parents", opts.get_parent_list()):
+        all_pk_fields.update(getattr(parent._meta, "pk_fields", [parent._meta.pk]))
+    if field in all_pk_fields:
+        param_str = f' in "{attr_name}="' if attr_name else ""
+        ctx.api.fail(f'"{method}()" does not support primary key fields{param_str}. Got "{field_name}"', ctx.context)
+        return False
+    return True
+
+
+def validate_non_pk_concrete_field(
+    ctx: MethodContext, model_cls: type[Model], field_name: str, method: str, *, attr_name: str | None = None
+) -> bool:
+    """Check that ``field_name`` is a concrete, non-primary-key field of ``model_cls``.
+
+    Mirrors Django's ``Options._non_pk_concrete_field_names``: the set of fields that may
+    appear in a database ``UPDATE`` (e.g. ``bulk_update`` fields, ``save(update_fields=...)``).
+    Foreign key attnames such as ``author_id`` are accepted.
+    """
+    return (
+        (field := try_get_field(ctx, model_cls, field_name)) is not None
+        and check_field_concrete(ctx, field, field_name, method)
+        and check_field_not_pk(ctx, model_cls, field, field_name, method, attr_name=attr_name)
+    )

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -35,6 +35,7 @@ from mypy_django_plugin.transformers import (
     meta,
     orm_lookups,
     querysets,
+    save,
     settings,
 )
 from mypy_django_plugin.transformers.auth import get_user_model
@@ -237,6 +238,9 @@ class NewSemanalDjangoPlugin(Plugin):
             info, [fullnames.QUERYSET_CLASS_FULLNAME, fullnames.MANAGER_CLASS_FULLNAME]
         ):
             return self.manager_and_queryset_method_hooks[method_name]
+
+        if method_name in ("save", "asave") and helpers.is_model_type(info):
+            return partial(save.validate_save_update_fields, django_context=self.django_context, method=method_name)
 
         if method_name == "get_field" and info.has_base(fullnames.OPTIONS_CLASS_FULLNAME):
             return partial(meta.return_proper_field_type_from_get_field, django_context=self.django_context)

--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -45,13 +45,13 @@ from mypy.types import Type as MypyType
 
 from mypy_django_plugin.django.context import DjangoContext, LookupsAreUnsupported
 from mypy_django_plugin.lib import fullnames, helpers
+from mypy_django_plugin.lib.field_validation import check_field_concrete, try_get_field, validate_non_pk_concrete_field
 from mypy_django_plugin.transformers.models import get_annotated_type
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from django.db.models.base import Model
-    from django.db.models.options import _AnyField
     from mypy.checker import TypeChecker
     from mypy.plugin import FunctionContext, MethodContext
 
@@ -989,45 +989,6 @@ def extract_prefetch_related_annotations(ctx: MethodContext, django_context: Dja
     return default_return_type.copy_modified(args=[annotated_model, row_type])
 
 
-def _try_get_field(
-    ctx: MethodContext, model_cls: type[Model], field_name: str, *, resolve_pk: bool = False
-) -> _AnyField | None:
-    opts = model_cls._meta
-    resolved_name = opts.pk.name if resolve_pk and field_name == "pk" else field_name
-    try:
-        return opts.get_field(resolved_name)
-    except FieldDoesNotExist as e:
-        ctx.api.fail(str(e), ctx.context)
-        return None
-
-
-def _check_field_concrete(ctx: MethodContext, field: _AnyField, field_name: str, method: str) -> bool:
-    if not field.concrete or field.many_to_many:
-        ctx.api.fail(f'"{method}()" can only be used with concrete fields. Got "{field_name}"', ctx.context)
-        return False
-    return True
-
-
-def _check_field_not_pk(
-    ctx: MethodContext,
-    model_cls: type[Model],
-    field: _AnyField,
-    field_name: str,
-    method: str,
-    *,
-    attr_name: str | None = None,
-) -> bool:
-    opts = model_cls._meta
-    all_pk_fields = set(getattr(opts, "pk_fields", [opts.pk]))
-    for parent in getattr(opts, "all_parents", opts.get_parent_list()):
-        all_pk_fields.update(getattr(parent._meta, "pk_fields", [parent._meta.pk]))
-    if field in all_pk_fields:
-        param_str = f' in "{attr_name}="' if attr_name else ""
-        ctx.api.fail(f'"{method}()" does not support primary key fields{param_str}. Got "{field_name}"', ctx.context)
-        return False
-    return True
-
-
 def _extract_field_names_from_collection(
     ctx: MethodContext, django_context: DjangoContext, arg_index: int
 ) -> list[str] | None:
@@ -1122,16 +1083,6 @@ def validate_select_related(ctx: MethodContext, django_context: DjangoContext) -
     return ctx.default_return_type
 
 
-def _validate_bulk_update_field(
-    ctx: MethodContext, model_cls: type[Model], field_name: str, method: str, *, attr_name: str | None = None
-) -> bool:
-    return (
-        (field := _try_get_field(ctx, model_cls, field_name)) is not None
-        and _check_field_concrete(ctx, field, field_name, method)
-        and _check_field_not_pk(ctx, model_cls, field, field_name, method, attr_name=attr_name)
-    )
-
-
 def validate_bulk_update(
     ctx: MethodContext, django_context: DjangoContext, method: Literal["bulk_update", "abulk_update"]
 ) -> MypyType:
@@ -1154,7 +1105,7 @@ def validate_bulk_update(
         return ctx.default_return_type
 
     for field_name in field_names:
-        _validate_bulk_update_field(ctx, django_model.cls, field_name, method)
+        validate_non_pk_concrete_field(ctx, django_model.cls, field_name, method)
 
     return ctx.default_return_type
 
@@ -1162,7 +1113,7 @@ def validate_bulk_update(
 def _validate_bulk_create_unique_field(
     ctx: MethodContext, model_cls: type[Model], field_name: str, method: str
 ) -> bool:
-    return (field := _try_get_field(ctx, model_cls, field_name, resolve_pk=True)) is not None and _check_field_concrete(
+    return (field := try_get_field(ctx, model_cls, field_name, resolve_pk=True)) is not None and check_field_concrete(
         ctx, field, field_name, method
     )
 
@@ -1181,7 +1132,7 @@ def validate_bulk_create(
     update_field_names = _extract_field_names_from_collection(ctx, django_context, arg_index=4)
     if update_field_names is not None:
         for field_name in update_field_names:
-            _validate_bulk_update_field(ctx, django_model.cls, field_name, method, attr_name="update_fields")
+            validate_non_pk_concrete_field(ctx, django_model.cls, field_name, method, attr_name="update_fields")
 
     unique_field_names = _extract_field_names_from_collection(ctx, django_context, arg_index=5)
     if unique_field_names is not None:

--- a/mypy_django_plugin/transformers/save.py
+++ b/mypy_django_plugin/transformers/save.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mypy.nodes import ListExpr, SetExpr, TupleExpr
+from mypy.types import Instance
+from mypy.types import Type as MypyType
+
+from mypy_django_plugin.lib import helpers
+from mypy_django_plugin.lib.field_validation import validate_non_pk_concrete_field
+
+if TYPE_CHECKING:
+    from mypy.plugin import MethodContext
+
+    from mypy_django_plugin.django.context import DjangoContext
+
+
+def validate_save_update_fields(ctx: MethodContext, django_context: DjangoContext, method: str) -> MypyType:
+    """
+    Type check the keyword-only `update_fields` argument passed to `Model.save(...)` / `Model.asave(...)`.
+    """
+    if not isinstance(ctx.type, Instance) or not helpers.is_model_type(ctx.type.type):
+        return ctx.default_return_type
+    django_model = helpers.DjangoModel.from_model_type(ctx.type, django_context)
+    if django_model is None:
+        return ctx.default_return_type
+
+    update_fields_expr = helpers.get_call_argument_by_name(ctx, "update_fields")
+    if not isinstance(update_fields_expr, (ListExpr, TupleExpr, SetExpr)):
+        # `None`, a `set()` call, or any non-literal collection cannot be checked statically.
+        return ctx.default_return_type
+
+    for field_arg in update_fields_expr.items:
+        field_name = helpers.resolve_string_attribute_value(field_arg, django_context)
+        if field_name is not None:
+            validate_non_pk_concrete_field(ctx, django_model.cls, field_name, method)
+
+    return ctx.default_return_type

--- a/tests/typecheck/models/test_save.yml
+++ b/tests/typecheck/models/test_save.yml
@@ -1,0 +1,99 @@
+-   case: save_update_fields_valid
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article
+
+        article = Article()
+
+        # Concrete fields accepted as list, tuple and set literals
+        article.save(update_fields=["title"])
+        article.save(update_fields=("title", "content"))
+        article.save(update_fields={"title", "content", "published"})
+
+        # Foreign keys accepted both by field name and by attname
+        article.save(update_fields=["author", "author_id"])
+
+        # Empty collection, None and an absent argument are all valid no-ops
+        article.save(update_fields=[])
+        article.save(update_fields=None)
+        article.save()
+
+        # Non-literal collections cannot be checked statically (bad name not flagged)
+        fields = ["nonexistent"]
+        article.save(update_fields=fields)
+
+        # asave is checked the same way
+        async def test_async_save() -> None:
+            await Article().asave(update_fields=["title", "author_id"])
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Category(models.Model):
+                    name = models.CharField(max_length=100)
+
+                class Author(models.Model):
+                    name = models.CharField(max_length=100)
+
+                class Tag(models.Model):
+                    name = models.CharField(max_length=50)
+
+                class Article(models.Model):
+                    title = models.CharField(max_length=200)
+                    content = models.TextField()
+                    published = models.BooleanField(default=False)
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    category = models.ForeignKey(Category, on_delete=models.CASCADE)
+                    tags = models.ManyToManyField(Tag)
+
+
+-   case: save_update_fields_invalid
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article, Author
+        from typing import Literal
+
+        article = Article()
+
+        # Unknown field name
+        article.save(update_fields=["nonexistent"])  # E: Article has no field named 'nonexistent'  [misc]
+
+        # Primary key is not an updatable field
+        article.save(update_fields=["id"])  # E: "save()" does not support primary key fields. Got "id"  [misc]
+
+        # ManyToMany is not a concrete field
+        article.save(update_fields={"tags"})  # E: "save()" can only be used with concrete fields. Got "tags"  [misc]
+
+        # Every invalid field in a collection is reported
+        article.save(update_fields=["nonexistent1", "nonexistent2"])  # E: Article has no field named 'nonexistent1'  [misc] # E: Article has no field named 'nonexistent2'  [misc]
+
+        # Literal-typed values are resolved and checked
+        pk_field: Literal["id"] = "id"
+        article.save(update_fields=[pk_field])  # E: "save()" does not support primary key fields. Got "id"  [misc]
+
+        # The model is resolved from the instance, so the message names the right model
+        Author().save(update_fields=["invalid"])  # E: Author has no field named 'invalid'  [misc]
+
+        # asave is checked too, reporting its own name
+        async def test_async_save_invalid() -> None:
+            await Article().asave(update_fields=["id"])  # E: "asave()" does not support primary key fields. Got "id"  [misc]
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Author(models.Model):
+                    name = models.CharField(max_length=100)
+
+                class Tag(models.Model):
+                    name = models.CharField(max_length=50)
+
+                class Article(models.Model):
+                    title = models.CharField(max_length=200)
+                    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+                    tags = models.ManyToManyField(Tag)

--- a/tests/typecheck/models/test_save.yml
+++ b/tests/typecheck/models/test_save.yml
@@ -68,12 +68,21 @@
         # ManyToMany is not a concrete field
         article.save(update_fields={"tags"})  # E: "save()" can only be used with concrete fields. Got "tags"  [misc]
 
+        # Related lookups are not field names
+        article.save(update_fields=["author__name"])  # E: Article has no field named 'author__name'  [misc]
+
         # Every invalid field in a collection is reported
         article.save(update_fields=["nonexistent1", "nonexistent2"])  # E: Article has no field named 'nonexistent1'  [misc] # E: Article has no field named 'nonexistent2'  [misc]
 
         # Literal-typed values are resolved and checked
         pk_field: Literal["id"] = "id"
         article.save(update_fields=[pk_field])  # E: "save()" does not support primary key fields. Got "id"  [misc]
+
+        # Non-field attributes are not model fields
+        article.save(update_fields=["get_display_title"])  # E: Article has no field named 'get_display_title'  [misc]
+        article.save(update_fields=["is_recent"])  # E: Article has no field named 'is_recent'  [misc]
+        article.save(update_fields=["CATEGORY"])  # E: Article has no field named 'CATEGORY'  [misc]
+        article.save(update_fields=["extra_objects"])  # E: Article has no field named 'extra_objects'  [misc]
 
         # The model is resolved from the instance, so the message names the right model
         Author().save(update_fields=["invalid"])  # E: Author has no field named 'invalid'  [misc]
@@ -85,6 +94,8 @@
         -   path: myapp/__init__.py
         -   path: myapp/models.py
             content: |
+                from typing import ClassVar
+
                 from django.db import models
 
                 class Author(models.Model):
@@ -97,3 +108,13 @@
                     title = models.CharField(max_length=200)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE)
                     tags = models.ManyToManyField(Tag)
+
+                    CATEGORY: ClassVar[str] = "news"
+                    extra_objects = models.Manager()
+
+                    def get_display_title(self) -> str:
+                        return self.title
+
+                    @property
+                    def is_recent(self) -> bool:
+                        return True


### PR DESCRIPTION
Validates the `update_fields` argument of Model.save() and Model.asave() against the model's actual fields.

I also moved the field helpers to a new module called `field_validation.py` so they could be reused across `save.py` and `querysets.py`.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
