### PR TITLE
Fix order_by false positives with JSONField key transforms

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -12,7 +12,6 @@ from django.db.models.fields.related_descriptors import (
     ReverseOneToOneDescriptor,
 )
 from django.db.models.fields.reverse_related import ForeignObjectRel
-from django.db.models.lookups import Transform
 from django.db.models.sql.query import Query
 from mypy.errorcodes import NO_REDEF
 from mypy.nodes import (
@@ -1159,8 +1158,7 @@ def _validate_order_by_lookup(ctx: MethodContext, model_cls: type[Model], parts:
     if remainder:
         # Check if the trailing part is a valid transform (e.g. __year, __month) on the field.
         # Transforms are allowed in order_by, but lookups (e.g. __exact) are not.
-        lookup_cls = final_field.get_lookups().get(remainder[0])
-        if lookup_cls is None or not issubclass(lookup_cls, Transform):
+        if final_field.get_transform(remainder[0]) is None:
             msg = f"Cannot resolve keyword '{remainder[0]}' into field or transform on '{final_field.name}'."
             ctx.api.fail(msg, ctx.context)
 

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -186,6 +186,24 @@
                     created = models.DateTimeField(auto_now_add=True)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE)
 
+-   case: order_by_with_jsonfield_key_transforms
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Item
+
+        Item.objects.order_by("data__field")
+        Item.objects.order_by("-data__field")
+        Item.objects.order_by("data__nested__key")
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class Item(models.Model):
+                    data = models.JSONField()
+
 -   case: order_by_with_annotations_typeddict
     installed_apps:
         - myapp


### PR DESCRIPTION
JSONField key transforms (`data__key`) are resolved via `get_transform()`, not `get_lookups()`, so the check added in #3178 wrongly rejected them.

## Related issues

Fixes https://github.com/typeddjango/django-stubs/issues/3457

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
