### PR TITLE
Defer `_meta.get_field()` when the model is defined later in the module

### DIFF
--- a/mypy_django_plugin/transformers/meta.py
+++ b/mypy_django_plugin/transformers/meta.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import FieldDoesNotExist
+from mypy.nodes import Var
 from mypy.types import AnyType, Instance, TypeOfAny, get_proper_type
 from mypy.types import Type as MypyType
 
@@ -27,6 +28,15 @@ def return_proper_field_type_from_get_field(ctx: MethodContext, django_context: 
     field_type = get_field_type_from_model_type_info(model_type.type, field_name)
     if field_type is not None:
         return field_type
+
+    # Fields of a model defined further down the module aren't inferred yet; defer to a later pass.
+    field_sym = model_type.type.get(field_name)
+    if field_sym is not None and isinstance(field_sym.node, Var) and not field_sym.node.is_ready:
+        typechecker_api = helpers.get_typechecker_api(ctx)
+        # Deferral re-checks the enclosing top-level function, so without one there is nothing to defer.
+        if typechecker_api.scope.top_level_function() is not None:
+            typechecker_api.handle_cannot_determine_type(field_name, ctx.context)
+            return ctx.default_return_type
 
     if (django_model := DjangoModel.from_model_type(model_type, django_context)) is None:
         return ctx.default_return_type

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -93,6 +93,29 @@
                     model_a = models.ForeignKey(ModelA, on_delete=models.CASCADE, related_query_name="model_b")
                     model_a_bis = models.ForeignKey(ModelA, on_delete=models.CASCADE, related_name="model_b_bis")
 
+# Regression test for #2833
+-   case: get_field_with_model_defined_later_in_module
+    main: |
+        from myapp.models import MyModel
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing_extensions import reveal_type
+                from django.db import models
+
+                def get_field_before_model_is_defined() -> None:
+                    # Definition order is the test: this body is checked before `MyModel`'s fields are inferred.
+                    reveal_type(MyModel._meta.get_field('short_id'))  # N: Revealed type is "django.db.models.fields.IntegerField[float | int | str | django.db.models.expressions.Combinable, int]"
+
+                # A module-level lambda has nothing to defer, so this falls back to the runtime lookup.
+                unresolvable = lambda: reveal_type(MyModel._meta.get_field('short_id'))  # N: Revealed type is "django.db.models.fields.IntegerField"
+
+                class MyModel(models.Model):
+                    short_id = models.IntegerField()
+
 -   case: base_model_meta_incompatible_types
     main: |
         from django.db import models

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -99,6 +99,29 @@
                 class ModelC(models.Model):
                     model_a = models.OneToOneField(ModelA, on_delete=models.CASCADE)
 
+# Regression test for #2833
+-   case: get_field_with_model_defined_later_in_module
+    main: |
+        from myapp.models import MyModel
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing_extensions import reveal_type
+                from django.db import models
+
+                def get_field_before_model_is_defined() -> None:
+                    # Definition order is the test: this body is checked before `MyModel`'s fields are inferred.
+                    reveal_type(MyModel._meta.get_field('short_id'))  # N: Revealed type is "django.db.models.fields.IntegerField[float | int | str | django.db.models.expressions.Combinable, int]"
+
+                # A module-level lambda has nothing to defer, so this falls back to the runtime lookup.
+                unresolvable = lambda: reveal_type(MyModel._meta.get_field('short_id'))  # N: Revealed type is "django.db.models.fields.IntegerField"
+
+                class MyModel(models.Model):
+                    short_id = models.IntegerField()
+
 -   case: base_model_meta_incompatible_types
     main: |
         from django.db import models


### PR DESCRIPTION
## Related issues

Fixes #2833

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
