### PR TITLE
Misc plugin cleanups

### DIFF
--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -91,8 +91,10 @@ def get_field_type_from_model_type_info(info: TypeInfo | None, field_name: str) 
     field_type = get_proper_type(field_node.type)
     if not isinstance(field_type, Instance):
         return None
-    # Field declares a set and a get type arg. Fallback to `None` when we can't find any args
-    if len(field_type.args) != 2:
+    # Field declares a set and a get type arg. Fallback to `None` when we can't find any args.
+    # Not every model attribute is a field,
+    # a reverse o2o accessor is a two arg descriptor whose args would be misread as set/get types.
+    if len(field_type.args) != 2 or not field_type.type.has_base(fullnames.FIELD_FULLNAME):
         return None
     return field_type
 

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -149,6 +149,8 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
     """
     Insert a new manager class node for a: '<Name> = <Manager>.from_queryset(<QuerySet>)'.
     When the assignment expression lives at module level.
+
+    class level cases are resolved in `AddManagers.try_create_manager_from_from_queryset`
     """
     semanal_api = helpers.get_semanal_api(ctx)
 

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -390,7 +390,7 @@ class AddManagers(ModelClassInitializer):
 
             if manager_info is None:
                 # We couldn't find a manager type, see if we should create one
-                manager_info = self.create_manager_from_from_queryset(manager_name)
+                manager_info = self.try_create_manager_from_from_queryset(manager_name)
 
             if manager_info is None:
                 incomplete_manager_defs.add(manager_name)
@@ -453,12 +453,14 @@ class AddManagers(ModelClassInitializer):
 
         return self.lookup_typeinfo(generated_manager_name)
 
-    def create_manager_from_from_queryset(self, name: str) -> TypeInfo | None:
+    def try_create_manager_from_from_queryset(self, name: str) -> TypeInfo | None:
         """
         Try to create a manager from a .from_queryset call:
 
             class MyModel(models.Model):
                 objects = MyManager.from_queryset(MyQuerySet)()
+
+        module level cases are resolved in `create_new_manager_class_from_from_queryset_method`
         """
 
         assign_statement = self.get_manager_expression(name)

--- a/tests/typecheck/models/test_meta_options.yml
+++ b/tests/typecheck/models/test_meta_options.yml
@@ -68,7 +68,7 @@
                 class MyModel(AbstractModel):
                     field = ArrayField(models.IntegerField(), default=[])
 
--   case: get_field_reverse_fk_with_related_query_name
+-   case: get_field_reverse_relations
     main: |
         from typing_extensions import reveal_type
         from myapp.models import ModelA
@@ -78,6 +78,9 @@
 
         reveal_type(ModelA._meta.get_field("model_b_bis")) # N: Revealed type is "django.db.models.fields.reverse_related.ManyToOneRel"
         reveal_type(ModelA.model_b_bis.field) # N: Revealed type is "django.db.models.fields.related.ForeignKey[myapp.models.ModelB, myapp.models.ModelB]"
+
+        # The reverse o2o accessor is a two arg descriptor, not a field
+        reveal_type(ModelA._meta.get_field("modelc")) # N: Revealed type is "django.db.models.fields.reverse_related.OneToOneRel"
 
     installed_apps:
         - myapp
@@ -92,6 +95,9 @@
                 class ModelB(models.Model):
                     model_a = models.ForeignKey(ModelA, on_delete=models.CASCADE, related_query_name="model_b")
                     model_a_bis = models.ForeignKey(ModelA, on_delete=models.CASCADE, related_name="model_b_bis")
+
+                class ModelC(models.Model):
+                    model_a = models.OneToOneField(ModelA, on_delete=models.CASCADE)
 
 -   case: base_model_meta_incompatible_types
     main: |


### PR DESCRIPTION
# I have made things!
Small plugin tweaks and a bug fix misreading OneToOnefield accessors

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
