### PR TITLE
Allow all supported types in GeneratedField.choices.

### DIFF
--- a/django-stubs/db/models/fields/generated.pyi
+++ b/django-stubs/db/models/fields/generated.pyi
@@ -7,7 +7,7 @@ from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.expressions import Expression
 from django.db.models.fields import _ErrorMessagesMapping
 from django.db.models.sql import Query
-from django.utils.choices import _Choices
+from django.utils.choices import _ChoicesInput
 from django.utils.datastructures import DictWrapper
 from django.utils.functional import _StrOrPromise, cached_property
 from typing_extensions import override
@@ -37,7 +37,7 @@ class GeneratedField(models.Field[Any, Any]):
         unique_for_date: str | None = ...,
         unique_for_month: str | None = ...,
         unique_for_year: str | None = ...,
-        choices: _Choices | None = ...,
+        choices: _ChoicesInput | None = ...,
         help_text: _StrOrPromise = ...,
         db_column: str | None = ...,
         db_comment: str | None = ...,

--- a/tests/typecheck/db/models/test_fields_choices.yml
+++ b/tests/typecheck/db/models/test_fields_choices.yml
@@ -100,3 +100,58 @@
         int8 = models.IntegerField(choices=to_named_seq(int_tuple)(), default=1)
         int9 = models.IntegerField(choices=to_named_seq(int_mapping)(), default=1)
         int10 = models.IntegerField(choices=choices_type)
+
+        generated1 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=TextChoices,
+            db_persist=False,
+        )
+        generated2 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=str_tuple,
+            db_persist=False,
+        )
+        generated3 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=str_mapping,
+            db_persist=False,
+        )
+        generated4 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=str_tuple(),
+            db_persist=False,
+        )
+        generated5 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=str_mapping(),
+            db_persist=False,
+        )
+        generated6 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=to_named_seq(str_tuple),
+            db_persist=False,
+        )
+        generated7 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=to_named_mapping(str_mapping),
+            db_persist=False,
+        )
+        generated8 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=to_named_seq(str_tuple)(),
+            db_persist=False,
+        )
+        generated9 = models.GeneratedField(
+            expression=models.Value("foo"),
+            output_field=models.CharField(max_length=5),
+            choices=to_named_mapping(str_mapping)(),
+            db_persist=False,
+        )


### PR DESCRIPTION
## Related issues

#3540

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
