### PR TITLE
Allow callables returning Choices type for Field.choices.

### DIFF
--- a/django-stubs/utils/choices.pyi
+++ b/django-stubs/utils/choices.pyi
@@ -8,7 +8,8 @@ _Choice: TypeAlias = tuple[Any, Any]
 _ChoiceNamedGroup: TypeAlias = tuple[str, Iterable[_Choice]]
 _Choices: TypeAlias = Iterable[_Choice | _ChoiceNamedGroup]
 _ChoicesMapping: TypeAlias = Mapping[Any, Any]
-_ChoicesInput: TypeAlias = _Choices | _ChoicesMapping | type[Choices] | Callable[[], _Choices | _ChoicesMapping]  # noqa: PYI047
+_ChoicesPrimitive: TypeAlias = _Choices | _ChoicesMapping | type[Choices]
+_ChoicesInput: TypeAlias = _ChoicesPrimitive | Callable[[], _ChoicesPrimitive]  # noqa: PYI047
 
 @type_check_only
 class _ChoicesCallable(Protocol):

--- a/tests/assert_type/forms/test_fields_choices.py
+++ b/tests/assert_type/forms/test_fields_choices.py
@@ -42,6 +42,14 @@ def int_mapping() -> Mapping[int, str]:
     return {3: "bar", 4: "bazz"}
 
 
+class ExternalIntegerChoices(models.IntegerChoices):
+    FIRST = 1
+
+
+def choices_type() -> type[models.Choices]:
+    return ExternalIntegerChoices
+
+
 # Invalid choices
 class BadForm(forms.Form):
     my_choice = forms.ChoiceField(choices="test")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
@@ -76,3 +84,4 @@ class TestForm(forms.Form):
     int7 = forms.ChoiceField(choices=to_named_seq(int_mapping))
     int8 = forms.ChoiceField(choices=to_named_seq(int_tuple)())
     int9 = forms.ChoiceField(choices=to_named_seq(int_mapping)())
+    int10 = forms.ChoiceField(choices=choices_type)

--- a/tests/typecheck/db/models/test_fields_choices.yml
+++ b/tests/typecheck/db/models/test_fields_choices.yml
@@ -5,7 +5,7 @@
     class MyModel(models.Model):
         char1 = models.CharField(max_length=200, choices='test')
   out: |
-    main:4: error: Argument "choices" to "CharField" has incompatible type "str"; expected "Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices] | Callable[[], Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any]] | None"  [arg-type]
+    main:4: error: Argument "choices" to "CharField" has incompatible type "str"; expected "Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices] | Callable[[], Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices]] | None"  [arg-type]
     main:4: note: Following member(s) of "str" have conflicts:
     main:4: note:     Expected:
     main:4: note:         def __iter__(self) -> Iterator[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]]
@@ -19,7 +19,7 @@
     class MyModel(models.Model):
         int1 = models.IntegerField(choices='test')
   out: |
-    main:4: error: Argument "choices" to "IntegerField" has incompatible type "str"; expected "Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices] | Callable[[], Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any]] | None"  [arg-type]
+    main:4: error: Argument "choices" to "IntegerField" has incompatible type "str"; expected "Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices] | Callable[[], Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Mapping[Any, Any] | type[Choices]] | None"  [arg-type]
     main:4: note: Following member(s) of "str" have conflicts:
     main:4: note:     Expected:
     main:4: note:         def __iter__(self) -> Iterator[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]]
@@ -65,6 +65,11 @@
     def int_mapping() -> Mapping[int, str]:
         return {3: "bar", 4: "bazz"}
 
+    class ExternalIntegerChoices(models.IntegerChoices):
+        FIRST = 1
+
+    def choices_type() -> type[models.Choices]:
+        return ExternalIntegerChoices
 
     class TestModel(models.Model):
         class TextChoices(models.TextChoices):
@@ -94,3 +99,4 @@
         int7 = models.IntegerField(choices=to_named_seq(int_mapping), default=1)
         int8 = models.IntegerField(choices=to_named_seq(int_tuple)(), default=1)
         int9 = models.IntegerField(choices=to_named_seq(int_mapping)(), default=1)
+        int10 = models.IntegerField(choices=choices_type)


### PR DESCRIPTION
## Related issues
Fixes #3505

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
