### PR TITLE
Run every typechecker before reporting failures

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,7 +53,14 @@ ty *files="tests/assert_type":
 
 # Run all typecheckers on test cases (default), or on the given files
 [group('typecheck')]
-typecheck-all *files="tests/assert_type": (pyrefly files) (ty files) (pyright files) (mypy files)
+typecheck-all *files="tests/assert_type":
+    #!/usr/bin/env bash
+    failed=()
+    for checker in pyrefly ty pyright mypy; do
+        printf '=================================== %s ===================================\n' "$checker"
+        just "$checker" {{ files }} || failed+=("$checker")
+    done
+    [[ ${#failed[@]} -eq 0 ]] || { echo "Failed: ${failed[*]}"; exit 1; }
 
 # Run pytest tests
 [group('test')]


### PR DESCRIPTION
# I have made things!
I find `just typecheck-all` very useful to iterate locally but it currently fails on the first typechecker in case of error which is not the best. I usually want to see the broad impact of a change directly and find myself calling every typechecker manually.

This changes it so that we always get all outputs, error or not!

<details><summary>No errors</summary>
<p>

```bash
$ just typecheck-all 
=================================== pyrefly ===================================
uv run pyrefly check tests/assert_type
 INFO 0 errors (114 suppressed, 1 warning not shown)
=================================== ty ===================================
uv run ty check tests/assert_type
All checks passed!
=================================== pyright ===================================
uv run pyright tests/assert_type
0 errors, 0 warnings, 0 informations
=================================== mypy ===================================
uv run mypy tests/assert_type
Success: no issues found in 109 source files
```

</p>
</details> 

<details><summary>Errors</summary>
<p>

```bash
$ just typecheck-all 
=================================== pyrefly ===================================
uv run pyrefly check tests/assert_type
ERROR `Literal['12']` is not assignable to `int` [bad-assignment]
  --> tests/assert_type/test_shortcuts.py:23:10
   |
23 | a: int = "12"
   |    ---   ^^^^
   |    |
   |    declared type
   |
 INFO 1 error (114 suppressed, 1 warning not shown)
error: recipe `pyrefly` failed on line 47 with exit code 1
=================================== ty ===================================
uv run ty check tests/assert_type
error[invalid-assignment]: Object of type `Literal["12"]` is not assignable to `int`
  --> tests/assert_type/test_shortcuts.py:23:10
   |
23 | a: int = "12"
   |    ---   ^^^^ Incompatible value of type `Literal["12"]`
   |    |
   |    Declared type

Found 1 diagnostic
error: recipe `ty` failed on line 52 with exit code 1
=================================== pyright ===================================
uv run pyright tests/assert_type
/home/thibaut/workspace/django-stubs/tests/assert_type/test_shortcuts.py
  /home/thibaut/workspace/django-stubs/tests/assert_type/test_shortcuts.py:23:10 - error: Type "Literal['12']" is not assignable to declared type "int"
    "Literal['12']" is not assignable to "int" (reportAssignmentType)
1 error, 0 warnings, 0 informations
error: recipe `pyright` failed on line 42 with exit code 1
=================================== mypy ===================================
uv run mypy tests/assert_type
tests/assert_type/test_shortcuts.py:23: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
Found 1 error in 1 file (checked 109 source files)
error: recipe `mypy` failed on line 37 with exit code 1
Failed: pyrefly ty pyright mypy
error: recipe `typecheck-all` failed with exit code 1
```

</p>
</details> 


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
