### PR TITLE
Fix #3472: allow None for nullable FK/OneToOne _id lookups

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, NamedTuple, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
@@ -411,9 +411,7 @@ class DjangoContext:
 
         return related_model_cls
 
-    def _resolve_field_from_parts(
-        self, field_parts: Iterable[str], model_cls: type[Model]
-    ) -> ResolvedLookupField:
+    def _resolve_field_from_parts(self, field_parts: Iterable[str], model_cls: type[Model]) -> ResolvedLookupField:
         """
         Resolve ``field_parts`` (as produced by ``Query.solve_lookup_type``) to a
         concrete field and the model it belongs to.  ``is_nullable`` is ``True``
@@ -606,9 +604,7 @@ class DjangoContext:
                 return AnyType(TypeOfAny.explicit)
 
         if lookup_cls is None or issubclass(lookup_cls, Exact):
-            return self.get_field_lookup_exact_type(
-                helpers.get_typechecker_api(ctx), field, is_nullable=is_nullable
-            )
+            return self.get_field_lookup_exact_type(helpers.get_typechecker_api(ctx), field, is_nullable=is_nullable)
 
         if issubclass(lookup_cls, In):
             exact_type = self.get_field_lookup_exact_type(

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, NamedTuple, Literal
 
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
@@ -111,6 +111,14 @@ def _get_field_get_type_from_model_type_info(info: TypeInfo | None, field_name: 
     return None
 
 
+class ResolvedLookupField(NamedTuple):
+    """Result of resolving a lookup's field parts to a concrete field."""
+
+    field: Field[Any, Any] | ForeignObjectRel
+    model: type[Model]
+    is_nullable: bool
+
+
 class DjangoContext:
     def __init__(self, django_settings_module: str) -> None:
         self.django_settings_module = django_settings_module
@@ -163,7 +171,7 @@ class DjangoContext:
         api: TypeChecker,
         field: Field[Any, Any] | ForeignObjectRel,
         *,
-        is_nullable_fk_id: bool = False,
+        is_nullable: bool = False,
     ) -> MypyType:
         if isinstance(field, RelatedField | ForeignObjectRel):
             related_model_cls = self.get_field_related_model_cls(field)
@@ -181,7 +189,7 @@ class DjangoContext:
         if field_info is None:
             return AnyType(TypeOfAny.explicit)
         return helpers.get_private_descriptor_type(
-            field_info, "_pyi_lookup_exact_type", is_nullable=field.null or is_nullable_fk_id
+            field_info, "_pyi_lookup_exact_type", is_nullable=field.null or is_nullable
         )
 
     def get_related_target_field(
@@ -405,18 +413,19 @@ class DjangoContext:
 
     def _resolve_field_from_parts(
         self, field_parts: Iterable[str], model_cls: type[Model]
-    ) -> tuple[Field[Any, Any] | ForeignObjectRel, type[Model], bool]:
+    ) -> ResolvedLookupField:
         """
         Resolve ``field_parts`` (as produced by ``Query.solve_lookup_type``) to a
-        concrete field and the model it belongs to.  The third return value is
-        ``True`` when the resolved field was reached via a nullable FK ``_id``
-        attname (e.g. ``prospect_id`` on ``prospect = ForeignKey(null=True)``);
-        callers that inspect ``field.null`` should treat the field as nullable in
-        that case, because the underlying PK field is always ``null=False``.
+        concrete field and the model it belongs to.  ``is_nullable`` is ``True``
+        when the resolved field should be treated as nullable even if
+        ``field.null`` is ``False`` — this happens when the lookup goes through
+        a nullable FK ``_id`` attname (e.g. ``prospect_id`` on
+        ``prospect = ForeignKey(null=True)``), because the underlying PK field
+        is always ``null=False`` but the column is nullable when the FK is.
         """
         currently_observed_model = model_cls
         field: _AnyField | None = None
-        is_nullable_fk_id = False
+        is_nullable = False
         for field_part in field_parts:
             if field_part == "pk":
                 field = self.get_primary_key_field(currently_observed_model)
@@ -435,7 +444,7 @@ class DjangoContext:
                     # FK is.
                     # ``field_part != field.name`` excludes ManyToManyField, whose
                     # ``attname`` equals its ``name`` (no ``_id`` column variant).
-                    is_nullable_fk_id = field.null
+                    is_nullable = field.null
                     field = self.get_primary_key_field(currently_observed_model)
 
             if isinstance(field, ForeignObjectRel):
@@ -443,7 +452,7 @@ class DjangoContext:
 
         # Guaranteed by `query.solve_lookup_type` before.
         assert isinstance(field, Field | ForeignObjectRel)
-        return field, currently_observed_model, is_nullable_fk_id
+        return ResolvedLookupField(field, currently_observed_model, is_nullable)
 
     def solve_lookup_type(
         self, model_cls: type[Model], lookup: str
@@ -584,7 +593,9 @@ class DjangoContext:
         if is_expression:
             return AnyType(TypeOfAny.explicit)
 
-        field, _, is_nullable_fk_id = self._resolve_field_from_parts(field_parts, model_cls)
+        resolved = self._resolve_field_from_parts(field_parts, model_cls)
+        field = resolved.field
+        is_nullable = resolved.is_nullable
 
         lookup_cls = None
         if lookup_parts:
@@ -596,12 +607,12 @@ class DjangoContext:
 
         if lookup_cls is None or issubclass(lookup_cls, Exact):
             return self.get_field_lookup_exact_type(
-                helpers.get_typechecker_api(ctx), field, is_nullable_fk_id=is_nullable_fk_id
+                helpers.get_typechecker_api(ctx), field, is_nullable=is_nullable
             )
 
         if issubclass(lookup_cls, In):
             exact_type = self.get_field_lookup_exact_type(
-                helpers.get_typechecker_api(ctx), field, is_nullable_fk_id=is_nullable_fk_id
+                helpers.get_typechecker_api(ctx), field, is_nullable=is_nullable
             )
             return ctx.api.named_generic_type("typing.Iterable", [exact_type])
 

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -158,7 +158,13 @@ class DjangoContext:
             if isinstance(field, ForeignObjectRel):
                 yield field
 
-    def get_field_lookup_exact_type(self, api: TypeChecker, field: Field[Any, Any] | ForeignObjectRel) -> MypyType:
+    def get_field_lookup_exact_type(
+        self,
+        api: TypeChecker,
+        field: Field[Any, Any] | ForeignObjectRel,
+        *,
+        is_nullable_fk_id: bool = False,
+    ) -> MypyType:
         if isinstance(field, RelatedField | ForeignObjectRel):
             related_model_cls = self.get_field_related_model_cls(field)
             rel_model_info = helpers.lookup_class_typeinfo(api, related_model_cls)
@@ -174,7 +180,9 @@ class DjangoContext:
         field_info = helpers.lookup_class_typeinfo(api, field.__class__)
         if field_info is None:
             return AnyType(TypeOfAny.explicit)
-        return helpers.get_private_descriptor_type(field_info, "_pyi_lookup_exact_type", is_nullable=field.null)
+        return helpers.get_private_descriptor_type(
+            field_info, "_pyi_lookup_exact_type", is_nullable=field.null or is_nullable_fk_id
+        )
 
     def get_related_target_field(
         self, related_model_cls: type[Model], field: ForeignKey[Any, Any]
@@ -397,9 +405,18 @@ class DjangoContext:
 
     def _resolve_field_from_parts(
         self, field_parts: Iterable[str], model_cls: type[Model]
-    ) -> tuple[Field[Any, Any] | ForeignObjectRel, type[Model]]:
+    ) -> tuple[Field[Any, Any] | ForeignObjectRel, type[Model], bool]:
+        """
+        Resolve ``field_parts`` (as produced by ``Query.solve_lookup_type``) to a
+        concrete field and the model it belongs to.  The third return value is
+        ``True`` when the resolved field was reached via a nullable FK ``_id``
+        attname (e.g. ``prospect_id`` on ``prospect = ForeignKey(null=True)``);
+        callers that inspect ``field.null`` should treat the field as nullable in
+        that case, because the underlying PK field is always ``null=False``.
+        """
         currently_observed_model = model_cls
         field: _AnyField | None = None
+        is_nullable_fk_id = False
         for field_part in field_parts:
             if field_part == "pk":
                 field = self.get_primary_key_field(currently_observed_model)
@@ -408,8 +425,17 @@ class DjangoContext:
             field = currently_observed_model._meta.get_field(field_part)
             if isinstance(field, RelatedField):
                 currently_observed_model = self.get_field_related_model_cls(field)
-                model_name = currently_observed_model._meta.model_name
-                if model_name is not None and field_part == (model_name + "_id"):
+                if field_part == field.attname and field_part != field.name:
+                    # The lookup uses the FK's ``_id`` suffix (e.g. ``prospect_id``).
+                    # Django's ``get_field`` returns the ``RelatedField`` for this
+                    # attname, but semantically it refers to the underlying column,
+                    # so resolve to the related model's primary key field instead.
+                    # Preserve the original FK's nullability — the PK field itself
+                    # is always ``null=False`` but the column is nullable when the
+                    # FK is.
+                    # ``field_part != field.name`` excludes ManyToManyField, whose
+                    # ``attname`` equals its ``name`` (no ``_id`` column variant).
+                    is_nullable_fk_id = field.null
                     field = self.get_primary_key_field(currently_observed_model)
 
             if isinstance(field, ForeignObjectRel):
@@ -417,7 +443,7 @@ class DjangoContext:
 
         # Guaranteed by `query.solve_lookup_type` before.
         assert isinstance(field, Field | ForeignObjectRel)
-        return field, currently_observed_model
+        return field, currently_observed_model, is_nullable_fk_id
 
     def solve_lookup_type(
         self, model_cls: type[Model], lookup: str
@@ -462,7 +488,8 @@ class DjangoContext:
         lookup_parts, field_parts, _ = solved_lookup
         if lookup_parts:
             raise LookupsAreUnsupported()
-        return self._resolve_field_from_parts(field_parts, model_cls)
+        field, model, _ = self._resolve_field_from_parts(field_parts, model_cls)
+        return field, model
 
     def _resolve_lookup_type_from_lookup_class(
         self, ctx: MethodContext, lookup_cls: type, field: Field[Any, Any] | ForeignObjectRel | None = None
@@ -557,7 +584,7 @@ class DjangoContext:
         if is_expression:
             return AnyType(TypeOfAny.explicit)
 
-        field, _ = self._resolve_field_from_parts(field_parts, model_cls)
+        field, _, is_nullable_fk_id = self._resolve_field_from_parts(field_parts, model_cls)
 
         lookup_cls = None
         if lookup_parts:
@@ -568,10 +595,14 @@ class DjangoContext:
                 return AnyType(TypeOfAny.explicit)
 
         if lookup_cls is None or issubclass(lookup_cls, Exact):
-            return self.get_field_lookup_exact_type(helpers.get_typechecker_api(ctx), field)
+            return self.get_field_lookup_exact_type(
+                helpers.get_typechecker_api(ctx), field, is_nullable_fk_id=is_nullable_fk_id
+            )
 
         if issubclass(lookup_cls, In):
-            exact_type = self.get_field_lookup_exact_type(helpers.get_typechecker_api(ctx), field)
+            exact_type = self.get_field_lookup_exact_type(
+                helpers.get_typechecker_api(ctx), field, is_nullable_fk_id=is_nullable_fk_id
+            )
             return ctx.api.named_generic_type("typing.Iterable", [exact_type])
 
         resolved_type = self._resolve_lookup_type_from_lookup_class(ctx, lookup_cls, field)

--- a/tests/typecheck/managers/querysets/test_filter.yml
+++ b/tests/typecheck/managers/querysets/test_filter.yml
@@ -177,6 +177,57 @@
                     publisher = models.ForeignKey(Publisher, on_delete=models.CASCADE, related_name='blogs')
 
 
+-   case: nullable_foreign_key_id_lookup
+    main: |
+        from myapp.models import Article, Author
+        author = Author()
+
+        # Nullable FK: filtering on the _id column with None is valid
+        Article.objects.filter(author_id=None)
+        Article.objects.filter(author_id=1)
+        Article.objects.filter(author_id=author)  # E: Incompatible type for lookup 'author_id': (got "Author", expected "str | int | None")  [misc]
+
+        # Non-nullable FK: None is not valid for the _id column
+        Article.objects.filter(blog_id=None)  # E: Incompatible type for lookup 'blog_id': (got "None", expected "str | int")  [misc]
+        Article.objects.filter(blog_id=1)
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class Author(models.Model):
+                    pass
+                class Blog(models.Model):
+                    pass
+                class Article(models.Model):
+                    author = models.ForeignKey(Author, null=True, on_delete=models.SET_NULL, related_name='articles')
+                    blog = models.ForeignKey(Blog, on_delete=models.CASCADE, related_name='articles')
+
+
+-   case: nullable_one_to_one_id_lookup
+    main: |
+        from myapp.models import User, Profile
+        user = User()
+
+        # Nullable O2O: filtering on the _id column with None is valid
+        Profile.objects.filter(user_id=None)
+        Profile.objects.filter(user_id=1)
+        Profile.objects.filter(user_id=user)  # E: Incompatible type for lookup 'user_id': (got "User", expected "str | int | None")  [misc]
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                class User(models.Model):
+                    pass
+                class Profile(models.Model):
+                    user = models.OneToOneField(User, null=True, on_delete=models.SET_NULL)
+
+
 -   case: related_model_reverse_foreign_key_lookup
     main: |
         from myapp.models import Blog, Publisher, Category


### PR DESCRIPTION
## Related issues

Fixes #3472

## Problem

Filtering on the `_id` column of a nullable ForeignKey or OneToOneField with `None` was incorrectly rejected by mypy:

```python
class MyModel(models.Model):
    prospect = models.OneToOneField(OtherModel, blank=True, null=True, on_delete=models.CASCADE)

MyModel.objects.filter(prospect_id=None)  # error: Incompatible type for lookup 'prospect_id': (got "None", expected "str | int")
```

This has two root causes in `_resolve_field_from_parts`:

1. **Field name detection**: The old check compared `field_part` against `model_name + "_id"` (the related model's lowercase name + `"_id"`). This only worked when the FK field name happened to match the related model name (e.g. `publisher` → `Publisher`). When the field name differs (e.g. `prospect` → `OtherModel`), the check `"prospect_id" == "othermodel_id"` failed, and the field stayed as the `RelatedField` instead of being resolved to the PK column field.

2. **Nullability**: Even when the `_id` variant was correctly detected (e.g. for `publisher_id`), the resolved PK field always has `null=False`. So `get_field_lookup_exact_type` returned `str | int` without `None`, even for nullable FKs where `prospect_id=None` is valid at the database level.

## Fix

- Replaced the `model_name + "_id"` check with `field.attname`, which is the actual column name Django assigns to the FK's `_id` variant. This works regardless of whether the field name matches the model name.
- Added `is_nullable_fk_id` tracking: when a FK `_id` attname is detected, the original FK's `null` attribute is preserved and passed through to `get_field_lookup_exact_type`, so `None` is accepted for nullable `_id` lookups.
- Excluded `ManyToManyField` via `field_part != field.name` (M2M fields have `attname == name`, no `_id` column variant exists).

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result