### PR TITLE
Invalidate mypy cache when `settings.INSTALLED_APPS` change and cache full config computation

### DIFF
--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -349,17 +349,26 @@ class NewSemanalDjangoPlugin(Plugin):
                 return create_new_manager_class_from_from_queryset_method
         return None
 
-    @override
-    def report_config_data(self, ctx: ReportConfigContext) -> dict[str, Any]:
+    @cached_property
+    def _report_config_data(self) -> dict[str, Any]:
         # Cache would be cleared if any settings do change.
         extra_data = {
+            # The additional deps depend on the installed apps
+            "INSTALLED_APPS": list(self.django_context.settings.INSTALLED_APPS),
+            # The user model determines the `_User` alias expansion
             "AUTH_USER_MODEL": self.django_context.settings.AUTH_USER_MODEL,
+            # The implicit `pk` field type depends on `DEFAULT_AUTO_FIELD`
+            "DEFAULT_AUTO_FIELD": self.django_context.settings.DEFAULT_AUTO_FIELD,
             "django_version": _package_version("django"),
             "django_stubs_version": _package_version("django-stubs"),
         }
         if (django_stubs_ext_version := _package_version("django-stubs-ext")) is not None:
             extra_data["django_stubs_ext_version"] = django_stubs_ext_version
         return self.plugin_config.to_json(extra_data)
+
+    @override
+    def report_config_data(self, ctx: ReportConfigContext) -> dict[str, Any]:
+        return self._report_config_data
 
 
 @cache


### PR DESCRIPTION
The `_User` alias expansion and the additional deps go into cached files but their source settings (`INSTALLED_APPS`, `DEFAULT_AUTO_FIELD`) were not part of the reported config data, so mypy served stale results when they changed.

This was causing an issue in #3513 with invalid cache being served causing error message to change. Rebasing on this branch solved the issue

This also compute the config data once instead of on every call, since it is called for every module.

# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

## Related issues
Followup to #3461 by caching the whole config like [pydantic does](https://github.com/pydantic/pydantic/blob/a2a6577d4c329dd574a45dbb01a8feaa16b1ad3d/pydantic/mypy.py#L164) because it does not change based on the module inspected
Was the solution to the issue in #3513

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
