### PR TITLE
Support custom arguments in queryset update methods

### DIFF
--- a/mypy_django_plugin/transformers/querysets.py
+++ b/mypy_django_plugin/transformers/querysets.py
@@ -1252,9 +1252,21 @@ def validate_distinct(ctx: MethodContext, django_context: DjangoContext) -> Mypy
     return ctx.default_return_type
 
 
+def gather_update_kwargs(ctx: MethodContext) -> dict[str, MypyType]:
+    """Gather named arguments destined for the `**kwargs` collector."""
+    kwargs: dict[str, MypyType] = {}
+    named = (ARG_NAMED, ARG_NAMED_OPT)
+    slots = zip(ctx.callee_arg_names, ctx.arg_kinds, ctx.arg_types, ctx.arg_names, strict=False)
+    for formal_name, kinds, types, names in slots:
+        for kind, arg_type, name in zip(kinds, types, names, strict=False):
+            if kind in named and name is not None and name != formal_name:
+                kwargs[name] = arg_type
+    return kwargs
+
+
 def validate_update(ctx: MethodContext, django_context: DjangoContext) -> MypyType:
     if (django_model := helpers.get_model_info_from_qs_ctx(ctx, django_context)) is None or not (
-        kwargs := gather_kwargs(ctx)
+        kwargs := gather_update_kwargs(ctx)
     ):
         return ctx.default_return_type
 

--- a/tests/typecheck/managers/querysets/test_update.yml
+++ b/tests/typecheck/managers/querysets/test_update.yml
@@ -96,3 +96,32 @@
                     published = models.BooleanField(default=False)
                     author = models.ForeignKey(Author, on_delete=models.CASCADE)
                     tags = models.ManyToManyField(Tag)
+
+
+-   case: update_override_with_declared_kwargs
+    installed_apps:
+        - myapp
+    main: |
+        from myapp.models import Article
+
+        # Kwargs declared explicitly by an `update()` override are consumed by
+        # the override; only ones destined for `**kwargs` are model fields.
+        Article.objects.update(title="new title", author_name="foo")
+        Article.objects.update(nonexistent=1, author_name="foo")  # E: Article has no field named 'nonexistent'  [misc]
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from typing import Any
+
+                from django.db import models
+                from typing_extensions import override
+
+                class ArticleQuerySet(models.QuerySet["Article"]):
+                    @override
+                    def update(self, *, author_name: str | None = None, **kwargs: Any) -> int:
+                        return super().update(**kwargs)
+
+                class Article(models.Model):
+                    title = models.CharField(max_length=200)
+                    objects = ArticleQuerySet.as_manager()


### PR DESCRIPTION
Example in test should be pretty self-explanatory.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
