### PR TITLE
Implicit M2M through models lose their `objects` / `_default_manager` attributes

### DIFF
--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -744,6 +744,9 @@ class ProcessManyToManyFields(ModelClassInitializer):
                     model_fullname=f"{self.model_classdef.info.module_name}.{through_model_name}",
                     m2m_args=args,
                 )
+                if through_model is not None:
+                    self.add_through_table_managers(through_model)
+
                 container = self.model_classdef.info.get_containing_type_info(m2m_field_name)
                 if (
                     through_model is not None
@@ -893,21 +896,26 @@ class ProcessManyToManyFields(ModelClassInitializer):
         # Add the foreign key's '_id' field: <other_model>_id or to_<model>_id
         other_pk = self.get_pk_instance(m2m_args.to.model.type)
         helpers.add_new_sym_for_info(through_model, name=f"{to_name}_id", sym_type=other_pk.copy_modified())
-        # Add a manager named 'objects'
-        helpers.add_new_sym_for_info(
-            through_model,
-            name="objects",
-            sym_type=Instance(self.manager_info, [Instance(through_model, [])]),
-            is_classvar=True,
-        )
-        # Also add manager as '_default_manager' attribute
-        helpers.add_new_sym_for_info(
-            through_model,
-            name="_default_manager",
-            sym_type=Instance(self.manager_info, [Instance(through_model, [])]),
-            is_classvar=True,
-        )
         return through_model
+
+    def add_through_table_managers(self, through_model: TypeInfo) -> None:
+        """The `self.manager_info` lookup might trigger a deferral pass so this has to be idempotent"""
+        # Add a manager named 'objects'
+        if through_model.names.get("objects") is None:
+            helpers.add_new_sym_for_info(
+                through_model,
+                name="objects",
+                sym_type=Instance(self.manager_info, [Instance(through_model, [])]),
+                is_classvar=True,
+            )
+        # Also add manager as '_default_manager' attribute
+        if through_model.names.get("_default_manager") is None:
+            helpers.add_new_sym_for_info(
+                through_model,
+                name="_default_manager",
+                sym_type=Instance(self.manager_info, [Instance(through_model, [])]),
+                is_classvar=True,
+            )
 
     def resolve_many_to_many_arguments(self, call: CallExpr, /, context: Context) -> M2MArguments | None:
         """

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -407,6 +407,28 @@
                 class User(models.Model):
                     friends = models.ManyToManyField('self')
 
+-   case: implicit_through_model_gets_managers_despite_deferrals
+    main: |
+        from typing_extensions import reveal_type
+        from django.contrib.auth.models import Group
+        reveal_type(Group.permissions.through.objects)  # N: Revealed type is "django.db.models.manager.Manager[django.contrib.auth.models.Group_permissions]"
+        reveal_type(Group.permissions.through._default_manager)  # N: Revealed type is "django.db.models.manager.Manager[django.contrib.auth.models.Group_permissions]"
+    custom_settings: |
+        INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth', 'myapp')
+        # 'django.contrib.auth.models' is analyzed *before* 'myapp' (which imports it), so
+        # this 'DEFAULT_AUTO_FIELD' lookup fails and triggers a deferral right after the
+        # implicit through models of 'django.contrib.auth' were created.
+        DEFAULT_AUTO_FIELD = 'myapp.models.MyAutoField'
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.contrib.auth.models import Group  # noqa: F401
+
+                class MyAutoField(models.BigAutoField):
+                    ...
+
 -   case: recursively_checking_for_base_model_in_to_parameter
     main: |
     installed_apps:


### PR DESCRIPTION
# I have made things!

ProcessManyToManyFields.create_through_table_class builds the implicit through model (<Model>_<field>) in one go: it registersthe new TypeInfo, then adds pk/id/FK fields, and finally the `objects` and `_default_manager` symbols. 
Several lookups inside that window (manager_info, default_pk_instance, …) can raise `IncompleteDefnException`, which defers the whole class hook to a later semantic-analysis pass.

The problem is the early return at the top of the function: on the next pass the through model already exists in the symbol table, so it is returned as-is and the remaining symbols are never added. The half-built through model persists to the end of the run.

The added test was initially failing with `error: "type[Group_permissions]" has no attribute "objects"  [attr-defined]`
## Related issues
I encountered this issue while working on #2776 which seem to make it happen more often

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
