### PR TITLE
Resolve objects through the metaclass and ban manager access on instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,26 @@ you are using our mypy plugin.
 
 Use this setting on your own risk, because it can hide valid errors.
 
+### Do I need to annotate reverse relations?
+
+Not if you use our mypy plugin. It reads your app registry and declares every reverse accessor for you, as
+`RelatedManager[Model]`, or `ManyRelatedManager[Model, Through]` for a `ManyToManyField`.
+
+pyright, pyrefly and ty do not run the plugin, so under those you declare them yourself.
+Reach for `RelatedManager` rather than `Manager`: a reverse accessor is read from a model instance, whereas a regular manager such as `objects` only exists on the model class.
+
+```python
+from django.db import models
+from django_stubs_ext.db.models.manager import ManyRelatedManager, RelatedManager
+
+
+class Article(models.Model):
+    category_set: RelatedManager[Category]
+    tags: ManyRelatedManager[Tag, ArticleTag]
+```
+
+Make sure to import symbols from `django_stubs_ext.db.models.manager`. Django dynamically create these so they cannot be imported directly
+
 ### How to type a custom `models.Field`?
 
 > [!NOTE]

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -48,7 +48,7 @@ class ModelBase(type):
     def _base_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
     @property
     def _default_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
-    # Class level only access for the `objects` manager when it's not defined explicitly (`objects = CustomManager()`).
+    # Class level only access for the `objects` manager when it's not defined explicitly.
     # Because this acts as a fallback (matching django adding this manager if not defined), it resolves conflict
     # we previously had with pyright and pyrefly when overriding `objects`.
     # See https://github.com/typeddjango/django-stubs/pull/3559#issue-5057479304

--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Iterable, Sequence
-from typing import Any, ClassVar, Final, Self, overload
+from typing import Any, ClassVar, Final, Literal, Self, overload
 from weakref import ReferenceType
 
 from django.core.checks.messages import CheckMessage
@@ -48,6 +48,11 @@ class ModelBase(type):
     def _base_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
     @property
     def _default_manager(cls: type[_Self]) -> Manager[_Self]: ...  # type: ignore[misc]
+    # Class level only access for the `objects` manager when it's not defined explicitly (`objects = CustomManager()`).
+    # Because this acts as a fallback (matching django adding this manager if not defined), it resolves conflict
+    # we previously had with pyright and pyrefly when overriding `objects`.
+    # See https://github.com/typeddjango/django-stubs/pull/3559#issue-5057479304
+    def __getattr__(cls: type[_Self], name: Literal["objects"]) -> Manager[_Self]: ...
 
 class Model(AltersData, metaclass=ModelBase):
     # These attributes should only exist on concrete subclasses, not abstract models, and are
@@ -59,7 +64,6 @@ class Model(AltersData, metaclass=ModelBase):
     DoesNotExist: Final[type[ObjectDoesNotExist]]
     NotUpdated: Final[type[ObjectNotUpdated]]
     MultipleObjectsReturned: Final[type[BaseMultipleObjectsReturned]]
-    objects: ClassVar[Manager[Self]]
 
     _meta: ClassVar[Options[Self]]
     pk: Any

--- a/django-stubs/db/models/fields/related_descriptors.pyi
+++ b/django-stubs/db/models/fields/related_descriptors.pyi
@@ -104,6 +104,9 @@ class ReverseManyToOneDescriptor(Generic[_To]):
 @type_check_only
 class RelatedManager(Manager[_To], Generic[_To]):
     related_val: tuple[int, ...]
+    # Related managers are bound to model instances, so we allow instance access.
+    @override
+    def __get__(self, instance: object, cls: type[Any] | None = None) -> Self: ...
     def __call__(self, *, manager: str) -> RelatedManager[_To]: ...
     def add(self, *objs: _To | int, bulk: bool = ...) -> None: ...
     async def aadd(self, *objs: _To | int, bulk: bool = ...) -> None: ...
@@ -161,6 +164,9 @@ class ManyToManyDescriptor(ReverseManyToOneDescriptor[Any], Generic[_To, _Throug
 @type_check_only
 class ManyRelatedManager(Manager[_To], Generic[_To, _Through]):
     related_val: tuple[int, ...]
+    # See `RelatedManager.__get__`
+    @override
+    def __get__(self, instance: object, cls: type[Any] | None = None) -> Self: ...
     through: type[_Through]
     def __call__(self, *, manager: str) -> ManyRelatedManager[_To, _Through]: ...
     def add(

--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -35,10 +35,10 @@ class BaseManager(Generic[_T]):
     def db(self) -> str: ...
     def get_queryset(self) -> QuerySet[_T]: ...
     def all(self) -> QuerySet[_T]: ...
-    # Stub-only. At runtime a manager declared on a model is wrapped in a `ManagerDescriptor`,
-    # which raises on instance access, so accepting only `instance=None` makes `instance.objects` a type error.
-    # `Options` is accepted to work around https://github.com/python/mypy/issues/13608: mypy re-applies
-    # `__get__` to the return type of `Options.base_manager`, passing the `Options` object as `instance`.
+    # At runtime, managers declared on a model are wrapped in a `ManagerDescriptor` which raises on instance access.
+    # Accepting only `instance=None` makes `instance.objects` a type error.
+    # `Options` is accepted to work around https://github.com/python/mypy/issues/13608
+    # mypy re-applies `__get__` to the return type of `Options.base_manager`, passing the `Options` object as `instance`.
     def __get__(self, instance: Options[Any] | None, cls: type[Any] | None = None) -> Self: ...
 
 class Manager(BaseManager[_T]):
@@ -180,7 +180,7 @@ class ManagerDescriptor:
 
 class EmptyManager(Manager[_T]):
     def __init__(self, model: type[_T]) -> None: ...
-    # Unlike other managers, `EmptyManager` is exposed through properties of plain
-    # classes (e.g. `AnonymousUser.groups`) where instance access is legitimate.
+    # Unlike other managers, `EmptyManager` is exposed through properties of plain classes (e.g. `AnonymousUser.groups`)
+    # where instance access is legitimate.
     @override
     def __get__(self, instance: object, cls: type[Any] | None = None) -> Self: ...

--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -5,8 +5,9 @@ from typing import Any, Generic, Literal, NoReturn, Self, overload
 from django.core.checks.messages import CheckMessage
 from django.db.models.base import Model
 from django.db.models.expressions import Combinable, OrderBy
+from django.db.models.options import Options
 from django.db.models.query import Prefetch, QuerySet, RawQuerySet, _LookupT, _PrefetchedQuerySetT, _ToAttrT
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, override
 
 _T = TypeVar("_T", bound=Model, covariant=True)
 
@@ -34,6 +35,11 @@ class BaseManager(Generic[_T]):
     def db(self) -> str: ...
     def get_queryset(self) -> QuerySet[_T]: ...
     def all(self) -> QuerySet[_T]: ...
+    # Stub-only. At runtime a manager declared on a model is wrapped in a `ManagerDescriptor`,
+    # which raises on instance access, so accepting only `instance=None` makes `instance.objects` a type error.
+    # `Options` is accepted to work around https://github.com/python/mypy/issues/13608: mypy re-applies
+    # `__get__` to the return type of `Options.base_manager`, passing the `Options` object as `instance`.
+    def __get__(self, instance: Options[Any] | None, cls: type[Any] | None = None) -> Self: ...
 
 class Manager(BaseManager[_T]):
     # NOTE: The following methods are in common with QuerySet, but note that the use of QuerySet as a return type
@@ -174,3 +180,7 @@ class ManagerDescriptor:
 
 class EmptyManager(Manager[_T]):
     def __init__(self, model: type[_T]) -> None: ...
+    # Unlike other managers, `EmptyManager` is exposed through properties of plain
+    # classes (e.g. `AnonymousUser.groups`) where instance access is legitimate.
+    @override
+    def __get__(self, instance: object, cls: type[Any] | None = None) -> Self: ...

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1021,10 +1021,17 @@ class MetaclassAdjustments(ModelClassInitializer):
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
             return
 
-        for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned", "objects"]:
+        for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned"]:
             attr = ctx.cls.info.names.get(attr_name)
             if attr is not None and isinstance(attr.node, Var) and not attr.plugin_generated:
                 del ctx.cls.info.names[attr_name]
+
+        # `ModelBase.__getattr__` is the `objects` fallback for the other type checkers.
+        # mypy ignores its `Literal["objects"]` restriction (https://github.com/python/mypy/issues/8203),
+        # so it would swallow unknown attributes. `objects` is already inserted by the plugin.
+        metaclass = ctx.cls.info.metaclass_type
+        if metaclass is not None and "__getattr__" in metaclass.type.names:
+            del metaclass.type.names["__getattr__"]
 
     def get_exception_bases(self, name: str) -> list[Instance]:
         bases = []

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1016,6 +1016,14 @@ class MetaclassAdjustments(ModelClassInitializer):
 
         Turn this setting off at your own risk.
         """
+        # Mypy does not properly support narrowing in `__getattr__` based on `Literal["objects"]`
+        # so the current `ModelBase.__getattr__` swallows every unknown attributes errors.
+        # `objects` is already inserted by the plugin, so the fallback is not necessary for mypy. We can drop it
+        # TODO: remove once https://github.com/python/mypy/issues/8203 is resolved
+        metaclass = ctx.cls.info.metaclass_type
+        if metaclass is not None and "__getattr__" in metaclass.type.names:
+            del metaclass.type.names["__getattr__"]
+
         if not plugin_config.strict_model_abstract_attrs:
             return
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
@@ -1025,13 +1033,6 @@ class MetaclassAdjustments(ModelClassInitializer):
             attr = ctx.cls.info.names.get(attr_name)
             if attr is not None and isinstance(attr.node, Var) and not attr.plugin_generated:
                 del ctx.cls.info.names[attr_name]
-
-        # `ModelBase.__getattr__` is the `objects` fallback for the other type checkers.
-        # mypy ignores its `Literal["objects"]` restriction (https://github.com/python/mypy/issues/8203),
-        # so it would swallow unknown attributes. `objects` is already inserted by the plugin.
-        metaclass = ctx.cls.info.metaclass_type
-        if metaclass is not None and "__getattr__" in metaclass.type.names:
-            del metaclass.type.names["__getattr__"]
 
     def get_exception_bases(self, name: str) -> list[Instance]:
         bases = []

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1024,9 +1024,20 @@ class MetaclassAdjustments(ModelClassInitializer):
         if metaclass is not None and "__getattr__" in metaclass.type.names:
             del metaclass.type.names["__getattr__"]
 
-        if not plugin_config.strict_model_abstract_attrs:
-            return
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
+            return
+
+        if not plugin_config.strict_model_abstract_attrs:
+            # `__getattr__` was the only source of `Model.objects`, redeclare it explicitly for this setting.
+            manager = helpers.lookup_fully_qualified_typeinfo(
+                helpers.get_semanal_api(ctx), fullnames.MANAGER_CLASS_FULLNAME
+            )
+            if manager is not None:
+                helpers.add_new_sym_for_info(
+                    ctx.cls.info,
+                    name="objects",
+                    sym_type=Instance(manager, [Instance(ctx.cls.info, [])]),
+                )
             return
 
         for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned"]:

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1028,10 +1028,17 @@ class MetaclassAdjustments(ModelClassInitializer):
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
             return
 
-        for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned", "objects"]:
+        for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned"]:
             attr = ctx.cls.info.names.get(attr_name)
             if attr is not None and isinstance(attr.node, Var) and not attr.plugin_generated:
                 del ctx.cls.info.names[attr_name]
+
+        # `ModelBase.__getattr__` is the `objects` fallback for the other type checkers.
+        # mypy ignores its `Literal["objects"]` restriction (https://github.com/python/mypy/issues/8203),
+        # so it would swallow unknown attributes. `objects` is already inserted by the plugin.
+        metaclass = ctx.cls.info.metaclass_type
+        if metaclass is not None and "__getattr__" in metaclass.type.names:
+            del metaclass.type.names["__getattr__"]
 
     def get_exception_bases(self, name: str) -> list[Instance]:
         bases = []

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1031,9 +1031,20 @@ class MetaclassAdjustments(ModelClassInitializer):
         if metaclass is not None and "__getattr__" in metaclass.type.names:
             del metaclass.type.names["__getattr__"]
 
-        if not plugin_config.strict_model_abstract_attrs:
-            return
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
+            return
+
+        if not plugin_config.strict_model_abstract_attrs:
+            # `__getattr__` was the only source of `Model.objects`, redeclare it explicitly for this setting.
+            manager = helpers.lookup_fully_qualified_typeinfo(
+                helpers.get_semanal_api(ctx), fullnames.MANAGER_CLASS_FULLNAME
+            )
+            if manager is not None:
+                helpers.add_new_sym_for_info(
+                    ctx.cls.info,
+                    name="objects",
+                    sym_type=Instance(manager, [Instance(ctx.cls.info, [])]),
+                )
             return
 
         for attr_name in ["DoesNotExist", "NotUpdated", "MultipleObjectsReturned"]:

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -1023,6 +1023,14 @@ class MetaclassAdjustments(ModelClassInitializer):
 
         Turn this setting off at your own risk.
         """
+        # Mypy does not properly support narrowing in `__getattr__` based on `Literal["objects"]`
+        # so the current `ModelBase.__getattr__` swallows every unknown attributes errors.
+        # `objects` is already inserted by the plugin, so the fallback is not necessary for mypy. We can drop it
+        # TODO: remove once https://github.com/python/mypy/issues/8203 is resolved
+        metaclass = ctx.cls.info.metaclass_type
+        if metaclass is not None and "__getattr__" in metaclass.type.names:
+            del metaclass.type.names["__getattr__"]
+
         if not plugin_config.strict_model_abstract_attrs:
             return
         if ctx.cls.fullname != fullnames.MODEL_CLASS_FULLNAME:
@@ -1032,13 +1040,6 @@ class MetaclassAdjustments(ModelClassInitializer):
             attr = ctx.cls.info.names.get(attr_name)
             if attr is not None and isinstance(attr.node, Var) and not attr.plugin_generated:
                 del ctx.cls.info.names[attr_name]
-
-        # `ModelBase.__getattr__` is the `objects` fallback for the other type checkers.
-        # mypy ignores its `Literal["objects"]` restriction (https://github.com/python/mypy/issues/8203),
-        # so it would swallow unknown attributes. `objects` is already inserted by the plugin.
-        metaclass = ctx.cls.info.metaclass_type
-        if metaclass is not None and "__getattr__" in metaclass.type.names:
-            del metaclass.type.names["__getattr__"]
 
     def get_exception_bases(self, name: str) -> list[Instance]:
         bases = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pyrefly = [
   "psycopg2-binary"
 ]
 ty = [
-  "ty==0.0.69",
+  "ty==0.0.71",
   "psycopg2-binary"
 ]
 

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -275,6 +275,11 @@ django.contrib.contenttypes.forms.generic_inlineformset_factory
 django.forms.models.inlineformset_factory
 django.forms.models.modelformset_factory
 
+# Stub-only, replicates the runtime `ManagerDescriptor` behavior of raising when
+# a manager is accessed on a model instance rather than on the model class
+django.db.models.manager.BaseManager.__get__
+django.db.models.manager.EmptyManager.__get__
+
 # Field.__get__/__set__ are stub-only for the mypy plugin, they don't exist at runtime
 django.contrib.contenttypes.fields.GenericForeignKey.__get__
 django.db.models.fields.Field.__get__

--- a/tests/assert_type/db/models/test_manager_access/models.py
+++ b/tests/assert_type/db/models/test_manager_access/models.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, assert_type
+from typing import assert_type
 
 from django.contrib.auth.models import AnonymousUser, Group
 from django.db import models
 from django.db.models.manager import EmptyManager
 
-if TYPE_CHECKING:
-    from django.db.models.fields.related_descriptors import RelatedManager
+from django_stubs_ext.db.models.manager import RelatedManager
 
 
 class CategoryManager(models.Manager["Category"]):
@@ -27,6 +26,7 @@ class Post(models.Model):
 
 class Article(models.Model):
     # Reverse accessors are bound to instances, so they must be annotated with `RelatedManager`, not a bare `Manager`.
+    mistyped_category_set: models.Manager[Category]  # pyright: ignore[reportUninitializedInstanceVariable]
     category_set: RelatedManager[Category]  # pyright: ignore[reportUninitializedInstanceVariable]
 
 
@@ -55,7 +55,12 @@ def unknown_attribute_is_still_an_error() -> None:
 
 
 def related_manager_access_on_instance_is_allowed() -> None:
-    assert_type(Article().category_set, "RelatedManager[Category]")
+    assert_type(Article().category_set, RelatedManager[Category])
+
+
+def bare_manager_annotation_on_instance_is_banned() -> None:
+    # A reverse accessor annotated as `Manager` is unreachable from the instance that owns it
+    Article().mistyped_category_set  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-attribute-access]
 
 
 def empty_manager_access_through_property_is_allowed() -> None:
@@ -66,3 +71,4 @@ def empty_manager_access_through_property_is_allowed() -> None:
 def meta_manager_access_on_instance_is_allowed() -> None:
     # `Options` hands out managers from an instance the same way
     assert_type(Category()._meta.base_manager, models.Manager[Category])
+    assert_type(Category()._meta.default_manager, models.Manager[Category] | None)

--- a/tests/assert_type/db/models/test_manager_access/models.py
+++ b/tests/assert_type/db/models/test_manager_access/models.py
@@ -31,9 +31,8 @@ class Article(models.Model):
 
 
 def declared_manager_access_on_instance_is_banned() -> None:
-    # ty doesn't check the `instance` argument of `__get__`, so it accepts both accesses
-    Category().objects  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]
-    Category().secondary  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]
+    Category().objects  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-attribute-access]
+    Category().secondary  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-attribute-access]
 
 
 def default_manager_access_on_instance_is_banned() -> None:
@@ -51,7 +50,7 @@ def manager_access_on_class_is_allowed() -> None:
 
 def unknown_attribute_is_still_an_error() -> None:
     # `Literal["objects"]` must not turn `__getattr__` into a catch-all
-    Category.not_defined  # type: ignore[attr-defined]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[unresolved-attribute]
+    Category.not_defined  # type: ignore[attr-defined]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-attribute-access]
     Category().not_defined  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[missing-attribute]  # ty: ignore[unresolved-attribute]
 
 

--- a/tests/assert_type/db/models/test_manager_access/models.py
+++ b/tests/assert_type/db/models/test_manager_access/models.py
@@ -1,0 +1,69 @@
+"""Managers are only accessible on the model class, never on an instance."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, assert_type
+
+from django.contrib.auth.models import AnonymousUser, Group
+from django.db import models
+from django.db.models.manager import EmptyManager
+
+if TYPE_CHECKING:
+    from django.db.models.fields.related_descriptors import RelatedManager
+
+
+class CategoryManager(models.Manager["Category"]):
+    pass
+
+
+class Category(models.Model):
+    objects = CategoryManager()
+    secondary = CategoryManager()
+
+
+class Post(models.Model):
+    """No declared manager, `objects` only resolves through `ModelBase.__getattr__`."""
+
+
+class Article(models.Model):
+    # Reverse accessors are bound to instances, so they must be annotated with `RelatedManager`, not a bare `Manager`.
+    category_set: RelatedManager[Category]  # pyright: ignore[reportUninitializedInstanceVariable]
+
+
+def declared_manager_access_on_instance_is_banned() -> None:
+    # ty doesn't check the `instance` argument of `__get__`, so it accepts both accesses
+    Category().objects  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]
+    Category().secondary  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[bad-argument-type]
+
+
+def default_manager_access_on_instance_is_banned() -> None:
+    # `ModelBase.__getattr__` lives on the metaclass, so instances can't reach it. mypy sees the
+    # per-model attribute the plugin declares instead, and rejects it through `BaseManager.__get__`
+    Post().objects  # type: ignore[arg-type]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[missing-attribute]  # ty: ignore[unresolved-attribute]
+
+
+def manager_access_on_class_is_allowed() -> None:
+    # A declared manager keeps its own type, exactly like any other class attribute
+    assert_type(Category.objects, CategoryManager)
+    assert_type(Category.secondary, CategoryManager)
+    assert_type(Post.objects, models.Manager[Post])
+
+
+def unknown_attribute_is_still_an_error() -> None:
+    # `Literal["objects"]` must not turn `__getattr__` into a catch-all
+    Category.not_defined  # type: ignore[attr-defined]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[unresolved-attribute]
+    Category().not_defined  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]  # pyrefly: ignore[missing-attribute]  # ty: ignore[unresolved-attribute]
+
+
+def related_manager_access_on_instance_is_allowed() -> None:
+    assert_type(Article().category_set, "RelatedManager[Category]")
+
+
+def empty_manager_access_through_property_is_allowed() -> None:
+    # `EmptyManager` reaches instances through `AnonymousUser.groups`, a plain property
+    assert_type(AnonymousUser().groups, EmptyManager[Group])
+
+
+def meta_manager_access_on_instance_is_allowed() -> None:
+    # `Options` hands out managers from an instance the same way
+    assert_type(Category()._meta.base_manager, models.Manager[Category])

--- a/tests/assert_type/db/models/test_manager_overrides/models.py
+++ b/tests/assert_type/db/models/test_manager_overrides/models.py
@@ -43,8 +43,7 @@ class BookManager(models.Manager["Book"]):
 
 
 class Book(models.Model):
-    # pyrefly doesn't solve `Self` in the `objects: ClassVar[Manager[Self]]` declaration
-    objects = BookManager()  # pyrefly: ignore[bad-assignment]
+    objects = BookManager()
 
 
 def override_manager_create_with_type_param() -> None:
@@ -64,7 +63,7 @@ class ReviewManager(models.Manager["Author"]):
 
 
 class Review(models.Model):
-    objects = ReviewManager()  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[bad-assignment]
+    objects = ReviewManager()  # pyright: ignore[reportGeneralTypeIssues]
 
 
 class Author(models.Model):

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -80,9 +80,9 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "str"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "str"
         reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "str"
         reveal_type(MyModel.objects.filter(id=1)) # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel]"
     installed_apps:
@@ -306,9 +306,9 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "str"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "str"
     installed_apps:
         - myapp
     files:
@@ -424,9 +424,9 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "str"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "str"
     installed_apps:
         - myapp
     files:
@@ -449,10 +449,10 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel().objects.queryset_method)  # N: Revealed type is "def (param: str | None =) -> str | None"
-        reveal_type(MyModel().objects.queryset_method('str'))  # N: Revealed type is "str | None"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.queryset_method)  # N: Revealed type is "def (param: str | None =) -> str | None"
+        reveal_type(MyModel.objects.queryset_method('str'))  # N: Revealed type is "str | None"
     installed_apps:
         - myapp
     files:
@@ -479,10 +479,10 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
-        reveal_type(MyModel().objects.base_queryset_method)  # N: Revealed type is "def (param: int | str) -> Never"
-        reveal_type(MyModel().objects.base_queryset_method(2))  # N: Revealed type is "Never"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
+        reveal_type(MyModel.objects.base_queryset_method)  # N: Revealed type is "def (param: int | str) -> Never"
+        reveal_type(MyModel.objects.base_queryset_method(2))  # N: Revealed type is "Never"
     installed_apps:
         - myapp
     files:
@@ -512,8 +512,8 @@
     main: |
         from typing_extensions import reveal_type
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
-        reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "str"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "str"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "int"
     installed_apps:
         - myapp

--- a/tests/typecheck/test_config.yml
+++ b/tests/typecheck/test_config.yml
@@ -5,7 +5,7 @@
         mymodel = MyModel(user_id=1)
         reveal_type(mymodel.id)  # N: Revealed type is "int"
         reveal_type(mymodel.user)  # N: Revealed type is "django.contrib.auth.models.User"
-        reveal_type(mymodel.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
     mypy_config: |
         [mypy.plugins.django-stubs]
         django_settings_module = mysettings

--- a/uv.lock
+++ b/uv.lock
@@ -409,7 +409,7 @@ dev = [
     { name = "pytest-shard", specifier = "==0.1.2" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "ty", specifier = "==0.0.69" },
+    { name = "ty", specifier = "==0.0.71" },
 ]
 pyrefly = [
     { name = "psycopg2-binary" },
@@ -432,7 +432,7 @@ tests = [
 ]
 ty = [
     { name = "psycopg2-binary" },
-    { name = "ty", specifier = "==0.0.69" },
+    { name = "ty", specifier = "==0.0.71" },
 ]
 
 [[package]]
@@ -1412,27 +1412,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.69"
+version = "0.0.71"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/5b/7a618632dfe9373b7df572ecd7a08c8f799d772fbc317da82dd3aa363207/ty-0.0.69.tar.gz", hash = "sha256:b65106e9ff24fa76e25e1142fb09c85244e815c40450e3021d2bf652c231bb43", size = 6565094, upload-time = "2026-08-06T10:04:25.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e2/f6e716371b5913a31190db1ad250ac2b5c68b3ca2db71afeba3f98f5fe50/ty-0.0.71.tar.gz", hash = "sha256:c2a24f2745294946c27cef8cc012b84fb2db5405ecefddbe845be4162833da01", size = 6624721, upload-time = "2026-08-13T00:39:31.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/60/6534092f4d2c15e2491807edd609c2e50d527c1fed957acf40b9f110b64a/ty-0.0.69-py3-none-linux_armv6l.whl", hash = "sha256:98bfd383b273540829af673e7f98b9c1c4bcc8547d12a1a3806cd0bec7f0e087", size = 12364185, upload-time = "2026-08-06T10:03:47.137Z" },
-    { url = "https://files.pythonhosted.org/packages/34/2b/5c29689bd4f74c2e3394d983d85e4011b629f2ce3730c9442553b8554bf8/ty-0.0.69-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:964621ddd05771660017c51b4e74078d861d9fc863c21ef2a500db1ab62c9ccf", size = 12042510, upload-time = "2026-08-06T10:03:49.481Z" },
-    { url = "https://files.pythonhosted.org/packages/09/46/fa085bde4d23516d7ef14b24736fc5dd7dc498f60f52b3d077e59ffdea20/ty-0.0.69-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ffea4048dd0da4c9c97393b4be0901098a9065b06fa81be2477cbde65d8a151", size = 11549397, upload-time = "2026-08-06T10:03:51.747Z" },
-    { url = "https://files.pythonhosted.org/packages/25/cc/97b9efb2061dcab6fef1e94a4ad99df0bb45bd2cc15d4f5794c787ee0552/ty-0.0.69-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8684d4a70aadd1eab0f41bdba835e3288ef49db8402a8e6ca81bab52ed5d610", size = 12115567, upload-time = "2026-08-06T10:03:53.79Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c1/a5e0404965093835f3e62544e661784ec0aa8ef0b006ed50af50b19c107e/ty-0.0.69-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:afaaba240ab4122e2069a796836d10be81b4ddb053ae268b3dff962a0b4ca5c7", size = 12149770, upload-time = "2026-08-06T10:03:55.993Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/39/8cad6b205a4abe8a044ca0c84aea71e8ccda29b07a75a5f090e310605580/ty-0.0.69-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11ea63ef07d4e33aeb1a775cf5f2c736b3ed22fa6f8b1b608591612c36795044", size = 12941278, upload-time = "2026-08-06T10:03:58.324Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/8b/8766d96b732c2a060d70dc8ccafcc4d6a54109a2a95f1deb0705de88892b/ty-0.0.69-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb3730b1268e92a2907d7aea3afe8dd1b360ae65862f0557080cf479d481b424", size = 13426509, upload-time = "2026-08-06T10:04:00.621Z" },
-    { url = "https://files.pythonhosted.org/packages/02/1f/e991b2cde953ea5b94d6a9a4c45c87937bd916bc09235f764407bf471c0a/ty-0.0.69-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a544ff57a752ef186ed40b5a2f44c17402af4cdefeb74a311ca02ebd57c4fca0", size = 13106582, upload-time = "2026-08-06T10:04:02.818Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/bb/73538f1b99e3558fd9db87b98698426f0f60fc8666da0b1efd0e70e275eb/ty-0.0.69-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87ed2cbca20caddfdf8e3e14d213ce91b67e75feed78900f4aaf3ef884954028", size = 12708931, upload-time = "2026-08-06T10:04:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/87/cd/484a5208d74c4ad1155933906295ccdce9aa81a257d8df2ab9e41bd60133/ty-0.0.69-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2684efcbce5b6fe45045faf610b377b50781b6d2aa7e61ea23ecf5b3d2bce421", size = 12985322, upload-time = "2026-08-06T10:04:07.587Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/81/b75003f0d4da9ab3bc8fd4f4802f836cb9921ff7e70f460604f7b769a0b5/ty-0.0.69-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:da9aeb26fdac1d2214937542b59e0d4d1ba94ec7a3f45444f33c846de1eb1d63", size = 12063910, upload-time = "2026-08-06T10:04:09.835Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/76/088469f547ef63dceefc4a75826aedee5014f9371dc5171cde931896a82c/ty-0.0.69-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:00e7677cd14ede381f705f71104ea7b8ea0ce217a8634e19a89781953de0e9ad", size = 12166823, upload-time = "2026-08-06T10:04:12.114Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c9/ce88a0bec0d46d8ae180b99c6ec014866fecc4cba1727b5feec8877b2765/ty-0.0.69-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d91965eb799649833d0d6042db09cd03d15289125245337cc46a2606effb7bda", size = 12483136, upload-time = "2026-08-06T10:04:14.33Z" },
-    { url = "https://files.pythonhosted.org/packages/63/9e/6fae0ff225a0012642cf72c077e20f8f448c0a80771bc3360e8178fe2f32/ty-0.0.69-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f03359cd8e5c412aa0c181118fa9b9061a4dddaedbb61bac0a424fb0814d402", size = 12799025, upload-time = "2026-08-06T10:04:16.445Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/43/78a658d18b2a4ccf35b053392f2213bf12e3c63b2abea512d3b6751d1f4c/ty-0.0.69-py3-none-win32.whl", hash = "sha256:ec460e01586b1eb91894c4a8403bee3e045a47e7a4ada943cc27ce8e348e88cf", size = 11787774, upload-time = "2026-08-06T10:04:18.622Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/88db1f674403f2b81316a853a44a81ed220621fa96f8f7ae586fb6ca7513/ty-0.0.69-py3-none-win_amd64.whl", hash = "sha256:18976ca26a4e28fc3249477f79a695d5502e670803f2e080d89ac905baef3c6e", size = 12864038, upload-time = "2026-08-06T10:04:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/7b/6fc6efd00c69103d70f2bdbe824343089cd70b17b3079170057d3e5a3ac0/ty-0.0.69-py3-none-win_arm64.whl", hash = "sha256:7d4ca3bb74d91cb9947ba3f3b4cb131ad6a2b3ecc76d34040c4ec6092d2e411d", size = 12196693, upload-time = "2026-08-06T10:04:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e4/8d6d17827c5335d0efe54241fb54fed3cb6ca2d2eca62f3f2382be196b91/ty-0.0.71-py3-none-linux_armv6l.whl", hash = "sha256:a309c9a35e69f45d7053e9205c7fe2295fac09e07e3a2fdb791524f30440a9cc", size = 12576435, upload-time = "2026-08-13T00:38:50.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cb/d4c48832ee3d162abc6c834ba62242ec27630cb93014a0e1be82e86c3ee3/ty-0.0.71-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2d42e9ae4b754ce1f34dd1b545f1cdcfc8e704d7460b584c898be156f048828f", size = 12177806, upload-time = "2026-08-13T00:38:53.068Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/97/e04782c9eaa1a0b634830f61b0e18cd1b3415332143d45a28882802c8ea1/ty-0.0.71-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4d0b1f2002adc03f3a53aeb70b5cafcea634bb48726d82a307b0f15580d2f74b", size = 12015265, upload-time = "2026-08-13T00:38:55.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/d716b9049c11a7b85b3b74ec3547d2dbab9a261347a6558420dcae37083d/ty-0.0.71-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:165e6086363f5c149ae4acacfbc36eea0093552a60f4153ef48321e4a3a15c4c", size = 12119608, upload-time = "2026-08-13T00:38:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/560ce2d874467d50605b7783e19e45b571fea7a89f664bd0ccdf252adf8a/ty-0.0.71-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:067e16f80855afbda024e7ff6fa5ed3ada5290c403badc63800f0534bd617c04", size = 12353762, upload-time = "2026-08-13T00:38:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/7b/f6a22c0bf2c0dbfe20b7ce90b51bc09efa9a9e245f1c35e160e39ed5dea9/ty-0.0.71-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:416149a550bcb678e619b4e2cd1cca9066d28edc52df76ad9d3640b36e6b5bf1", size = 13088120, upload-time = "2026-08-13T00:39:02.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/95/6f5382781f2e4fa933296d303376c61b8b3475d58ed60125c54de665fd21/ty-0.0.71-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:39e04c41e6d0e74f73cf8b3247d4dde3642ec38aeda7f4674110155b3da416a5", size = 13545140, upload-time = "2026-08-13T00:39:04.655Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/8f0ad7b6c4804f8682e08fb161eaf710dd1765006b1b6df7c657b9707c95/ty-0.0.71-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fb696bdea4a3554a0d0a7bbb36e4c5f508acb2bbad435e91c7fc812c1de6bfb", size = 13266730, upload-time = "2026-08-13T00:39:06.858Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/06/b83158fdf1473c2486fba0de337a963e9cc21317ccaa3e54ab003d419737/ty-0.0.71-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3ec4ca9d4ba3e11ecc282c3d50d0730a2e181da7142734219d9f213fcbaaa00", size = 12673786, upload-time = "2026-08-13T00:39:09.281Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/10f37c0550277722ac1d2c8096e492e0f3fc1aa2e587082439dd066fdb8d/ty-0.0.71-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48a231253b32639ff4b19f74e476bacdba0150182603011d3792d1f1a335b932", size = 13140294, upload-time = "2026-08-13T00:39:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e6/5710de1da7eb8aa755d289aa25316691e545b72b4ee2ab14172612eec1c9/ty-0.0.71-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1a082f57d1fcbe209afdcacff37870defd4cea15ce69e2c6c652a9208462722f", size = 12171216, upload-time = "2026-08-13T00:39:14.382Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c5/8d9113e3cf0d4c6c0a9c9e088cee93e41facb278026bea6f6e12533b09dd/ty-0.0.71-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cbe1c962f6c9e8964180cd171cc6ad35d687f74d51c07f60b670d3f1c5d58ffe", size = 12360626, upload-time = "2026-08-13T00:39:16.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a0/0e167507c4c863814d3ea7602bde958baefd03346bd38bae3a430dff1ea9/ty-0.0.71-py3-none-musllinux_1_2_i686.whl", hash = "sha256:25f641b988916b3975e50b2a59cbc5179f2a466d181f207f3032e1e6bc617a88", size = 12637309, upload-time = "2026-08-13T00:39:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c6/ff6719b91e4916985e9a92f9bddb10d9fe3cb3bdf5abf0f9019a67aebe21/ty-0.0.71-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c5fe916b6e5b152ef4f583324e1efd770ac3316894776dc1b57c354cb767b8ee", size = 12937996, upload-time = "2026-08-13T00:39:21.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3e/21a0873da8f1ece28e166fbbaf696cd48c55fd7cd203dba0266a1fe05ceb/ty-0.0.71-py3-none-win32.whl", hash = "sha256:a273fe0dcc453e94cf2e1955076efec8b739e6e1a890862de29d3c5a1c9ddaff", size = 11953321, upload-time = "2026-08-13T00:39:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/ce6614c748f7abfc546d12983d4bad1085116b6458b8c84d9372eb713f08/ty-0.0.71-py3-none-win_amd64.whl", hash = "sha256:65f5f980551ed79f68a0f6c0f2fb71b39a8d54ed0625d2529b01f6c919db72c5", size = 12570891, upload-time = "2026-08-13T00:39:26.346Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7f/0fb022535c66fd96e7dd2a1f9c14e3a0e39544a4c3f35a451e8835562730/ty-0.0.71-py3-none-win_arm64.whl", hash = "sha256:6d5552078b9934d359bd5f381dbcb160f1fc5addfca59a960021adca38a73741", size = 12338716, upload-time = "2026-08-13T00:39:28.987Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Do I need to annotate reverse relations?

Not if you use our mypy plugin. It reads your app registry and declares every reverse accessor for you, as
`RelatedManager[Model]`, or `ManyRelatedManager[Model, Through]` for a `ManyToManyField`.

pyright, pyrefly and ty do not run the plugin, so under those you declare them yourself.
Reach for `RelatedManager` rather than `Manager`: a reverse accessor is read from a model instance, whereas a regular manager such as `objects` only exists on the model class.

```python
from django.db import models
from django_stubs_ext.db.models.manager import ManyRelatedManager, RelatedManager


class Article(models.Model):
    category_set: RelatedManager[Category]
    tags: ManyRelatedManager[Tag, ArticleTag]
```

Make sure to import symbols from `django_stubs_ext.db.models.manager`. Django dynamically create these so they cannot be imported directly

---

# I have made things!

This fixes two issues around [`Model.objects`](https://docs.djangoproject.com/en/6.0/ref/models/class/#django.db.models.Model.objects):
- `MyModel().objects` was allowed while it's a runtime error -> I've used explicit `__get__(self, instance: None)` to solve that
- explicit `objects = BookManager()` are not overriding our stub-defined type for pyright/pyrefly so `objects` was a `Manager[Book]` and incorrect. -> I think I found a way to have our `objects` annotation to act as a true fallback using `__getattr__` on the `ModelBase` metaclass. By nature getattr is always checked last so now it's correct for every type checker!

I had to workaround two mypy issues that made this a bit more difficult but in the end it seem to work:
- https://github.com/python/mypy/issues/8203
- https://github.com/python/mypy/issues/13608

# Related issues
From https://github.com/typeddjango/django-stubs/pull/3559

> This also revealed that our typing of `Model.objects` as `ClassVar[Manager[Self]]` is already a bit problematic with pyright and pyrefly (see the type-ignore's). Given this exemple:
>
> ```python
> class Book(models.Model):
>     objects = BookManager()
>     foo = BookManager()
> ```
>
> I get these revealed types
>
> ```
> ┌─────────────┬───────────────┬─────────────┐
> │             │ Book.objects  │  Book.foo   │
> ├─────────────┼───────────────┼─────────────┤
> │ mypy+plugin │ BookManager   │ BookManager │
> ├─────────────┼───────────────┼─────────────┤
> │ ty          │ BookManager   │ BookManager │
> ├─────────────┼───────────────┼─────────────┤
> │ pyright     │ Manager[Book] │ BookManager │
> ├─────────────┼───────────────┼─────────────┤
> │ pyrefly     │ Manager[Book] │ BookManager │
> └─────────────┴───────────────┴─────────────┘
> ```
>
> To me our declaration in the stubs should not impact regular class level assignment inference and I would expect `objects` to have the same type as `foo`. The plugin should only apply the "does not exist on abstract model" bit, the rest should be regular inference.

Fixes #174
Fixes #1414
Also improves #579


## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result