### PR TITLE
Permanently allowlist module-level proxy objects in stubtest

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -17,13 +17,17 @@ django.contrib.redirects.migrations.*
 django.contrib.sessions.migrations.*
 django.contrib.sites.migrations.*
 
-# default_storage is actually an instance of DefaultStorage, but it proxies through to a Storage
-django.core.files.storage.default_storage
-
-# site is actually an instance of DefaultAdminSite, but it proxies through to an AdminSite
+# Note: At runtime, these are `LazyObject` or `ConnectionProxy` instances.
+# However, to avoid type degradation, we stub them using the underlying target type instead.
+#
+# Why? Both wrapper classes define `__getattr__(self, name: str) -> Any`.
+# Type-hinting as the wrapper would turn every attribute access into `Any`.
 django.contrib.admin.sites.site
-
-# default_task_backend is actually an instance of ConnectionProxy, but it proxies through to a BaseTaskBackend
+django.contrib.staticfiles.finders.DefaultStorageFinder.storage
+django.contrib.staticfiles.storage.staticfiles_storage
+django.core.cache.cache
+django.core.files.storage.default_storage
+django.db.connection
 django.tasks.default_task_backend
 
 # path/re_path are actually functools.partial objects at runtime, but stubs type them as functions

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -91,13 +91,9 @@ django.contrib.sessions.models.Session.session_key
 django.contrib.sites.models.Site.domain
 django.contrib.sites.models.Site.id
 django.contrib.sites.models.Site.name
-django.contrib.staticfiles.finders.DefaultStorageFinder.storage
-django.contrib.staticfiles.storage.staticfiles_storage
-django.core.cache.cache
 django.db.backends.mysql.base.DatabaseWrapper.ops
 django.db.backends.postgresql.base.DatabaseWrapper.ops
 django.db.backends.sqlite3.base.DatabaseWrapper.ops
-django.db.connection
 django.db.migrations.recorder.MigrationRecorder.Migration.get_next_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.get_previous_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.id


### PR DESCRIPTION
# I have made things!

Group ignore entries for the same issue (a proxy type defining `__getattr__ -> Any` that would degrade every attriubte access if faithfully typed)


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
