### PR TITLE
Add overloads for `assertTemplateUsed` and `assertTemplateNotUsed`

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -116,16 +116,48 @@ class SimpleTestCase(unittest.TestCase):
         errors: list[str] | str,
         msg_prefix: str = "",
     ) -> None: ...
+    # with self.assertTemplateUsed("template.html"): ...
+    @overload
     def assertTemplateUsed(
         self,
-        response: HttpResponseBase | str | None = None,
+        response: str,
+        template_name: None = None,
+        msg_prefix: str = "",
+        count: int | None = None,
+    ) -> _AssertTemplateUsedContext: ...
+    # with self.assertTemplateUsed(template_name="template.html"): ...
+    @overload
+    def assertTemplateUsed(
+        self,
+        response: None = None,
         template_name: str | None = None,
         msg_prefix: str = "",
         count: int | None = None,
-    ) -> _AssertTemplateUsedContext | None: ...
+    ) -> _AssertTemplateUsedContext: ...
+    # self.assertTemplateUsed(response, "template.html")
+    @overload
+    def assertTemplateUsed(
+        self,
+        response: HttpResponseBase,
+        template_name: str | None = None,
+        msg_prefix: str = "",
+        count: int | None = None,
+    ) -> None: ...
+    # with self.assertTemplateNotUsed("template.html"): ...
+    @overload
     def assertTemplateNotUsed(
-        self, response: HttpResponseBase | str | None = None, template_name: str | None = None, msg_prefix: str = ""
-    ) -> _AssertTemplateNotUsedContext | None: ...
+        self, response: str, template_name: None = None, msg_prefix: str = ""
+    ) -> _AssertTemplateNotUsedContext: ...
+    # with self.assertTemplateNotUsed(template_name="template.html"): ...
+    @overload
+    def assertTemplateNotUsed(
+        self, response: None = None, template_name: str | None = None, msg_prefix: str = ""
+    ) -> _AssertTemplateNotUsedContext: ...
+    # self.assertTemplateNotUsed(response, "template.html")
+    @overload
+    def assertTemplateNotUsed(
+        self, response: HttpResponseBase, template_name: str | None = None, msg_prefix: str = ""
+    ) -> None: ...
     def assertRaisesMessage(
         self, expected_exception: type[Exception], expected_message: str, *args: Any, **kwargs: Any
     ) -> Any: ...

--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -117,16 +117,48 @@ class SimpleTestCase(unittest.TestCase):
         errors: list[str] | str,
         msg_prefix: str = "",
     ) -> None: ...
+    # with self.assertTemplateUsed("template.html"): ...
+    @overload
     def assertTemplateUsed(
         self,
-        response: HttpResponseBase | str | None = None,
+        response: str,
+        template_name: None = None,
+        msg_prefix: str = "",
+        count: int | None = None,
+    ) -> _AssertTemplateUsedContext: ...
+    # with self.assertTemplateUsed(template_name="template.html"): ...
+    @overload
+    def assertTemplateUsed(
+        self,
+        response: None = None,
         template_name: str | None = None,
         msg_prefix: str = "",
         count: int | None = None,
-    ) -> _AssertTemplateUsedContext | None: ...
+    ) -> _AssertTemplateUsedContext: ...
+    # self.assertTemplateUsed(response, "template.html")
+    @overload
+    def assertTemplateUsed(
+        self,
+        response: HttpResponseBase,
+        template_name: str | None = None,
+        msg_prefix: str = "",
+        count: int | None = None,
+    ) -> None: ...
+    # with self.assertTemplateNotUsed("template.html"): ...
+    @overload
     def assertTemplateNotUsed(
-        self, response: HttpResponseBase | str | None = None, template_name: str | None = None, msg_prefix: str = ""
-    ) -> _AssertTemplateNotUsedContext | None: ...
+        self, response: str, template_name: None = None, msg_prefix: str = ""
+    ) -> _AssertTemplateNotUsedContext: ...
+    # with self.assertTemplateNotUsed(template_name="template.html"): ...
+    @overload
+    def assertTemplateNotUsed(
+        self, response: None = None, template_name: str | None = None, msg_prefix: str = ""
+    ) -> _AssertTemplateNotUsedContext: ...
+    # self.assertTemplateNotUsed(response, "template.html")
+    @overload
+    def assertTemplateNotUsed(
+        self, response: HttpResponseBase, template_name: str | None = None, msg_prefix: str = ""
+    ) -> None: ...
     def assertRaisesMessage(
         self, expected_exception: type[Exception], expected_message: str, *args: Any, **kwargs: Any
     ) -> Any: ...

--- a/tests/assert_type/test/test_testcase.py
+++ b/tests/assert_type/test/test_testcase.py
@@ -4,7 +4,7 @@ from typing import assert_type
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.test.client import Client
-from django.test.testcases import TestCase
+from django.test.testcases import TestCase, _AssertTemplateNotUsedContext, _AssertTemplateUsedContext
 
 
 class ExampleTestCase(TestCase):
@@ -14,3 +14,19 @@ class ExampleTestCase(TestCase):
         assert_type(resp.status_code, int)
         resp.json()
         assert_type(resp.wsgi_request, WSGIRequest)
+
+    def test_assert_template_used(self) -> None:
+        response = self.client.get("/url")
+        assert_type(self.assertTemplateUsed(response, "template.html"), None)
+        with self.assertTemplateUsed("template.html") as ctx:
+            assert_type(ctx, _AssertTemplateUsedContext)
+        with self.assertTemplateUsed(template_name="template.html") as ctx:
+            assert_type(ctx, _AssertTemplateUsedContext)
+
+    def test_assert_template_not_used(self) -> None:
+        response = self.client.get("/url")
+        assert_type(self.assertTemplateNotUsed(response, "template.html"), None)
+        with self.assertTemplateNotUsed("template.html") as ctx:
+            assert_type(ctx, _AssertTemplateNotUsedContext)
+        with self.assertTemplateNotUsed(template_name="template.html") as ctx:
+            assert_type(ctx, _AssertTemplateNotUsedContext)

--- a/tests/assert_type/test/test_testcase.py
+++ b/tests/assert_type/test/test_testcase.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.test.client import Client
-from django.test.testcases import TestCase
+from django.test.testcases import TestCase, _AssertTemplateNotUsedContext, _AssertTemplateUsedContext
 from typing_extensions import assert_type
 
 
@@ -13,3 +13,15 @@ class ExampleTestCase(TestCase):
         assert_type(resp.status_code, int)
         resp.json()
         assert_type(resp.wsgi_request, WSGIRequest)
+
+    def test_assert_template_used(self) -> None:
+        response = self.client.get("/url")
+        assert_type(self.assertTemplateUsed(response, "template.html"), None)
+        assert_type(self.assertTemplateUsed("template.html"), _AssertTemplateUsedContext)
+        assert_type(self.assertTemplateUsed(template_name="template.html"), _AssertTemplateUsedContext)
+
+    def test_assert_template_not_used(self) -> None:
+        response = self.client.get("/url")
+        assert_type(self.assertTemplateNotUsed(response, "template.html"), None)
+        assert_type(self.assertTemplateNotUsed("template.html"), _AssertTemplateNotUsedContext)
+        assert_type(self.assertTemplateNotUsed(template_name="template.html"), _AssertTemplateNotUsedContext)


### PR DESCRIPTION
The return type of these can actually be determined more precisely, given the argument types.

Follows https://github.com/pytest-dev/pytest-django/pull/1278

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
