### PR TITLE
Fix monkeypatch() erasing parametrization of real Generic subclasses

### DIFF
--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -134,14 +134,11 @@ if VERSION >= (6, 0):
 
 def _make_class_getitem(patched_cls: type) -> Any:
     def __class_getitem__(cls: type, item: Any) -> Any:
-        # `cls` may be a subclass that also inherits from `typing.Generic`.
-        # In that case the patched class shadows `Generic.__class_getitem__` in
-        # the MRO, which would silently erase the runtime parametrization of
-        # `cls[...]` (https://github.com/typeddjango/django-stubs/issues/3609).
-        # Delegate to the next `__class_getitem__` in the MRO if there is one,
-        # and only fall back to the no-op behavior of returning `cls` as is.
+        # A patched class may shadow `Generic.__class_getitem__` in a subclass MRO.
+        # Delegate to the next implementation when present, otherwise keep the
+        # existing no-op behavior.
         mro = cls.__mro__
-        for base in mro[mro.index(patched_cls) + 1 :]:
+        for base in mro[mro.index(patched_cls) + 1 : -1]:
             getitem = base.__dict__.get("__class_getitem__")
             if getitem is not None:
                 return getitem.__get__(None, cls)(item)

--- a/ext/django_stubs_ext/patch.py
+++ b/ext/django_stubs_ext/patch.py
@@ -132,6 +132,24 @@ if VERSION >= (6, 0):
     )
 
 
+def _make_class_getitem(patched_cls: type) -> Any:
+    def __class_getitem__(cls: type, item: Any) -> Any:
+        # `cls` may be a subclass that also inherits from `typing.Generic`.
+        # In that case the patched class shadows `Generic.__class_getitem__` in
+        # the MRO, which would silently erase the runtime parametrization of
+        # `cls[...]` (https://github.com/typeddjango/django-stubs/issues/3609).
+        # Delegate to the next `__class_getitem__` in the MRO if there is one,
+        # and only fall back to the no-op behavior of returning `cls` as is.
+        mro = cls.__mro__
+        for base in mro[mro.index(patched_cls) + 1 :]:
+            getitem = base.__dict__.get("__class_getitem__")
+            if getitem is not None:
+                return getitem.__get__(None, cls)(item)
+        return cls
+
+    return classmethod(__class_getitem__)
+
+
 def monkeypatch(extra_classes: Iterable[type] | None = None) -> None:
     """Monkey patch django as necessary to work properly with mypy."""
     # Add the __class_getitem__ dunder.
@@ -140,7 +158,7 @@ def monkeypatch(extra_classes: Iterable[type] | None = None) -> None:
         _need_generic,
     )
     for el in suited_for_this_version:
-        el.cls.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)
+        el.cls.__class_getitem__ = _make_class_getitem(el.cls)
     if extra_classes:
         for cls in extra_classes:
-            cls.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: ignore[attr-defined]
+            cls.__class_getitem__ = _make_class_getitem(cls)  # type: ignore[attr-defined]

--- a/ext/tests/test_monkeypatching.py
+++ b/ext/tests/test_monkeypatching.py
@@ -86,10 +86,10 @@ def test_patched_extra_classes_generics(make_generic_classes: _MakeGenericClasse
 
 
 def test_patched_class_real_generic_subclass(make_generic_classes: _MakeGenericClasses) -> None:
-    """Test that real `Generic` subclasses of patched classes keep runtime parametrization.    """
+    """Test that real `Generic` subclasses of patched classes keep runtime parametrization."""
     make_generic_classes()
 
-    assert View[int] is View
+    assert View[int] is View  # type: ignore[type-var, comparison-overlap]
 
     _T = TypeVar("_T")
 

--- a/ext/tests/test_monkeypatching.py
+++ b/ext/tests/test_monkeypatching.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Generic, Protocol, get_args, get_origin
 
 import pytest
 from django.db.models import Model
 from django.forms.models import ModelForm
+from django.views import View
+from typing_extensions import TypeVar
 
 import django_stubs_ext
 from django_stubs_ext import patch
@@ -81,6 +83,41 @@ def test_patched_extra_classes_generics(make_generic_classes: _MakeGenericClasse
 
     class _TestGeneric(_NotGeneric[Model]):  # type: ignore[type-arg]
         pass
+
+
+def test_patched_class_real_generic_subclass(make_generic_classes: _MakeGenericClasses) -> None:
+    """Test that real `Generic` subclasses of patched classes keep runtime parametrization.    """
+    make_generic_classes()
+
+    assert View[int] is View
+
+    _T = TypeVar("_T")
+
+    class _Controller(View, Generic[_T]):
+        pass
+
+    alias = _Controller[int]
+    assert get_origin(alias) is _Controller
+    assert get_args(alias) == (int,)
+
+    class _Concrete(_Controller[int]):
+        pass
+
+    assert _Concrete.__orig_bases__ == (_Controller[int],)  # type: ignore[attr-defined]
+
+    class _PlainView(View):
+        pass
+
+    assert _PlainView[int] is _PlainView  # type: ignore[misc]
+
+    class _CustomGetitem:
+        def __class_getitem__(cls, item: object) -> object:
+            return ("custom", cls, item)
+
+    class _WithCustom(View, _CustomGetitem):
+        pass
+
+    assert _WithCustom[int] == ("custom", _WithCustom, int)  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This should fix the related issue. I implemented the approach described in #3609.

## Related issues

Fixes #3609 

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
