### PR TITLE
Fix `@admin.display` overload to specify `function`

### DIFF
--- a/django-stubs/contrib/admin/decorators.pyi
+++ b/django-stubs/contrib/admin/decorators.pyi
@@ -58,6 +58,7 @@ def display(
 ) -> Callable[[_F], _F]: ...
 @overload
 def display(
+    function: None = None,
     *,
     boolean: None = ...,
     ordering: str | Combinable | BaseExpression | None = ...,


### PR DESCRIPTION
# I have made things!
<!--
Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
-->

Fixes an inconsistency in overload definitions.

Follow up to 1f73fcff3bf8a06ea79df756111828a15dbd9f92 and fd3a2b8ac0d609e55c8abfa4831ce520bf7a6dec.

## Related issues
<!--
Mark what issues this Pull Request closes or references.

Example. Fixes #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

N/A

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result
