### PR TITLE
Detect form base classes with `has_base` instead of a metadata registry

### DIFF
--- a/mypy_django_plugin/lib/fullnames.py
+++ b/mypy_django_plugin/lib/fullnames.py
@@ -39,8 +39,6 @@ ANNOTATED_TYPES_FULLNAMES: Final = {
 
 
 BASEFORM_CLASS_FULLNAME: Final = "django.forms.forms.BaseForm"
-FORM_CLASS_FULLNAME: Final = "django.forms.forms.Form"
-MODELFORM_CLASS_FULLNAME: Final = "django.forms.models.ModelForm"
 
 FORM_MIXIN_CLASS_FULLNAME: Final = "django.views.generic.edit.FormMixin"
 

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from mypy import checker
 from mypy.checker import TypeChecker
@@ -76,7 +76,6 @@ class DjangoTypeMetadata(TypedDict, total=False):
     is_annotated_model: bool
     from_queryset_manager: str
     reverse_managers: dict[str, str]
-    baseform_bases: dict[str, int]
     m2m_throughs: dict[str, str]
     m2m_managers: dict[str, str]
     manager_to_model: str
@@ -84,10 +83,6 @@ class DjangoTypeMetadata(TypedDict, total=False):
 
 def get_django_metadata(model_info: TypeInfo) -> DjangoTypeMetadata:
     return cast("DjangoTypeMetadata", model_info.metadata.setdefault("django", {}))
-
-
-def get_django_metadata_bases(model_info: TypeInfo, key: Literal["baseform_bases"]) -> dict[str, int]:
-    return get_django_metadata(model_info).setdefault(key, cast("dict[str, int]", {}))
 
 
 def get_reverse_manager_info(

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -77,16 +77,6 @@ class NewSemanalDjangoPlugin(Plugin):
         sys.path.extend(options.mypy_path)
         self.django_context = DjangoContext(self.plugin_config.django_settings_module)
 
-    def _get_current_form_bases(self) -> dict[str, int]:
-        model_info = self._get_typeinfo_or_none(fullnames.BASEFORM_CLASS_FULLNAME)
-        if model_info:
-            bases = helpers.get_django_metadata_bases(model_info, "baseform_bases")
-            bases[fullnames.BASEFORM_CLASS_FULLNAME] = 1
-            bases[fullnames.FORM_CLASS_FULLNAME] = 1
-            bases[fullnames.MODELFORM_CLASS_FULLNAME] = 1
-            return bases
-        return {}
-
     def _get_typeinfo_or_none(self, class_name: str) -> TypeInfo | None:
         sym = self.lookup_fully_qualified(class_name)
         if sym is not None and isinstance(sym.node, TypeInfo):
@@ -305,17 +295,20 @@ class NewSemanalDjangoPlugin(Plugin):
 
     @override
     def get_base_class_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
-        # Base class is a Model class definition
         info = self._get_typeinfo_or_none(fullname)
-        if info and helpers.is_model_type(info):
+        if not info:
+            return None
+
+        # Base class is a Model class definition
+        if helpers.is_model_type(info):
             return partial(process_model_class, django_context=self.django_context)
 
         # Base class is a Form class definition
-        if fullname in self._get_current_form_bases():
-            return forms.transform_form_class
+        if info.has_base(fullnames.BASEFORM_CLASS_FULLNAME):
+            return forms.make_meta_nested_class_inherit_from_any
 
         # Base class is a QuerySet class definition
-        if info and info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
+        if info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
             return add_as_manager_to_queryset_class
         return None
 

--- a/mypy_django_plugin/transformers/forms.py
+++ b/mypy_django_plugin/transformers/forms.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mypy.nodes import TypeInfo
-
-from mypy_django_plugin.lib import fullnames, helpers
+from mypy_django_plugin.lib import helpers
 
 if TYPE_CHECKING:
     from mypy.plugin import ClassDefContext
@@ -17,12 +15,3 @@ def make_meta_nested_class_inherit_from_any(ctx: ClassDefContext) -> None:
             ctx.api.defer()
     else:
         meta_node.fallback_to_any = True
-
-
-def transform_form_class(ctx: ClassDefContext) -> None:
-    sym = ctx.api.lookup_fully_qualified_or_none(fullnames.BASEFORM_CLASS_FULLNAME)
-    if sym is not None and isinstance(sym.node, TypeInfo):
-        bases = helpers.get_django_metadata_bases(sym.node, "baseform_bases")
-        bases[ctx.cls.fullname] = 1
-
-    make_meta_nested_class_inherit_from_any(ctx)

--- a/tests/typecheck/test_forms.yml
+++ b/tests/typecheck/test_forms.yml
@@ -25,6 +25,30 @@
                 class Category(models.Model):
                     pass
 
+-   case: no_incompatible_meta_nested_class_false_positive_through_indirect_bases
+    main: |
+        from myapp.forms import ArticleFormBase, CategoryFormBase
+        class ArticleForm(ArticleFormBase):
+            class Meta:
+                fields = '__all__'
+        class CategoryForm(CategoryFormBase):
+            class Meta:
+                exclude = ('id',)
+        class CompositeForm(ArticleForm, CategoryForm):
+            pass
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/forms.py
+            content: |
+                from django import forms
+
+                class FormBase(forms.ModelForm):
+                    pass
+                class ArticleFormBase(FormBase):
+                    pass
+                class CategoryFormBase(FormBase):
+                    pass
+
 -   case: formview_methods_on_forms_return_proper_types
     main: |
         from typing import Any


### PR DESCRIPTION
# I have made things!

More deadcode removal, reducing our use of type metadatas

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
