### PR TITLE
Add `assert_type` coverage for manager and descriptor subclassing

### DIFF
--- a/tests/assert_type/db/models/fields/test_related_descriptors.py
+++ b/tests/assert_type/db/models/fields/test_related_descriptors.py
@@ -4,7 +4,9 @@ from typing import ClassVar
 
 from django.db import models
 from django.db.models.fields.related_descriptors import RelatedManager, ReverseManyToOneDescriptor
-from typing_extensions import assert_type
+from typing_extensions import TypeVar, assert_type
+
+_To = TypeVar("_To", bound=models.Model)
 
 
 class Other(models.Model):
@@ -16,3 +18,30 @@ class MyModel(models.Model):
 
 
 assert_type(Other().explicit_descriptor, RelatedManager[MyModel])
+
+
+class CustomDescriptor(ReverseManyToOneDescriptor[MyModel]):
+    def custom_method(self) -> int:
+        raise NotImplementedError
+
+
+class WithCustomDescriptor(models.Model):
+    custom_descriptor: ClassVar[CustomDescriptor]
+
+
+# Class-level access returns `Self`, preserving descriptor subclasses and their members
+assert_type(WithCustomDescriptor.custom_descriptor, CustomDescriptor)
+assert_type(WithCustomDescriptor.custom_descriptor.custom_method(), int)
+
+
+class PassThroughDescriptor(ReverseManyToOneDescriptor[_To]): ...
+
+
+class WithPassThroughDescriptor(models.Model):
+    passthrough_descriptor: ClassVar[PassThroughDescriptor[MyModel]]
+
+
+# Class-level access returns `Self`, preserving a generic subclass and its parameterization
+assert_type(WithPassThroughDescriptor.passthrough_descriptor, PassThroughDescriptor[MyModel])
+
+assert_type(MyModel._default_manager.__class__, type[models.Manager[MyModel]])

--- a/tests/assert_type/db/models/test_managers.py
+++ b/tests/assert_type/db/models/test_managers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from django.db import models
 from django.db.models.query import QuerySet
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, assert_type
 
 T = TypeVar("T", bound="MyModel")
 
@@ -20,3 +20,21 @@ class MyModelQuerySet(QuerySet[T]):
 class MyModel(models.Model):
     class Meta:
         app_label = "myapp"
+
+
+class CustomManager(models.Manager["OtherModel"]):
+    def manager_method(self) -> str:
+        return ""
+
+
+class OtherQuerySet(models.QuerySet["OtherModel"]): ...
+
+
+class OtherModel(models.Model):
+    class Meta:
+        app_label = "myapp"
+
+
+# `from_queryset` returns `type[Self]`, preserving manager subclasses and their members
+assert_type(CustomManager.from_queryset(OtherQuerySet), type[CustomManager])
+assert_type(CustomManager.from_queryset(OtherQuerySet)().manager_method(), str)


### PR DESCRIPTION
## Related issues
Extracting some side work from #2776

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
