### PR TITLE
Reduce CI test sharding from 4 to 2 shards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        shard: [0, 1, 2, 3]
+        shard: [0, 1]
       fail-fast: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -82,14 +82,14 @@ jobs:
 
       # Must match `shard` definition in the test matrix:
       - name: Run pytest tests
-        run: uv run pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests
+        run: uv run pytest --num-shards=2 --shard-id=${{ matrix.shard }} -n auto tests
 
   test-older-django:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1]
       fail-fast: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -117,7 +117,7 @@ jobs:
 
       # Exit 1 only if ont of the pytest error is a mypy crash
       - name: Run pytest tests
-        run: "! uv run pytest --num-shards=4 --shard-id=${{ matrix.shard }} -n auto tests | grep 'pytest_mypy_plugins.utils.TypecheckAssertionError: Critical error occurred'"
+        run: "! uv run pytest --num-shards=2 --shard-id=${{ matrix.shard }} -n auto tests | grep 'pytest_mypy_plugins.utils.TypecheckAssertionError: Critical error occurred'"
 
 
   stubtest:


### PR DESCRIPTION
# I have made things!
The test job runs 5 Python versions times 4 shards, saturating the 20-job concurrency limit of the free GitHub plan and queueing all other jobs. Halving the shards frees slots so other jobs run in parallel.

test jobs are also really fast now (~1min) so the setup is getting almost more expensive

This should speed up ci overall because jobs stop beeing queued up

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
