### PR TITLE
Add helper to generate synthetic manager/queryset classes

### DIFF
--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -500,6 +500,21 @@ def add_new_class_for_module(
     return new_typeinfo
 
 
+def build_reparametrized_subclass(module: MypyFile, base_info: TypeInfo, name: str, *, unique_name: bool) -> TypeInfo:
+    """
+    Create a `TypeInfo` subclassing generic `base_info`, generic over the same type vars.
+    """
+    base_instance = fill_typevars(base_info)
+    assert isinstance(base_instance, Instance)
+    if unique_name:
+        info = add_new_class_for_module(module, name, bases=[base_instance])
+    else:
+        info = create_type_info(name, module.fullname, bases=[base_instance])
+    info.defn.type_vars = base_info.defn.type_vars.copy()
+    info.add_type_vars()
+    return info
+
+
 def get_current_module(api: TypeChecker) -> MypyFile:
     """
     Scope is guaranteed to be initialized with the module as the first element of the stack.

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -500,7 +500,9 @@ def add_new_class_for_module(
     return new_typeinfo
 
 
-def build_reparametrized_subclass(module: MypyFile, base_info: TypeInfo, name: str, *, unique_name: bool) -> TypeInfo:
+def build_reparametrized_subclass(
+    module: MypyFile, base_info: TypeInfo, name: str, *, unique_name: bool, line: int = -1
+) -> TypeInfo:
     """
     Create a `TypeInfo` subclassing generic `base_info`, generic over the same type vars.
     """
@@ -512,6 +514,8 @@ def build_reparametrized_subclass(module: MypyFile, base_info: TypeInfo, name: s
         info = create_type_info(name, module.fullname, bases=[base_instance])
     info.defn.type_vars = base_info.defn.type_vars.copy()
     info.add_type_vars()
+    info.set_line(line)
+    info.defn.set_line(line)
     return info
 
 

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -230,7 +230,7 @@ def create_manager_info_from_from_queryset_call(
         # Reuse an identical, already generated, manager
         new_manager_info = manager_sym.node
     else:
-        # Create a new `TypeInfo` instance for the manager type.
+        # Create a new `TypeInfo` instance for the manager type
         try:
             new_manager_info = create_manager_class(
                 api=api,
@@ -267,13 +267,9 @@ def create_manager_class(
     if any(has_placeholder(type_var) for type_var in base_manager_info.defn.type_vars):
         raise helpers.IncompleteDefnException
 
-    manager_info = helpers.build_reparametrized_subclass(
-        api.modules[api.cur_mod_id], base_manager_info, name, unique_name=with_unique_name
+    return helpers.build_reparametrized_subclass(
+        api.modules[api.cur_mod_id], base_manager_info, name, unique_name=with_unique_name, line=line
     )
-    manager_info.line = line
-    manager_info.defn.line = line
-
-    return manager_info
 
 
 def populate_manager_from_queryset(manager_info: TypeInfo, queryset_info: TypeInfo) -> None:

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -22,7 +22,6 @@ from mypy.semanal_shared import has_placeholder
 from mypy.subtypes import find_member
 from mypy.types import AnyType, CallableType, Instance, ProperType, TypeOfAny, TypeType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
-from mypy.typevars import fill_typevars
 
 from mypy_django_plugin.lib import fullnames, helpers
 
@@ -231,7 +230,7 @@ def create_manager_info_from_from_queryset_call(
         # Reuse an identical, already generated, manager
         new_manager_info = manager_sym.node
     else:
-        # Create a new `TypeInfo` instance for the manager type
+        # Create a new `TypeInfo` instance for the manager type.
         try:
             new_manager_info = create_manager_class(
                 api=api,
@@ -264,25 +263,14 @@ def create_manager_info_from_from_queryset_call(
 def create_manager_class(
     api: SemanticAnalyzer, base_manager_info: TypeInfo, name: str, line: int, with_unique_name: bool
 ) -> TypeInfo:
-    base_manager_instance = fill_typevars(base_manager_info)
-    assert isinstance(base_manager_instance, Instance)
-
     # If any of the type vars are undefined we need to defer. This is handled by the caller
     if any(has_placeholder(type_var) for type_var in base_manager_info.defn.type_vars):
         raise helpers.IncompleteDefnException
 
-    if with_unique_name:
-        manager_info = helpers.add_new_class_for_module(
-            module=api.modules[api.cur_mod_id],
-            name=name,
-            bases=[base_manager_instance],
-        )
-    else:
-        manager_info = helpers.create_type_info(name, api.cur_mod_id, bases=[base_manager_instance])
-
+    manager_info = helpers.build_reparametrized_subclass(
+        api.modules[api.cur_mod_id], base_manager_info, name, unique_name=with_unique_name
+    )
     manager_info.line = line
-    manager_info.type_vars = base_manager_info.type_vars
-    manager_info.defn.type_vars = base_manager_info.defn.type_vars
     manager_info.defn.line = line
 
     return manager_info

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -26,7 +26,6 @@ from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
 from mypy.types import AnyType, Instance, ProperType, TypedDictType, TypeOfAny, TypeType, TypeVarType, get_proper_type
 from mypy.types import Type as MypyType
-from mypy.typevars import fill_typevars
 from typing_extensions import override
 
 from mypy_django_plugin.errorcodes import MANAGER_MISSING
@@ -45,6 +44,7 @@ if TYPE_CHECKING:
 
     from django.db.models import Manager, Model
     from mypy.checker import TypeChecker
+    from mypy.nodes import MypyFile
     from mypy.plugin import AnalyzeTypeContext, AttributeContext, ClassDefContext
 
     from mypy_django_plugin.config import DjangoPluginConfig
@@ -94,9 +94,12 @@ class ModelClassInitializer:
             self.model_classdef.info, name=name, sym_type=typ, no_serialize=no_serialize, is_classvar=is_classvar
         )
 
+    @property
+    def current_module(self) -> MypyFile:
+        return self.api.modules[self.model_classdef.info.module_name]
+
     def add_new_class_for_current_module(self, name: str, bases: list[Instance]) -> TypeInfo:
-        current_module = self.api.modules[self.model_classdef.info.module_name]
-        return helpers.add_new_class_for_module(current_module, name=name, bases=bases)
+        return helpers.add_new_class_for_module(self.current_module, name=name, bases=bases)
 
     def run(self) -> None:
         model_cls = self.django_context.get_model_class_by_fullname(self.model_classdef.fullname)
@@ -143,14 +146,10 @@ class ModelClassInitializer:
         if base_manager_info is None:
             return None
 
-        base_manager = fill_typevars(base_manager_info)
-        assert isinstance(base_manager, Instance)
-        manager_info = self.add_new_class_for_current_module(name, [base_manager])
+        manager_info = helpers.build_reparametrized_subclass(
+            self.current_module, base_manager_info, name, unique_name=True
+        )
         manager_info.fallback_to_any = True
-
-        manager_info.type_vars = base_manager_info.type_vars
-        manager_info.defn.type_vars = base_manager_info.defn.type_vars
-        manager_info.metaclass_type = manager_info.calculate_metaclass_type()
 
         # For methods on BaseManager that return a queryset we need to update
         # the return type to be the actual queryset subclass used. This is done
@@ -187,17 +186,13 @@ class ModelClassInitializer:
         if base_queryset_info is None:
             return None
 
-        base_queryset = fill_typevars(base_queryset_info)
-        assert isinstance(base_queryset, Instance)
-        queryset_info = self.add_new_class_for_current_module(name, [base_queryset])
+        queryset_info = helpers.build_reparametrized_subclass(
+            self.current_module, base_queryset_info, name, unique_name=True
+        )
         queryset_info.metadata["django"] = {
             "any_fallback_queryset": True,
         }
         queryset_info.fallback_to_any = True
-
-        queryset_info.type_vars = base_queryset_info.type_vars.copy()
-        queryset_info.defn.type_vars = base_queryset_info.defn.type_vars.copy()
-        queryset_info.metaclass_type = queryset_info.calculate_metaclass_type()
 
         return queryset_info
 


### PR DESCRIPTION
# I have made things!

A refactor I wanted to make for quite some time to unify the generation of synthetic queryset/managers

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
