### PR TITLE
Speed up test suite ~1.8x by caching package version lookups

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 import itertools
 import sys
-from functools import cached_property, partial
+from functools import cache, cached_property, partial
 from typing import TYPE_CHECKING, Any
 
 from mypy.build import PRI_MED, PRI_MYPY
@@ -354,14 +354,20 @@ class NewSemanalDjangoPlugin(Plugin):
         # Cache would be cleared if any settings do change.
         extra_data = {
             "AUTH_USER_MODEL": self.django_context.settings.AUTH_USER_MODEL,
-            "django_version": importlib.metadata.version("django"),
-            "django_stubs_version": importlib.metadata.version("django-stubs"),
+            "django_version": _package_version("django"),
+            "django_stubs_version": _package_version("django-stubs"),
         }
-        try:
-            extra_data["django_stubs_ext_version"] = importlib.metadata.version("django-stubs-ext")
-        except importlib.metadata.PackageNotFoundError:
-            pass
+        if (django_stubs_ext_version := _package_version("django-stubs-ext")) is not None:
+            extra_data["django_stubs_ext_version"] = django_stubs_ext_version
         return self.plugin_config.to_json(extra_data)
+
+
+@cache
+def _package_version(package: str) -> str | None:
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
 
 
 def plugin(version: str) -> type[NewSemanalDjangoPlugin]:


### PR DESCRIPTION
report_config_data is called by mypy once per cached module, and each call ran three importlib.metadata.version() lookups, each scanning dist-info metadata from disk. On a warm run over a django-importing module graph that is ~1,300 disk scans per mypy invocation, accounting for ~90% of mypy wall time in profiling.

Cache the lookups per process, including the not-installed case for django-stubs-ext (functools.cache does not memoize exceptions, so the sentinel is a None return instead).

This roughly halves the duration of a single warm test run, and makes the full django-stubs test suite under pytest -n auto ~1.8x faster while using ~40% less CPU. Behavior is unchanged: the emitted config data is identical, including omitting django_stubs_ext_version when the package is absent.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
