### PR TITLE
Fix bogus name-defined error for cross-module as_manager overrides

### DIFF
--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -419,7 +419,12 @@ def add_as_manager_to_queryset_class(ctx: ClassDefContext) -> None:
             return
         # A user override's return annotation may still be unanalyzed here, so
         # resolve it explicitly (a no-op if already analyzed); defer if incomplete.
-        base_as_manager_ret_type = semanal_api.anal_type(base_as_manager_type.ret_type)
+        # Suppress resolution errors: a not-yet-analyzed cross-module override may
+        # reference names private to its defining module — bail out, don't report.
+        with semanal_api.msg.filter_errors() as resolution_errors:
+            base_as_manager_ret_type = semanal_api.anal_type(base_as_manager_type.ret_type)
+        if resolution_errors.has_new_errors():
+            return
         if base_as_manager_ret_type is None:
             return _defer()
         base_as_manager_ret_type = get_proper_type(base_as_manager_ret_type)

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -98,6 +98,42 @@
                 class MyModel(models.Model):
                     objects = MyQuerySet.as_manager()
 
+-   case: overridden_as_manager_in_other_module_with_module_private_typevar
+    main: |
+        from myapp.models import MyModel
+    installed_apps:
+        - django.contrib.contenttypes
+        - myapp
+    files:
+        -   path: lib/__init__.py
+        -   path: lib/query.py
+            content: |
+                from typing import TypeVar
+
+                from django.db import models
+                from typing_extensions import override
+
+                _T = TypeVar("_T", bound=models.Model)
+
+                class LibQuerySet(models.QuerySet[_T]):
+                    @classmethod
+                    @override
+                    def as_manager(cls) -> "models.Manager[_T]":
+                        return models.Manager.from_queryset(cls)()
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.contrib.contenttypes.models import ContentType
+                from django.db import models
+
+                from lib.query import LibQuerySet
+
+                class MyModel(models.Model):
+                    ctype = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+
+                class MyQuerySet(LibQuerySet):
+                    pass
+
 -   case: declares_manager_type_like_django
     main: |
         from typing_extensions import reveal_type


### PR DESCRIPTION
Since #3460, [add_as_manager_to_queryset_class](https://github.com/typeddjango/django-stubs/blob/8980afff2f297758809b1300257bde35a9c24bec/mypy_django_plugin/transformers/managers.py#L371) resolves an inherited as_manager override's return annotation with [semanal_api.anal_type()](https://github.com/typeddjango/django-stubs/blob/8980afff2f297758809b1300257bde35a9c24bec/mypy_django_plugin/transformers/managers.py#L422). 

That resolves names against the current module. When the override lives in another module that mypy has not analyzed yet (consumer scheduled before the library inside the same SCC), the annotation is still an UnboundType, and any name private to the defining module - typically a TypeVar - fails to resolve, producing a spurious 'Name "..." is not defined' error reported against the consumer's file with the library's line number.

Suppress resolution errors from that call and bail out without generating a manager, restoring the pre-6.0.7 behaviour for the cross-module case while keeping #3460's fix for same-module overrides.

## Related issues
Fixes #3596

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
