### PR TITLE
Annotate `FileField.save_form_data`

### DIFF
--- a/django-stubs/db/models/fields/files.pyi
+++ b/django-stubs/db/models/fields/files.pyi
@@ -104,6 +104,8 @@ class FileField(Field[Any, Any]):
     @override
     def contribute_to_class(self, cls: type[Model], name: str, **kwargs: Any) -> None: ...  # type: ignore[override]
     def generate_filename(self, instance: Model | None, filename: StrPath) -> str: ...
+    @override
+    def save_form_data(self, instance: Model, data: File[Any] | str | bool | None) -> None: ...
 
 class ImageFileDescriptor(FileDescriptor):
     field: ImageField


### PR DESCRIPTION
`FileField.save_form_data` can have a more specific annotation than its parent `Field.save_form_data`.

Per the code comments and behavior:
https://github.com/django/django/blob/03988c5a5ba248c3b9b11ea96fd4fda5e98849aa/django/db/models/fields/files.py#L363-L371 the `data` parameter can be:
* `None`
* `False`
* a `File` instance (the normal case)
* a string (implicitly accepted, as `False` internally transforms to `""`, and the ultimate field value upon save is a string)

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
