### PR TITLE
Ensure ORM expressions return params as a tuple

### DIFF
--- a/django-stubs/db/models/sql/compiler.pyi
+++ b/django-stubs/db/models/sql/compiler.pyi
@@ -12,13 +12,12 @@ from django.db.models.base import Model
 from django.db.models.expressions import BaseExpression, Expression, Ref
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import AggregateQuery, DeleteQuery, InsertQuery, UpdateQuery
-from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import cached_property
 from typing_extensions import override
 
 _ParamT: TypeAlias = str | int
 
-_ParamsT: TypeAlias = _ListOrTuple[_ParamT]
+_ParamsT: TypeAlias = tuple[_ParamT, ...]
 _AsSqlType: TypeAlias = tuple[str, _ParamsT]
 
 class PositionRef(Ref):


### PR DESCRIPTION
# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

Since Django 6.0, it is expected that `as_sql()` returns params as a tuple, never a list. Changing this helps to ensure that this incompatibility is picked up at static type checking time.

See https://docs.djangoproject.com/en/stable/releases/6.0/#custom-orm-expressions-should-return-params-as-a-tuple

## Related issues
<!--
Mark what issues this Pull Request closes or references.

Example. Fixes #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
N/A

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
