### PR TITLE
Declare fields of `LogEntry`, `FlatPage` and `Redirect` as assignments

### DIFF
--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -2,6 +2,8 @@ from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, overload
 from uuid import UUID
 
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
 
@@ -33,13 +35,13 @@ class LogEntryManager(models.Manager[LogEntry]):
     ) -> list[LogEntry]: ...
 
 class LogEntry(models.Model):
-    action_time: models.DateTimeField
-    user: models.ForeignKey
-    content_type: models.ForeignKey
-    object_id: models.TextField
-    object_repr: models.CharField
-    action_flag: models.PositiveSmallIntegerField
-    change_message: models.TextField
+    action_time = models.DateTimeField()
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, blank=True, null=True)
+    object_id = models.TextField(blank=True, null=True)
+    object_repr = models.CharField(max_length=200)
+    action_flag = models.PositiveSmallIntegerField()
+    change_message = models.TextField(blank=True)
     objects: ClassVar[LogEntryManager]
     def is_addition(self) -> bool: ...
     def is_change(self) -> bool: ...

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, overload
 from uuid import UUID
@@ -6,6 +7,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
+from django.db.models.expressions import Combinable
 
 ADDITION: int
 CHANGE: int
@@ -35,7 +37,7 @@ class LogEntryManager(models.Manager[LogEntry]):
     ) -> list[LogEntry]: ...
 
 class LogEntry(models.Model):
-    action_time = models.DateTimeField()
+    action_time: models.DateTimeField[str | dt.datetime | dt.date | Combinable, dt.datetime]
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, blank=True, null=True)
     object_id = models.TextField(blank=True, null=True)

--- a/django-stubs/contrib/admin/models.pyi
+++ b/django-stubs/contrib/admin/models.pyi
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, overload
 from uuid import UUID
 
-from django.conf import settings
+from django.contrib.auth.models import _User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
@@ -38,12 +38,12 @@ class LogEntryManager(models.Manager[LogEntry]):
 
 class LogEntry(models.Model):
     action_time: models.DateTimeField[str | dt.datetime | dt.date | Combinable, dt.datetime]
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, blank=True, null=True)
-    object_id = models.TextField(blank=True, null=True)
-    object_repr = models.CharField(max_length=200)
-    action_flag = models.PositiveSmallIntegerField()
-    change_message = models.TextField(blank=True)
+    user: models.ForeignKey[_User | Combinable, _User]
+    content_type: models.ForeignKey[ContentType | Combinable | None, ContentType | None]
+    object_id: models.TextField[str | Combinable | None, str | None]
+    object_repr: models.CharField[str | int | Combinable, str]
+    action_flag: models.PositiveSmallIntegerField[float | int | str | Combinable, int]
+    change_message: models.TextField[str | Combinable, str]
     objects: ClassVar[LogEntryManager]
     def is_addition(self) -> bool: ...
     def is_change(self) -> bool: ...

--- a/django-stubs/contrib/auth/base_user.pyi
+++ b/django-stubs/contrib/auth/base_user.pyi
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, overload
 
@@ -21,8 +22,8 @@ class AbstractBaseUser(models.Model):
     class Meta:
         abstract: ClassVar[bool]
 
-    password = models.CharField(max_length=128)
-    last_login = models.DateTimeField(blank=True, null=True)
+    password: models.CharField[str | int | Combinable, str]
+    last_login: models.DateTimeField[str | dt.datetime | dt.date | Combinable | None, dt.datetime | None]
     is_active: bool | BooleanField[bool | Combinable, bool]
     backend: str  # Set dynamically by authenticate(), used by login()
 

--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, TypeAlias
 
@@ -8,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import QuerySet
 from django.db.models.base import Model
+from django.db.models.expressions import Combinable
 from django.db.models.manager import EmptyManager
 from django.utils.functional import _StrOrPromise
 from typing_extensions import Never, Self, TypeVar
@@ -36,9 +38,9 @@ class Permission(models.Model):
     content_type_id: int
     objects: ClassVar[PermissionManager]
 
-    name = models.CharField(max_length=255)
-    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    codename = models.CharField(max_length=100)
+    name: models.CharField[str | int | Combinable, str]
+    content_type: models.ForeignKey[ContentType | Combinable, ContentType]
+    codename: models.CharField[str | int | Combinable, str]
     def natural_key(self) -> tuple[str, str, str]: ...
 
 class GroupManager(models.Manager[Group]):
@@ -48,8 +50,8 @@ class GroupManager(models.Manager[Group]):
 class Group(models.Model):
     objects: ClassVar[GroupManager]
 
-    name = models.CharField(max_length=150)
-    permissions = models.ManyToManyField(Permission)
+    name: models.CharField[str | int | Combinable, str]
+    permissions: models.ManyToManyField[Permission, Permission]
     def natural_key(self) -> tuple[str]: ...
 
 class UserManager(BaseUserManager[_UserType]):
@@ -75,9 +77,9 @@ class UserManager(BaseUserManager[_UserType]):
     ) -> QuerySet[_UserType]: ...
 
 class PermissionsMixin(models.Model):
-    is_superuser = models.BooleanField()
-    groups = models.ManyToManyField(Group)
-    user_permissions = models.ManyToManyField(Permission)
+    is_superuser: models.BooleanField[bool | Combinable, bool]
+    groups: models.ManyToManyField[Group, Group]
+    user_permissions: models.ManyToManyField[Permission, Permission]
 
     class Meta:
         abstract: ClassVar[bool]
@@ -103,13 +105,13 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         verbose_name: ClassVar[str]
         verbose_name_plural: ClassVar[str]
 
-    username = models.CharField(max_length=150)
-    first_name = models.CharField(max_length=30, blank=True)
-    last_name = models.CharField(max_length=150, blank=True)
-    email = models.EmailField(blank=True)
-    is_staff = models.BooleanField()
-    is_active = models.BooleanField()
-    date_joined = models.DateTimeField()
+    username: models.CharField[str | int | Combinable, str]
+    first_name: models.CharField[str | int | Combinable, str]
+    last_name: models.CharField[str | int | Combinable, str]
+    email: models.EmailField[str | Combinable, str]
+    is_staff: models.BooleanField[bool | Combinable, bool]
+    is_active: models.BooleanField[bool | Combinable, bool]
+    date_joined: models.DateTimeField[str | dt.datetime | dt.date | Combinable, dt.datetime]
 
     objects: ClassVar[UserManager[Self]]
 

--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -51,7 +51,7 @@ class Group(models.Model):
     objects: ClassVar[GroupManager]
 
     name: models.CharField[str | int | Combinable, str]
-    permissions: models.ManyToManyField[Permission, Permission]
+    permissions = models.ManyToManyField(Permission)
     def natural_key(self) -> tuple[str]: ...
 
 class UserManager(BaseUserManager[_UserType]):
@@ -78,8 +78,8 @@ class UserManager(BaseUserManager[_UserType]):
 
 class PermissionsMixin(models.Model):
     is_superuser: models.BooleanField[bool | Combinable, bool]
-    groups: models.ManyToManyField[Group, Group]
-    user_permissions: models.ManyToManyField[Permission, Permission]
+    groups = models.ManyToManyField(Group)
+    user_permissions = models.ManyToManyField(Permission)
 
     class Meta:
         abstract: ClassVar[bool]

--- a/django-stubs/contrib/contenttypes/models.pyi
+++ b/django-stubs/contrib/contenttypes/models.pyi
@@ -2,6 +2,7 @@ from typing import Any, ClassVar
 
 from django.db import models
 from django.db.models.base import Model
+from django.db.models.expressions import Combinable
 from django.db.models.query import QuerySet
 
 class ContentTypeManager(models.Manager[ContentType]):
@@ -14,8 +15,8 @@ class ContentTypeManager(models.Manager[ContentType]):
 
 class ContentType(models.Model):
     id: int
-    app_label = models.CharField(max_length=100)
-    model = models.CharField(max_length=100)
+    app_label: models.CharField[str | int | Combinable, str]
+    model: models.CharField[str | int | Combinable, str]
     objects: ClassVar[ContentTypeManager]
     @property
     def name(self) -> str: ...

--- a/django-stubs/contrib/flatpages/models.pyi
+++ b/django-stubs/contrib/flatpages/models.pyi
@@ -9,5 +9,5 @@ class FlatPage(models.Model):
     enable_comments: models.BooleanField[bool | Combinable, bool]
     template_name: models.CharField[str | int | Combinable, str]
     registration_required: models.BooleanField[bool | Combinable, bool]
-    sites: models.ManyToManyField[Site, Site]
+    sites = models.ManyToManyField(Site)
     def get_absolute_url(self) -> str: ...

--- a/django-stubs/contrib/flatpages/models.pyi
+++ b/django-stubs/contrib/flatpages/models.pyi
@@ -2,11 +2,11 @@ from django.contrib.sites.models import Site
 from django.db import models
 
 class FlatPage(models.Model):
-    url: models.CharField
-    title: models.CharField
-    content: models.TextField
-    enable_comments: models.BooleanField
-    template_name: models.CharField
-    registration_required: models.BooleanField
-    sites: models.ManyToManyField[Site, Site]
+    url = models.CharField(max_length=100)
+    title = models.CharField(max_length=200)
+    content = models.TextField(blank=True)
+    enable_comments = models.BooleanField()
+    template_name = models.CharField(max_length=70, blank=True)
+    registration_required = models.BooleanField()
+    sites = models.ManyToManyField(Site)
     def get_absolute_url(self) -> str: ...

--- a/django-stubs/contrib/flatpages/models.pyi
+++ b/django-stubs/contrib/flatpages/models.pyi
@@ -1,12 +1,13 @@
 from django.contrib.sites.models import Site
 from django.db import models
+from django.db.models.expressions import Combinable
 
 class FlatPage(models.Model):
-    url = models.CharField(max_length=100)
-    title = models.CharField(max_length=200)
-    content = models.TextField(blank=True)
-    enable_comments = models.BooleanField()
-    template_name = models.CharField(max_length=70, blank=True)
-    registration_required = models.BooleanField()
-    sites = models.ManyToManyField(Site)
+    url: models.CharField[str | int | Combinable, str]
+    title: models.CharField[str | int | Combinable, str]
+    content: models.TextField[str | Combinable, str]
+    enable_comments: models.BooleanField[bool | Combinable, bool]
+    template_name: models.CharField[str | int | Combinable, str]
+    registration_required: models.BooleanField[bool | Combinable, bool]
+    sites: models.ManyToManyField[Site, Site]
     def get_absolute_url(self) -> str: ...

--- a/django-stubs/contrib/redirects/models.pyi
+++ b/django-stubs/contrib/redirects/models.pyi
@@ -1,7 +1,8 @@
 from django.contrib.sites.models import Site
 from django.db import models
+from django.db.models.expressions import Combinable
 
 class Redirect(models.Model):
-    site = models.ForeignKey(Site, on_delete=models.CASCADE)
-    old_path = models.CharField(max_length=200)
-    new_path = models.CharField(max_length=200, blank=True)
+    site: models.ForeignKey[Site | Combinable, Site]
+    old_path: models.CharField[str | int | Combinable, str]
+    new_path: models.CharField[str | int | Combinable, str]

--- a/django-stubs/contrib/redirects/models.pyi
+++ b/django-stubs/contrib/redirects/models.pyi
@@ -1,6 +1,7 @@
+from django.contrib.sites.models import Site
 from django.db import models
 
 class Redirect(models.Model):
-    site: models.ForeignKey
-    old_path: models.CharField
-    new_path: models.CharField
+    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    old_path = models.CharField(max_length=200)
+    new_path = models.CharField(max_length=200, blank=True)

--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -1,20 +1,21 @@
-from datetime import datetime
+import datetime as dt
 from typing import Any, ClassVar
 
 from django.contrib.sessions.backends.base import SessionBase
 from django.db import models
+from django.db.models.expressions import Combinable
 from typing_extensions import Self, TypeVar
 
 _T = TypeVar("_T", bound=AbstractBaseSession)
 
 class BaseSessionManager(models.Manager[_T]):
     def encode(self, session_dict: dict[str, Any]) -> str: ...
-    def save(self, session_key: str, session_dict: dict[str, Any], expire_date: datetime) -> _T: ...
+    def save(self, session_key: str, session_dict: dict[str, Any], expire_date: dt.datetime) -> _T: ...
 
 class AbstractBaseSession(models.Model):
-    session_key = models.CharField(primary_key=True)
-    session_data = models.TextField()
-    expire_date = models.DateTimeField()
+    session_key: models.CharField[str | int | Combinable, str]
+    session_data: models.TextField[str | Combinable, str]
+    expire_date: models.DateTimeField[str | dt.datetime | dt.date | Combinable, dt.datetime]
     objects: ClassVar[BaseSessionManager[Self]]
 
     class Meta:

--- a/django-stubs/contrib/sites/models.pyi
+++ b/django-stubs/contrib/sites/models.pyi
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar
 
 from django.db import models
+from django.db.models.expressions import Combinable
 from django.http.request import HttpRequest
 
 SITE_CACHE: Any
@@ -13,8 +14,8 @@ class SiteManager(models.Manager[Site]):
 class Site(models.Model):
     objects: ClassVar[SiteManager]
 
-    domain = models.CharField(max_length=100)
-    name = models.CharField(max_length=50)
+    domain: models.CharField[str | int | Combinable, str]
+    name: models.CharField[str | int | Combinable, str]
     def natural_key(self) -> tuple[str]: ...
 
 def clear_site_cache(sender: type[Site], **kwargs: Any) -> None: ...

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -307,7 +307,7 @@ class OneToOneField(ForeignKey[_ST, _GT]):
     forward_related_accessor_class: type[ForwardOneToOneDescriptor[Any]]
     related_accessor_class: type[ReverseOneToOneDescriptor[Any, Any]]  # type: ignore[assignment]
 
-_Through = TypeVar("_Through", bound=Model)
+_Through = TypeVar("_Through", bound=Model, default=Model)
 _To = TypeVar("_To", bound=Model)
 
 class ManyToManyField(RelatedField[Any, Any], Generic[_To, _Through]):

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -307,7 +307,7 @@ class OneToOneField(ForeignKey[_ST, _GT]):
     forward_related_accessor_class: type[ForwardOneToOneDescriptor[Any]]
     related_accessor_class: type[ReverseOneToOneDescriptor[Any, Any]]  # type: ignore[assignment]
 
-_Through = TypeVar("_Through", bound=Model, default=Model)
+_Through = TypeVar("_Through", bound=Model, default=Any)
 _To = TypeVar("_To", bound=Model)
 
 class ManyToManyField(RelatedField[Any, Any], Generic[_To, _Through]):

--- a/mypy_django_plugin/transformers/manytomany.py
+++ b/mypy_django_plugin/transformers/manytomany.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from mypy.nodes import AssignmentStmt, NameExpr, Node, TypeInfo
-from mypy.types import Instance, ProperType, UninhabitedType, get_proper_type
+from mypy.types import AnyType, Instance, ProperType, TypeOfAny, UninhabitedType, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.lib import fullnames, helpers
@@ -30,6 +30,16 @@ class M2MArguments(NamedTuple):
     through: M2MThrough | None
 
 
+def _through_arg_is_unset(m2m_field: Instance) -> bool:
+    """Whether the 'through' type argument was left unsolved, or fell back on its 'Model' default."""
+    if len(m2m_field.args) < 2:
+        return False
+    through_arg = get_proper_type(m2m_field.args[1])
+    return isinstance(through_arg, UninhabitedType) or (
+        isinstance(through_arg, Instance) and through_arg.type.fullname == fullnames.MODEL_CLASS_FULLNAME
+    )
+
+
 def fill_model_args_for_many_to_many_field(
     *,
     ctx: FunctionContext,
@@ -44,6 +54,11 @@ def fill_model_args_for_many_to_many_field(
         and len(default_return_type.args) >= 2
         and (args := get_m2m_arguments(ctx=ctx, model_info=model_info, django_context=django_context))
     ):
+        if isinstance(default_return_type, Instance) and _through_arg_is_unset(default_return_type):
+            # Nothing could be resolved, so don't let the 'Model' default pass for a real answer.
+            return default_return_type.copy_modified(
+                args=[default_return_type.args[0], AnyType(TypeOfAny.from_omitted_generics)]
+            )
         return ctx.default_return_type
 
     default_to_arg = get_proper_type(default_return_type.args[0])
@@ -54,14 +69,13 @@ def fill_model_args_for_many_to_many_field(
         # Avoid overwriting a decent 'to' argument
         to_arg = default_return_type.args[0]
 
-    default_through_arg = get_proper_type(default_return_type.args[1])
-    if isinstance(default_through_arg, UninhabitedType):
+    if _through_arg_is_unset(default_return_type):
         if helpers.is_abstract_model(model_info):
             # Many to many on abstract models doesn't create any implicit, concrete
             # through model, so we populate it with the upper bound to avoid error messages
             through_arg = default_return_type.type.defn.type_vars[1].upper_bound
         elif args.through is None:
-            through_arg = default_through_arg
+            through_arg = UninhabitedType()
         else:
             through_arg = args.through.model
     else:

--- a/mypy_django_plugin/transformers/manytomany.py
+++ b/mypy_django_plugin/transformers/manytomany.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from mypy.nodes import AssignmentStmt, NameExpr, Node, TypeInfo
-from mypy.types import AnyType, Instance, ProperType, TypeOfAny, UninhabitedType, get_proper_type
+from mypy.types import AnyType, Instance, ProperType, UninhabitedType, get_proper_type
 from mypy.types import Type as MypyType
 
 from mypy_django_plugin.lib import fullnames, helpers
@@ -31,13 +31,11 @@ class M2MArguments(NamedTuple):
 
 
 def _through_arg_is_unset(m2m_field: Instance) -> bool:
-    """Whether the 'through' type argument was left unsolved, or fell back on its 'Model' default."""
+    """Whether the 'through' type argument was left unsolved, or fell back on its 'Any' default."""
     if len(m2m_field.args) < 2:
         return False
     through_arg = get_proper_type(m2m_field.args[1])
-    return isinstance(through_arg, UninhabitedType) or (
-        isinstance(through_arg, Instance) and through_arg.type.fullname == fullnames.MODEL_CLASS_FULLNAME
-    )
+    return isinstance(through_arg, (UninhabitedType, AnyType))
 
 
 def fill_model_args_for_many_to_many_field(
@@ -54,11 +52,6 @@ def fill_model_args_for_many_to_many_field(
         and len(default_return_type.args) >= 2
         and (args := get_m2m_arguments(ctx=ctx, model_info=model_info, django_context=django_context))
     ):
-        if isinstance(default_return_type, Instance) and _through_arg_is_unset(default_return_type):
-            # Nothing could be resolved, so don't let the 'Model' default pass for a real answer.
-            return default_return_type.copy_modified(
-                args=[default_return_type.args[0], AnyType(TypeOfAny.from_omitted_generics)]
-            )
         return ctx.default_return_type
 
     default_to_arg = get_proper_type(default_return_type.args[0])

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -39,6 +39,8 @@ django.contrib.auth.models.Permission_RelatedManager
 django.contrib.auth.models.Group_ManyRelatedManager
 django.contrib.auth.models.Permission_ManyRelatedManager
 django.contrib.auth.models.User_ManyRelatedManager
+django.contrib.flatpages.models.FlatPage_ManyRelatedManager
+django.contrib.sites.models.Site_ManyRelatedManager
 
 # BaseArchive abstract methods that take no argument, but typed with arguments to match the Archive and TarArchive Implementations
 django.utils.archive.BaseArchive.list

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -94,7 +94,6 @@ django.contrib.sessions.models.Session.get_previous_by_expire_date
 django.contrib.sessions.models.Session.session_data
 django.contrib.sessions.models.Session.session_key
 django.contrib.sites.models.Site.domain
-django.contrib.sites.models.Site.flatpage_set
 django.contrib.sites.models.Site.id
 django.contrib.sites.models.Site.name
 django.contrib.staticfiles.finders.DefaultStorageFinder.storage

--- a/tests/assert_type/contrib/test_models.py
+++ b/tests/assert_type/contrib/test_models.py
@@ -31,7 +31,7 @@ def flatpage_fields_are_inferred() -> None:
     assert_type(page.enable_comments, bool)
     assert_type(page.template_name, str)
     assert_type(page.registration_required, bool)
-    assert_type(page.sites.get(), Site)
+    assert_type(page.sites.get(), Site)  # pyright: ignore[reportUnknownMemberType]
 
 
 def redirect_fields_are_inferred() -> None:
@@ -70,7 +70,7 @@ def permission_fields_are_inferred() -> None:
 def group_fields_are_inferred() -> None:
     group = Group()
     assert_type(group.name, str)
-    assert_type(group.permissions.get(), Permission)
+    assert_type(group.permissions.get(), Permission)  # pyright: ignore[reportUnknownMemberType]
 
 
 def user_fields_are_inferred() -> None:
@@ -85,5 +85,5 @@ def user_fields_are_inferred() -> None:
     assert_type(user.is_active, bool)
     assert_type(user.is_superuser, bool)
     assert_type(user.date_joined, datetime)
-    assert_type(user.groups.get(), Group)
-    assert_type(user.user_permissions.get(), Permission)
+    assert_type(user.groups.get(), Group)  # pyright: ignore[reportUnknownMemberType]
+    assert_type(user.user_permissions.get(), Permission)  # pyright: ignore[reportUnknownMemberType]

--- a/tests/assert_type/contrib/test_models.py
+++ b/tests/assert_type/contrib/test_models.py
@@ -31,7 +31,7 @@ def flatpage_fields_are_inferred() -> None:
     assert_type(page.enable_comments, bool)
     assert_type(page.template_name, str)
     assert_type(page.registration_required, bool)
-    assert_type(page.sites.get(), Site)  # pyright: ignore[reportUnknownMemberType]
+    assert_type(page.sites.get(), Site)
 
 
 def redirect_fields_are_inferred() -> None:
@@ -70,7 +70,7 @@ def permission_fields_are_inferred() -> None:
 def group_fields_are_inferred() -> None:
     group = Group()
     assert_type(group.name, str)
-    assert_type(group.permissions.get(), Permission)  # pyright: ignore[reportUnknownMemberType]
+    assert_type(group.permissions.get(), Permission)
 
 
 def user_fields_are_inferred() -> None:
@@ -85,5 +85,5 @@ def user_fields_are_inferred() -> None:
     assert_type(user.is_active, bool)
     assert_type(user.is_superuser, bool)
     assert_type(user.date_joined, datetime)
-    assert_type(user.groups.get(), Group)  # pyright: ignore[reportUnknownMemberType]
-    assert_type(user.user_permissions.get(), Permission)  # pyright: ignore[reportUnknownMemberType]
+    assert_type(user.groups.get(), Group)
+    assert_type(user.user_permissions.get(), Permission)

--- a/tests/assert_type/contrib/test_models.py
+++ b/tests/assert_type/contrib/test_models.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 
 from django.contrib.admin.models import LogEntry
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.redirects.models import Redirect
+from django.contrib.sessions.models import Session
 from django.contrib.sites.models import Site
 from typing_extensions import assert_type
 
@@ -14,27 +15,75 @@ from typing_extensions import assert_type
 def log_entry_fields_are_inferred() -> None:
     entry = LogEntry()
     assert_type(entry.action_time, datetime)
-    assert_type(entry.user, User)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
-    assert_type(entry.content_type, ContentType | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(entry.object_id, str | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(entry.object_repr, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(entry.action_flag, int)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(entry.change_message, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.user, User)  # pyright: ignore[reportAssertTypeFailure]  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.content_type, ContentType | None)  # pyrefly: ignore[assert-type]
+    assert_type(entry.object_id, str | None)  # pyrefly: ignore[assert-type]
+    assert_type(entry.object_repr, str)
+    assert_type(entry.action_flag, int)
+    assert_type(entry.change_message, str)
 
 
 def flatpage_fields_are_inferred() -> None:
     page = FlatPage()
-    assert_type(page.url, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.title, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.content, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.enable_comments, bool)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.template_name, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.registration_required, bool)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(page.sites.get(), Site)  # pyright: ignore[reportUnknownMemberType]
+    assert_type(page.url, str)
+    assert_type(page.title, str)
+    assert_type(page.content, str)
+    assert_type(page.enable_comments, bool)
+    assert_type(page.template_name, str)
+    assert_type(page.registration_required, bool)
+    assert_type(page.sites.get(), Site)
 
 
 def redirect_fields_are_inferred() -> None:
     redirect = Redirect()
-    assert_type(redirect.site, Site)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(redirect.old_path, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
-    assert_type(redirect.new_path, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(redirect.site, Site)  # pyrefly: ignore[assert-type]
+    assert_type(redirect.old_path, str)
+    assert_type(redirect.new_path, str)
+
+
+def site_fields_are_inferred() -> None:
+    site = Site()
+    assert_type(site.domain, str)
+    assert_type(site.name, str)
+
+
+def content_type_fields_are_inferred() -> None:
+    content_type = ContentType()
+    assert_type(content_type.app_label, str)
+    assert_type(content_type.model, str)
+
+
+def session_fields_are_inferred() -> None:
+    session = Session()
+    assert_type(session.session_key, str)
+    assert_type(session.session_data, str)
+    assert_type(session.expire_date, datetime)
+
+
+def permission_fields_are_inferred() -> None:
+    permission = Permission()
+    assert_type(permission.name, str)
+    assert_type(permission.content_type, ContentType)  # pyrefly: ignore[assert-type]
+    assert_type(permission.codename, str)
+
+
+def group_fields_are_inferred() -> None:
+    group = Group()
+    assert_type(group.name, str)
+    assert_type(group.permissions.get(), Permission)
+
+
+def user_fields_are_inferred() -> None:
+    user = User()
+    assert_type(user.password, str)
+    assert_type(user.last_login, datetime | None)  # pyrefly: ignore[assert-type]
+    assert_type(user.username, str)
+    assert_type(user.first_name, str)
+    assert_type(user.last_name, str)
+    assert_type(user.email, str)
+    assert_type(user.is_staff, bool)
+    assert_type(user.is_active, bool)
+    assert_type(user.is_superuser, bool)
+    assert_type(user.date_joined, datetime)
+    assert_type(user.groups.get(), Group)
+    assert_type(user.user_permissions.get(), Permission)

--- a/tests/assert_type/contrib/test_models.py
+++ b/tests/assert_type/contrib/test_models.py
@@ -13,7 +13,7 @@ from typing_extensions import assert_type
 
 def log_entry_fields_are_inferred() -> None:
     entry = LogEntry()
-    assert_type(entry.action_time, datetime)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.action_time, datetime)
     assert_type(entry.user, User)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
     assert_type(entry.content_type, ContentType | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
     assert_type(entry.object_id, str | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]

--- a/tests/assert_type/contrib/test_models.py
+++ b/tests/assert_type/contrib/test_models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.contrib.admin.models import LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.flatpages.models import FlatPage
+from django.contrib.redirects.models import Redirect
+from django.contrib.sites.models import Site
+from typing_extensions import assert_type
+
+
+def log_entry_fields_are_inferred() -> None:
+    entry = LogEntry()
+    assert_type(entry.action_time, datetime)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.user, User)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.content_type, ContentType | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.object_id, str | None)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.object_repr, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.action_flag, int)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(entry.change_message, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+
+
+def flatpage_fields_are_inferred() -> None:
+    page = FlatPage()
+    assert_type(page.url, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.title, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.content, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.enable_comments, bool)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.template_name, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.registration_required, bool)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(page.sites.get(), Site)  # pyright: ignore[reportUnknownMemberType]
+
+
+def redirect_fields_are_inferred() -> None:
+    redirect = Redirect()
+    assert_type(redirect.site, Site)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(redirect.old_path, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]
+    assert_type(redirect.new_path, str)  # pyright: ignore[reportUnknownMemberType, reportAssertTypeFailure]  # ty: ignore[type-assertion-failure]


### PR DESCRIPTION
# I have made things!
Assignment-style field declarations let the mypy plugin infer the type correctly (instead of the current `Any` fallback).
This also makes our setup consistant, we use to mix ways of defining these.


## Related issues
Mostly implement the suggestion https://github.com/typeddjango/django-stubs/pull/2483#discussion_r1922014216

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
