### PR TITLE
Support django models discovery by the plugin in `tests/assert_type`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,51 +86,12 @@ pre-commit install --install-hooks
 
 ### Testing and Linting
 
-Running `just` at the root of the repository lists all available recipes:
-
-```
-$ just
-Available recipes:
-    [dev]
-    bootstrap      # Bootstrap dev environment: install pre-commit hooks and sync dependencies
-    lint           # Run pre-commit hooks on all files
-    pre-mr-check   # Run all checks before submitting a PR
-    clean          # Remove mypy cache
-
-    [typecheck]
-    mypy           # Run mypy on plugin, ext, scripts, stubs and tests
-    pyright        # Run pyright on test cases
-    pyrefly        # Run pyrefly on test cases
-    ty             # Run ty on test cases
-
-    [test]
-    test +args     # Run pytest on specific files or with custom args (no xdist)
-    all-test       # Run full pytest test suite with parallel workers
-    stubtest *args # Run stubtest to check stubs match runtime
-    ext-test       # Run django-stubs-ext tests
-
-    [build]
-    build          # Build all packages
-    lock-check     # Check that uv.lock is up to date
-```
+Running `just` at the root of the repository lists all available recipes
 
 Before submitting a PR, run all checks at once:
 
 ```bash
 just pre-mr-check
-```
-
-Or run individual checks:
-
-```bash
-just lint          # pre-commit hooks (ruff, codespell, ...)
-just mypy          # mypy on plugin, ext, scripts, stubs and tests
-just test tests/test_xyz.yml  # run specific tests (no xdist)
-just all-test      # full pytest suite (parallel)
-just stubtest      # stubtest: check stubs match runtime
-just pyright       # pyright on test cases
-just ty            # ty on test cases
-just pyrefly       # pyrefly on test cases
 ```
 
 Extra arguments can be passed to `test` and `stubtest`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,11 @@ just stubtest --allowlist extra.txt
 
 If you get unexpected results, clear the mypy cache with `just clean`.
 
+### Model-based `assert_type` tests
+
+For tests that need Django models, add a `models.py` module under `tests/assert_type/`.
+Its package is discovered and automatically added to `INSTALLED_APPS` for the test suite.
+
 ### Debugging plugin code
 
 For yml tests, we use a dedicated [pytest plugin](https://github.com/typeddjango/pytest-mypy-plugins) that is by default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,16 @@ If you get unexpected results, clear the mypy cache with `just clean`.
 For tests that need Django models, add a `models.py` module under `tests/assert_type/`.
 Its package is discovered and automatically added to `INSTALLED_APPS` for the test suite.
 
+For example, a model-based test can be structured like this:
+
+```text
+tests/assert_type/
+└── db/models/fields/test_related_forward/
+    ├── __init__.py
+    └── models.py
+    └── test_my_feature.py
+```
+
 ### Debugging plugin code
 
 For yml tests, we use a dedicated [pytest plugin](https://github.com/typeddjango/pytest-mypy-plugins) that is by default

--- a/scripts/django_tests_settings.py
+++ b/scripts/django_tests_settings.py
@@ -9,13 +9,11 @@ _ASSERT_TYPE_APPS_ROOT = _REPO_ROOT / "tests" / "assert_type"
 
 
 def _discover_assert_type_apps() -> list[str]:
-    """Discover Django apps under ``tests/assert_type``.
+    """Discover Django apps under `tests/assert_type`.
 
-    Each directory containing a ``models.py`` is registered as an app,
-    with the directory name as the implicit ``app_label``.
+    Each directory containing a `models.py` is registered as an app,
+    with the directory name as the implicit `app_label`.
     """
-    if not _ASSERT_TYPE_APPS_ROOT.is_dir():
-        return []
     return sorted(
         ".".join(models_py.parent.relative_to(_REPO_ROOT).parts)
         for models_py in _ASSERT_TYPE_APPS_ROOT.rglob("models.py")

--- a/scripts/django_tests_settings.py
+++ b/scripts/django_tests_settings.py
@@ -2,6 +2,26 @@
 # The following installed apps are required for stubtest to run correctly.
 from __future__ import annotations
 
+import pathlib
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_ASSERT_TYPE_APPS_ROOT = _REPO_ROOT / "tests" / "assert_type"
+
+
+def _discover_assert_type_apps() -> list[str]:
+    """Discover Django apps under ``tests/assert_type``.
+
+    Each directory containing a ``models.py`` is registered as an app,
+    with the directory name as the implicit ``app_label``.
+    """
+    if not _ASSERT_TYPE_APPS_ROOT.is_dir():
+        return []
+    return sorted(
+        ".".join(models_py.parent.relative_to(_REPO_ROOT).parts)
+        for models_py in _ASSERT_TYPE_APPS_ROOT.rglob("models.py")
+    )
+
+
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.admin",
@@ -10,6 +30,7 @@ INSTALLED_APPS = [
     "django.contrib.redirects",
     "django.contrib.sessions",
     "django.contrib.sites",
+    *_discover_assert_type_apps(),
 ]
 
 STATIC_URL = "static/"


### PR DESCRIPTION
# I have made things!

Add a minimal way to make test in the `assert_type` folder to work with django models.
This basically consider `tests/assert_type` to be a django project root, and will auto register any subdirectory inside as a django app if they declare a `models` module.

For example, a model-based test can be structured like this:

```tree
tests/assert_type/
└── db/models/fields/test_related_forward/
    ├── __init__.py
    ├── models.py
    └──test_my_feature.py
```

## Related issues

Solves most of #3343 except assertion of detailed error output
Enables migrating some yml test to assert_type test in #3317 to validate broad compatiblity with other typecheker

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
