### PR TITLE
Allow Py3.15, please

### DIFF
--- a/ext/pyproject.toml
+++ b/ext/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Typing :: Typed",
   "Framework :: Django",
   "Framework :: Django :: 5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Typing :: Typed",
   "Framework :: Django",
   "Framework :: Django :: 5.2",


### PR DESCRIPTION
# Metadata allow Py3.15
Helps with testing things on Py3.15 (pre-release). No new feature gonna affect typing.

## AI Policy
- [X] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
