### PR TITLE
Don't build a ManyRelatedManager from a placeholder _Through

### DIFF
--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -23,6 +23,7 @@ from mypy.nodes import (
 )
 from mypy.plugins import common
 from mypy.semanal import SemanticAnalyzer
+from mypy.semanal_shared import has_placeholder
 from mypy.typeanal import TypeAnalyser
 from mypy.types import AnyType, Instance, ProperType, TypedDictType, TypeOfAny, TypeType, TypeVarType, get_proper_type
 from mypy.types import Type as MypyType
@@ -971,6 +972,12 @@ class ProcessManyToManyFields(ModelClassInitializer):
         # class X_ManyRelatedManager(ManyRelatedManager[X, _Through], type(X._default_manager), Generic[_Through]): ...
         through_type_var = self.many_related_manager.defn.type_vars[1]
         assert isinstance(through_type_var, TypeVarType)
+        if has_placeholder(through_type_var):
+            # 'ManyRelatedManager' hasn't been fully analysed yet, so '_Through' still
+            # carries a 'PlaceholderType' bound. Copying it into the class we're about to
+            # create would store an unserializable type on a synthetic class that is never
+            # re-analysed, so defer instead and pick it up on a later iteration.
+            raise helpers.IncompleteDefnException()
         generic_to_many_related_manager = Instance(self.many_related_manager, [model, through_type_var.copy_modified()])
         related_manager_info = helpers.add_new_class_for_module(
             module=self.api.modules[model.type.module_name],


### PR DESCRIPTION
# I have made things!

## Related issues

Fixes #3605

## What was wrong

`ProcessManyToManyFields.create_many_related_manager` (`mypy_django_plugin/transformers/models.py`) reuses the `_Through` `TypeVar` from `ManyRelatedManager` when it synthesises `<Model>_ManyRelatedManager`:

```python
through_type_var = self.many_related_manager.defn.type_vars[1]
assert isinstance(through_type_var, TypeVarType)
generic_to_many_related_manager = Instance(self.many_related_manager, [model, through_type_var.copy_modified()])
related_manager_info = helpers.add_new_class_for_module(...)
related_manager_info.defn.type_vars = [through_type_var.copy_modified()]
related_manager_info.add_type_vars()
```

`_Through` is `TypeVar("_Through", bound=Model, default=Model)` in `django-stubs/db/models/fields/related_descriptors.pyi`. If that stub module is semantically analysed while its own `from django.db.models.base import Model` is still a `PlaceholderNode`, `_Through.upper_bound` is a `PlaceholderType`. Nothing here checks for that, and `set_many_to_many_manager_info` means the class is never revisited, so the placeholder is still there at `write_cache` time:

```
  File "mypy/build.py", line 4900, in process_stale_scc_interface
  File "mypy/build.py", line 3604, in write_cache
  File "mypy/build.py", line 2325, in write_cache
  File "mypy/nodes.py", line 599, in write        # MypyFile.write -> self.names.write(...)
  File "mypy/nodes.py", line 5169, in write       # SymbolTable.write
  File "mypy/nodes.py", line 5074, in write       # SymbolTableNode.write -> self.node.write(data)
  File "mypy/nodes.py", line 4321, in write       # TypeInfo.write -> self.defn.write(data)
  File "mypy/nodes.py", line 1760, in write       # ClassDef.write -> write_type_list(data, self.type_vars)
  File "mypy/types.py", line 4553, in write_type_list
  File "mypy/types.py", line 742, in write        # TypeVarType.write -> self.upper_bound.write(data)
  File "mypy/types.py", line 318, in write
NotImplementedError: Cannot serialize PlaceholderType instance
```

Both other places that store type vars taken from another class already guard against this — `create_manager_class` and `reparametrize_generic_class`, in `mypy_django_plugin/transformers/managers.py` — this one didn't. It is the same plugin contract described in python/mypy#21640.

## Evidence

Walking every module symbol table at the end of a build over a ~15,200 file codebase (mypy 2.3.1, django-stubs 6.1.0, `--num-workers 1`) found 39 classes whose `defn.type_vars` still contained a placeholder. All 39 are `<Model>_ManyRelatedManager`, including django's own:

```
POISONED django.contrib.auth.models.Group_ManyRelatedManager       tv=_Through bound=<placeholder django.db.models.fields.related_descriptors.Model>
POISONED django.contrib.auth.models.Permission_ManyRelatedManager  tv=_Through bound=<placeholder django.db.models.fields.related_descriptors.Model>
POISONED sd_organizations.models.CompanyProfile_ManyRelatedManager tv=_Through bound=<placeholder django.db.models.fields.related_descriptors.Model>
```

Logging the analysis order shows a narrow window between `related_descriptors`' first pass and its re-analysis. Every M2M manager built inside that window is affected; the ones built after are fine, which is why the module mypy blames moves around when you edit files:

```
line 18658  ManyRelatedManager analysed, _Through.bound = <placeholder ...Model>
line 18669  Group_ManyRelatedManager created, bound = <placeholder ...>
   ...      39 managers created inside the window
line 18836  ManyRelatedManager re-analysed, _Through.bound = django.db.models.base.Model
```

## The fix

Check `has_placeholder` and raise `helpers.IncompleteDefnException` — `process_model_defn` already turns that into `ctx.api.defer()`, exactly as `create_manager_class` does for the same situation.

## Test

No test, per review — reproducing the SCC ordering from scratch needs thousands of modules. I tried ~400 synthetic project shapes and could open the window (`_Through.upper_bound` observably becomes a `PlaceholderType`), but never with an M2M manager being built inside it. Verified against the real codebase instead, below.

## Verification

* The ~15,200 file codebase from #3605: `INTERNAL ERROR ... Cannot serialize PlaceholderType instance` (exit 2) before, `Found 1399 errors in 854 files (checked 15231 source files)` (exit 1) after. No crash, and no new error mentioning `ManyRelatedManager`.
* `pytest tests`: same result before and after the change locally (442 passed, 12 failed — the 12 are postgres/gis extras missing in my environment, unrelated to this change).
* Repeated runs are now stable: before this change the crash relocated between unrelated modules from run to run, and the build never reached a summary line.

## One thing I noticed but did not change

`reparametrize_generic_class` in `mypy_django_plugin/transformers/managers.py` calls `ctx.api.defer()` when it finds placeholders and then falls through and assigns them anyway:

```python
if any(has_placeholder(type_var) for type_var in type_vars):
    if not ctx.api.final_iteration:
        ctx.api.defer()
    else:
        return

parent_class.args = tuple(type_vars)
class_info.node.defn.type_vars = type_vars
```

That fires 84 times on the codebase above and self-heals, because mypy's `setup_type_vars` resets `defn.type_vars` when the class is re-analysed. So it is not this bug, but the `defer()` branch storing placeholders looks unintended. Happy to send a separate PR if you want it tightened.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
