### PR TITLE
Make the narrowed response type of `TemplateView` opt-in

### DIFF
--- a/django-stubs/views/generic/base.pyi
+++ b/django-stubs/views/generic/base.pyi
@@ -4,7 +4,6 @@ from typing import Any, Generic
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
-from django.template.response import TemplateResponse
 from django.utils.functional import _Getter
 from typing_extensions import TypeVar, override
 
@@ -26,11 +25,11 @@ class View(Generic[_ViewResponse]):
     @classmethod
     def as_view(cls: Any, **initkwargs: Any) -> Callable[..., _ViewResponse]: ...
     def setup(self, request: HttpRequest, *args: Any, **kwargs: Any) -> None: ...
-    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> _ViewResponse: ...
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
     def http_method_not_allowed(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def options(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase: ...
 
-_TemplateResponse = TypeVar("_TemplateResponse", bound=HttpResponse, default=TemplateResponse)
+_TemplateResponse = TypeVar("_TemplateResponse", bound=HttpResponse, default=HttpResponse)
 
 class TemplateResponseMixin(Generic[_TemplateResponse]):
     template_name: str | None

--- a/tests/assert_type/views/test_base.py
+++ b/tests/assert_type/views/test_base.py
@@ -1,16 +1,84 @@
 from __future__ import annotations
 
+from typing import Any
+
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin
+from django.http import HttpRequest, HttpResponse, HttpResponseBase, JsonResponse
+from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.test import RequestFactory
 from django.views.generic import TemplateView
-from typing_extensions import assert_type
+from typing_extensions import assert_type, override
+
+request = RequestFactory().get("/")
 
 
-class MyTemplateView(TemplateView):
+class BareTemplateView(TemplateView):
     template_name = "template.html"
 
 
-request = RequestFactory().get("/")
-response = MyTemplateView.as_view()(request)
-assert_type(response, TemplateResponse)
-assert_type(response.rendered_content, str)
+class NarrowedTemplateView(TemplateView[TemplateResponse]):
+    template_name = "template.html"
+
+
+def bare_is_permissive(view: BareTemplateView) -> None:
+    assert_type(BareTemplateView.as_view()(request), HttpResponse)
+    assert_type(view.get(request), HttpResponse)
+    assert_type(view.render_to_response({}), HttpResponse)
+
+
+def parametrising_narrows_the_response(view: NarrowedTemplateView) -> None:
+    response = NarrowedTemplateView.as_view()(request)
+    assert_type(response, TemplateResponse)
+    assert_type(response.rendered_content, str)
+    assert_type(view.get(request), TemplateResponse)
+    assert_type(view.render_to_response({}), TemplateResponse)
+
+
+def dispatch_is_never_narrowed(view: NarrowedTemplateView) -> None:
+    assert_type(view.dispatch(request), HttpResponseBase)
+    assert_type(view.http_method_not_allowed(request), HttpResponse)
+    assert_type(view.options(request), HttpResponseBase)
+
+
+class LoginRequired(LoginRequiredMixin, TemplateView):
+    template_name = "template.html"
+
+
+class PermissionRequired(PermissionRequiredMixin, NarrowedTemplateView):
+    template_name = "template.html"
+    permission_required = "app.some_permission"
+
+
+class UserPassesTest(UserPassesTestMixin, TemplateView):
+    template_name = "template.html"
+
+    @override
+    def test_func(self) -> bool:
+        return True
+
+
+class RedirectingGet(TemplateView):
+    template_name = "template.html"
+
+    @override
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if request.user.is_anonymous:
+            return redirect("/login/")
+        return super().get(request, *args, **kwargs)
+
+
+class UnionGet(TemplateView):
+    template_name = "template.html"
+
+    @override
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse | JsonResponse:
+        return JsonResponse({})
+
+
+class WideningDispatch(TemplateView):
+    template_name = "template.html"
+
+    @override
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
# I have made things!
Fixes a few issue introduced by #2874 (unreleased) I noticed trying to run master branch on my work codebase.

The typevar default of `TemplateView` was `TemplateResponse` which was causing:
- redirecting from `get` an error (tho it's rather common)
- `dispatch` might also returns whichever handler ran, and `http_method_not_allowed` and `options` are declared wider
- `class V(LoginRequiredMixin, TemplateView)`  from the auth docs was rejected with conflicting `dispatch`

So I changed the default to match the previous state and added more test case to avoid futur regression

This means you need to do `TemplateView[TemplateResponse]` if you want to narrow

## Related issues
#2874 (cc @samueljsb)

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
