### PR TITLE
Allowlist DatabaseWrapper.ops on the concrete database backends

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -151,6 +151,7 @@ django.db.migrations.operations.models.AlterTogetherOptionOperation.option_name
 
 # These are set to None in the base class but *must* be overridden
 # because they are required in the init, so we type them without the None option.
+django.contrib.gis.db.backends.spatialite.base.DatabaseWrapper.ops
 django.db.backends.base.base.BaseDatabaseWrapper.SchemaEditorClass
 django.db.backends.base.base.BaseDatabaseWrapper.client_class
 django.db.backends.base.base.BaseDatabaseWrapper.creation_class
@@ -158,6 +159,9 @@ django.db.backends.base.base.BaseDatabaseWrapper.features_class
 django.db.backends.base.base.BaseDatabaseWrapper.introspection_class
 django.db.backends.base.base.BaseDatabaseWrapper.ops
 django.db.backends.base.base.BaseDatabaseWrapper.ops_class
+django.db.backends.mysql.base.DatabaseWrapper.ops
+django.db.backends.postgresql.base.DatabaseWrapper.ops
+django.db.backends.sqlite3.base.DatabaseWrapper.ops
 
 # Attributes defaulting to None messing with mypy
 django.contrib.admin.options.InlineModelAdmin.model

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -71,7 +71,6 @@ django.contrib.flatpages.models.FlatPage.sites
 django.contrib.flatpages.models.FlatPage.template_name
 django.contrib.flatpages.models.FlatPage.title
 django.contrib.flatpages.models.FlatPage.url
-django.contrib.gis.db.backends.spatialite.base.DatabaseWrapper.ops
 django.contrib.redirects.models.Redirect.id
 django.contrib.redirects.models.Redirect.new_path
 django.contrib.redirects.models.Redirect.old_path
@@ -91,9 +90,6 @@ django.contrib.sessions.models.Session.session_key
 django.contrib.sites.models.Site.domain
 django.contrib.sites.models.Site.id
 django.contrib.sites.models.Site.name
-django.db.backends.mysql.base.DatabaseWrapper.ops
-django.db.backends.postgresql.base.DatabaseWrapper.ops
-django.db.backends.sqlite3.base.DatabaseWrapper.ops
 django.db.migrations.recorder.MigrationRecorder.Migration.get_next_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.get_previous_by_applied
 django.db.migrations.recorder.MigrationRecorder.Migration.id


### PR DESCRIPTION
# I have made things!
Same cause as the other in the ignore group

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
