### PR TITLE
Permanently allowlist the formset factory form default in stubtest

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -282,6 +282,13 @@ django.db.models.expressions.rhs
 # require them to be keyword-only, so require all usage to be keyword-only.
 django.db.models.fields.Field.formfield
 
+# `form` is a TypeVar with a PEP 696 default of `ModelForm[_M]`, so omitting it still ties the
+# formset to the model. stubtest never resolves TypeVar defaults, so it can't tell that the
+# runtime `ModelForm` default satisfies `type[_ModelFormT]`.
+django.contrib.contenttypes.forms.generic_inlineformset_factory
+django.forms.models.inlineformset_factory
+django.forms.models.modelformset_factory
+
 # Field.__get__/__set__ are stub-only for the mypy plugin, they don't exist at runtime
 django.db.models.fields.Field.__get__
 django.db.models.fields.Field.__set__

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -59,7 +59,6 @@ django.contrib.auth.models.User.last_name
 django.contrib.auth.models.User.password
 django.contrib.auth.models.User.user_permissions
 django.contrib.auth.models.User.username
-django.contrib.contenttypes.forms.generic_inlineformset_factory
 django.contrib.contenttypes.models.ContentType.app_label
 django.contrib.contenttypes.models.ContentType.id
 django.contrib.contenttypes.models.ContentType.model
@@ -96,5 +95,3 @@ django.db.migrations.recorder.MigrationRecorder.Migration.id
 django.db.models.fields.CharField.description
 django.db.models.fields.Field.description
 django.db.models.fields.json.CaseInsensitiveMixin.process_lhs
-django.forms.models.inlineformset_factory
-django.forms.models.modelformset_factory


### PR DESCRIPTION
# I have made things!
Move to regular ignore, it's a stubtest limitation around resolving typevar defaults in attribute defaults.


## Related issues
https://github.com/python/mypy/issues/3737 seem to be relevant

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
