### PR TITLE
Add defaults to the form type parameters of generic editing views

### DIFF
--- a/django-stubs/views/generic/edit.pyi
+++ b/django-stubs/views/generic/edit.pyi
@@ -1,8 +1,8 @@
 from typing import Any, Generic, Literal
 
 from django.db import models
-from django.forms.forms import BaseForm
-from django.forms.models import BaseModelForm
+from django.forms.forms import BaseForm, Form
+from django.forms.models import BaseModelForm, ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.utils.datastructures import _ListOrTuple
 from django.utils.functional import _StrOrPromise
@@ -10,9 +10,10 @@ from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
 from typing_extensions import TypeVar, override
 
-_FormT = TypeVar("_FormT", bound=BaseForm)
-_ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm[Any])
 _M = TypeVar("_M", bound=models.Model)
+_FormT = TypeVar("_FormT", bound=BaseForm)
+_DeleteFormT = TypeVar("_DeleteFormT", bound=BaseForm, default=Form)
+_ModelFormT = TypeVar("_ModelFormT", bound=BaseModelForm[Any], default=ModelForm[_M])
 
 class FormMixin(ContextMixin, Generic[_FormT]):
     initial: dict[str, Any]
@@ -76,9 +77,9 @@ class DeletionMixin(Generic[_M]):
     def delete(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse: ...
     def get_success_url(self) -> str: ...
 
-class BaseDeleteView(DeletionMixin[_M], FormMixin[_FormT], BaseDetailView[_M], Generic[_M, _FormT]):
+class BaseDeleteView(DeletionMixin[_M], FormMixin[_DeleteFormT], BaseDetailView[_M], Generic[_M, _DeleteFormT]):
     object: _M
 
-class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView[_M, _FormT], Generic[_M, _FormT]):
+class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView[_M, _DeleteFormT], Generic[_M, _DeleteFormT]):
     object: _M
     template_name_suffix: str

--- a/tests/assert_type/views/test_generic.py
+++ b/tests/assert_type/views/test_generic.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.db.models import F
 from django.db.models.functions import Upper
 from django.views.generic.detail import SingleObjectMixin
-from django.views.generic.edit import DeleteView
+from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 
 
@@ -44,6 +44,36 @@ class MyDeleteView(DeleteView[MyModel, ConfirmForm]): ...
 delete_view = MyDeleteView()
 assert_type(delete_view.get_form_class(), type[ConfirmForm])
 assert_type(delete_view.get_form(), ConfirmForm)
+
+
+# When no form type parameter is given, the form types default to what Django provides at runtime.
+class SimpleCreateView(CreateView[MyModel]):
+    model = MyModel
+    fields = "__all__"
+
+
+simple_create_view = SimpleCreateView()
+assert_type(simple_create_view.get_form_class(), type[forms.ModelForm[MyModel]])  # ty: ignore[type-assertion-failure]
+assert_type(simple_create_view.get_form(), forms.ModelForm[MyModel])  # ty: ignore[type-assertion-failure]
+
+
+class SimpleUpdateView(UpdateView[MyModel]):
+    model = MyModel
+    fields = "__all__"
+
+
+simple_update_view = SimpleUpdateView()
+assert_type(simple_update_view.get_form_class(), type[forms.ModelForm[MyModel]])  # ty: ignore[type-assertion-failure]
+assert_type(simple_update_view.get_form(), forms.ModelForm[MyModel])  # ty: ignore[type-assertion-failure]
+
+
+class SimpleDeleteView(DeleteView[MyModel]):
+    model = MyModel
+
+
+simple_delete_view = SimpleDeleteView()
+assert_type(simple_delete_view.get_form_class(), type[forms.Form])
+assert_type(simple_delete_view.get_form(), forms.Form)
 
 
 class MyOrderedListView(ListView[MyModel]):


### PR DESCRIPTION
This is a usability improvement: simple usages like `CreateView[Article]` or `DeleteView[Article]` no longer need to spell out a form type parameter, and instead default to the form type that Django actually provides at runtime when `form_class` is unset.

For example, the minimal usage changes from:
```py
class ArticleCreateView(CreateView[Article, ModelForm[Article]]): ...
```
to:
```py
class ArticleCreateView(CreateView[Article]): ...
```

The two defaults are justified differently:

- `_ModelFormT = ModelForm[_M]` (`CreateView`, `UpdateView`, and their bases): when `form_class` is unset, `ModelFormMixin.get_form_class()` falls back to `modelform_factory(model, fields=...)`, which generates a `ModelForm` subclass for the view's model, so `ModelForm[_M]` is what Django provides. This does require `fields` to be set (otherwise Django raises `ImproperlyConfigured`), a condition the type system cannot express, but that misconfiguration fails loudly at runtime.

- `_DeleteFormT = Form` (`BaseDeleteView`, `DeleteView`): `BaseDeleteView` unconditionally sets `form_class = Form`, so `Form` is always the runtime default. This is a new TypeVar rather than a default on the shared `_FormT`, because `FormView` also uses `_FormT` but inherits `form_class = None` and therefore has no runtime default to mirror.

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
