### PR TITLE
Auto-enable `django_stubs_ext.monkeypatch()` for assert_type tests

### DIFF
--- a/scripts/django_tests_settings.py
+++ b/scripts/django_tests_settings.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pathlib
 
+import django_stubs_ext
+
+django_stubs_ext.monkeypatch()
+
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _ASSERT_TYPE_APPS_ROOT = _REPO_ROOT / "tests" / "assert_type"
 


### PR DESCRIPTION
# I have made things!
This will allow migrating yml test that where using `monkeypatch: true`.

## Related issues
Followup to #3483

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
