### PR TITLE
Preserve values() aliases through annotate() for order_by

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -417,10 +417,10 @@ def _resolve_annotate_row_type(
         return annotated_model
     original_row_type = get_proper_type(default_return_type.args[1])
     if isinstance(original_row_type, TypedDictType):
-        return api.named_generic_type(
-            "builtins.dict",
-            [api.named_generic_type("builtins.str", []), AnyType(TypeOfAny.from_omitted_generics)],
+        annotation_td = helpers.make_typeddict(
+            api, {name: AnyType(TypeOfAny.from_omitted_generics) for name in expression_types}
         )
+        return helpers.merge_typeddict(api, original_row_type, annotation_td)
     if isinstance(original_row_type, TupleType):
         if original_row_type.partial_fallback.type.has_base("typing.NamedTuple"):
             # Rebuild the NamedTuple with existing fields + annotation fields.

--- a/tests/typecheck/managers/querysets/test_annotate.yml
+++ b/tests/typecheck/managers/querysets/test_annotate.yml
@@ -319,13 +319,10 @@
 
         # The following should happen to the TypeVars:
         #  1st typevar (Model): Blog => django_stubs_ext.WithAnnotations[Blog]
-        #  2nd typevar (Row): Should assume that we don't know what is in the row anymore (due to the annotation)
-        # Since we can't trust that only 'text' is in the row type anymore.
-
-        # It's possible to provide more precise types than than this, but without inspecting the
-        # arguments to .annotate, these are the best types we can infer.
+        #  2nd typevar (Row): The values() dict keys are preserved and extended with the
+        #  annotation aliases, mirroring Django's `.values(...).annotate(...)` behavior.
         qs1 = Blog.objects.values('text').annotate(foo=F('id'))
-        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], dict[str, Any]]"
+        reveal_type(qs1) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], TypedDict({'text': str, 'foo': Any})]"
         qs2 = Blog.objects.values_list('text').annotate(foo=F('id'))
         reveal_type(qs2) # N: Revealed type is "django.db.models.query.QuerySet[myapp.models.Blog@AnnotatedWith[TypedDict({'foo': Any})], tuple[Any, ...]]"
         qs3 = Blog.objects.values_list('text', named=True).annotate(foo=F('id'))
@@ -340,7 +337,7 @@
 
 
         before_values_no_params = Blog.objects.values().annotate(foo=F('id')).get()
-        reveal_type(before_values_no_params)  # N: Revealed type is "dict[str, Any]"
+        reveal_type(before_values_no_params)  # N: Revealed type is "TypedDict({'id': int, 'num_posts': int, 'text': str, 'foo': Any})"
 
         before_values_list_no_params = Blog.objects.values_list().annotate(foo=F('id')).get()
         reveal_type(before_values_list_no_params)  # N: Revealed type is "tuple[Any, ...]"

--- a/tests/typecheck/managers/querysets/test_order_by.yml
+++ b/tests/typecheck/managers/querysets/test_order_by.yml
@@ -60,6 +60,10 @@
 
         # values() with annotation then order_by
         Article.objects.values(name=F("author__name")).order_by("name")
+
+        # values() alias preserved through a subsequent annotate()
+        Article.objects.values(name=F("id")).annotate(foo=F("id")).order_by("name")
+        Article.objects.values(name=F("id")).annotate(foo=F("id")).order_by("foo")
     files:
         -   path: myapp/__init__.py
         -   path: myapp/models.py


### PR DESCRIPTION
When `.values(...)` is followed by `.annotate(...)`, the row TypedDict was collapsed to `dict[str, Any]`, discarding the selected column names. This caused a false-positive "Cannot resolve keyword" error on a subsequent `.order_by()` referencing a values() alias.

Extend the existing values-row TypedDict with the annotation aliases instead.

## Related issues

Fixes #3471

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
