### PR TITLE
Don't crash on a many-to-many through model that can't be resolved

### DIFF
--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -540,7 +540,7 @@ class AddReverseLookups(ModelClassInitializer):
                 assert relation.through is not None
                 if isinstance(relation.through, str):
                     # A lazy reference Django never resolved, i.e. the through model doesn't exist.
-                    return
+                    return  # type:ignore[unreachable] # this can only happen for broken django setup
                 through_fullname = helpers.get_class_fullname(relation.through)
                 through_model_info = self.lookup_typeinfo_or_incomplete_defn_error(through_fullname)
                 self.add_new_var_to_model_class(

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -538,6 +538,9 @@ class AddReverseLookups(ModelClassInitializer):
             if not reverse_lookup_declared:
                 # TODO: 'relation' should be based on `TypeInfo` instead of Django runtime.
                 assert relation.through is not None
+                if isinstance(relation.through, str):
+                    # A lazy reference Django never resolved, i.e. the through model doesn't exist.
+                    return
                 through_fullname = helpers.get_class_fullname(relation.through)
                 through_model_info = self.lookup_typeinfo_or_incomplete_defn_error(through_fullname)
                 self.add_new_var_to_model_class(

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -1389,6 +1389,31 @@
                 class Fourth(models.Model):
                     ...
 
+-   case: test_many_to_many_with_unresolvable_through_model
+    main: |
+        from typing_extensions import reveal_type
+        from myapp.models import First, Other
+        reveal_type(Other().first_set)
+        reveal_type(First().others)
+    out: |
+        main:3: error: "Other" has no attribute "first_set"  [attr-defined]
+        main:3: note: Revealed type is "Any"
+        main:4: note: Revealed type is "django.db.models.fields.related_descriptors.ManyRelatedManager[myapp.models.Other, Never]"
+        myapp/models:4: error: Could not match lazy reference with any model  [misc]
+    installed_apps:
+        -   myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class First(models.Model):
+                    others = models.ManyToManyField("myapp.Other", through="myapp.Missing")
+
+                class Other(models.Model):
+                    ...
+
 -   case: test_many_to_many_lazy_references_with_implicit_app_label
     main: |
         from typing_extensions import reveal_type


### PR DESCRIPTION
# I have made things!

The crash can happen when the `through` argumetn reference a non existing model.
This is very easy to land in this state when using dmypy since the django model cache is not properly invalidated when you swap branches 

Reproduced with this test failing before the fix and now passing

```python
tests/typecheck/fields/test_related.yml::test_many_to_many_with_unresolvable_through_model Traceback (most recent call last):
  File "mypy/semanal.py", line 7732, in accept
  File "mypy/nodes.py", line 1727, in accept
  File "mypy/semanal.py", line 1846, in visit_class_def
  File "mypy/semanal.py", line 2078, in analyze_class
  File "mypy/semanal.py", line 2139, in analyze_class_body_common
  File "mypy/semanal.py", line 2226, in apply_class_plugin_hooks
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/models.py", line 1100, in process_model_class
    initializer_cls(ctx, django_context).run()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/models.py", line 108, in run
    self.run_with_model_cls(model_cls)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/models.py", line 621, in run_with_model_cls
    self.process_relation(relation)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/transformers/models.py", line 544, in process_relation
    through_fullname = helpers.get_class_fullname(relation.through)
  File "/home/thibaut/workspace/django-stubs/mypy_django_plugin/lib/helpers.py", line 164, in get_class_fullname
    return klass.__module__ + "." + klass.__qualname__
           ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute '__module__'. Did you mean: '__mod__'?
```

## Related issues
Fixes #3568

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
