### PR TITLE
Allowlist module-level loop leak variables in expressions

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -255,9 +255,19 @@ django.test.selenium.SeleniumTestCase.__init_subclass__
 # mypy does not understand __getitem__ unpacking python/mypy#2220
 django.urls.resolvers.ResolverMatch.__iter__
 
-# Loop leak variables - values depend on dict iteration order, not public API
+# Targets of the module-level `for key, op in OPERATORS.items()` in template/smartif.py,
+# left over in the module namespace. Not public API.
 django.template.smartif.key
 django.template.smartif.op
+
+# Targets of the module-level loop over _connector_combinations in db/models/expressions.py,
+# left over in the module namespace. Not public API.
+django.db.models.expressions.connector
+django.db.models.expressions.d
+django.db.models.expressions.field_types
+django.db.models.expressions.lhs
+django.db.models.expressions.result
+django.db.models.expressions.rhs
 
 # The parameters form_class / choices_form_class are positional at runtime, but
 # usage and docs always pass them as keyword args; additionally, all subclasses

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -101,16 +101,8 @@ django.db.connection
 django.db.migrations.recorder.MigrationRecorder.Migration.get_next_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.get_previous_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.id
-django.db.models.expressions.connector
-django.db.models.expressions.d
-django.db.models.expressions.field_types
 django.db.models.fields.CharField.description
 django.db.models.fields.Field.description
 django.db.models.fields.json.CaseInsensitiveMixin.process_lhs
 django.forms.models.inlineformset_factory
 django.forms.models.modelformset_factory
-
-# mypy 1.9.0 new issues:
-django.db.models.expressions.rhs
-django.db.models.expressions.result
-django.db.models.expressions.lhs


### PR DESCRIPTION
# I have made things!

Same root cause as the django.template.smartif.key/op entries already in the permanent allowlist: a module-level for loop leaks its targets, here the triple-nested loop over _connector_combinations in expressions.py.


## Related issues
Same as #3114
We can probably do a similar fix to https://github.com/django/django/pull/20760/changes upstream ? (cc @sobolevn)

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


### Summary from thread on [my own fork pr](https://github.com/UnknownPlatypus/django-stubs/pull/1) cause :sleepy: 
> [sobolevn](https://github.com/sobolevn)
left a comment
Yes, please send a PR to django :)
@[sobolevn](https://github.com/sobolevn)
sobolevn
commented
[6 minutes ago](https://github.com/UnknownPlatypus/django-stubs/pull/1#issuecomment-5153392616)
Btw, this a PR to your own fork? 🤔
@[UnknownPlatypus](https://github.com/UnknownPlatypus)
UnknownPlatypus
commented
[3 minutes ago](https://github.com/UnknownPlatypus/django-stubs/pull/1#issuecomment-5153406691)
Owner Author
    Btw, this a PR to your own fork? 🤔
ye lmao i'm tired ahah, updating