### PR TITLE
Add a mutable HttpRequest typing helper

### DIFF
--- a/ext/django_stubs_ext/__init__.py
+++ b/ext/django_stubs_ext/__init__.py
@@ -9,12 +9,14 @@ from .annotations import Annotations as Annotations
 from .annotations import WithAnnotations as WithAnnotations
 from .patch import monkeypatch as monkeypatch
 from .types import AnyAttrAllowed as AnyAttrAllowed
+from .types import MutableHttpRequest as MutableHttpRequest
 
 __all__ = [
     "Annotations",
     "AnyAttrAllowed",
     "FieldOpts",
     "FieldsetSpec",
+    "MutableHttpRequest",
     "QuerySetAny",
     "StrOrPromise",
     "StrPromise",

--- a/ext/django_stubs_ext/types.py
+++ b/ext/django_stubs_ext/types.py
@@ -13,9 +13,10 @@ if TYPE_CHECKING:
         GET: QueryDict  # type: ignore[assignment]
         POST: QueryDict  # type: ignore[assignment]
 else:
-    # The runtime class is Django's regular HttpRequest; mutability is a
-    # type-checking distinction only.
-    from django.http import HttpRequest as MutableHttpRequest
+    # The runtime class is Django's regular HttpRequest; mutability is a type-checking distinction only.
+    from django.http import HttpRequest
+
+    MutableHttpRequest = HttpRequest
 
 
 # Used internally by mypy_django_plugin.
@@ -24,6 +25,3 @@ class AnyAttrAllowed(Protocol):
 
     @override
     def __setattr__(self, item: str, value: Any) -> None: ...
-
-
-__all__ = ["AnyAttrAllowed", "MutableHttpRequest"]

--- a/ext/django_stubs_ext/types.py
+++ b/ext/django_stubs_ext/types.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from django.http.request import HttpRequest, QueryDict
+
+    class MutableHttpRequest(HttpRequest):
+        """A request with mutable query dictionaries, as used in tests."""
+
+        GET: QueryDict  # type: ignore[assignment]
+        POST: QueryDict  # type: ignore[assignment]
+else:
+    # The runtime class is Django's regular HttpRequest; mutability is a
+    # type-checking distinction only.
+    from django.http import HttpRequest as MutableHttpRequest
 
 
 # Used internally by mypy_django_plugin.
@@ -11,3 +24,6 @@ class AnyAttrAllowed(Protocol):
 
     @override
     def __setattr__(self, item: str, value: Any) -> None: ...
+
+
+__all__ = ["AnyAttrAllowed", "MutableHttpRequest"]

--- a/ext/tests/typecheck/test_aliases.yml
+++ b/ext/tests/typecheck/test_aliases.yml
@@ -14,3 +14,11 @@
 
                 class Blog(models.Model):
                     created_at = models.DateTimeField()
+
+-   case: mutable_http_request
+    main: |
+        from django_stubs_ext import MutableHttpRequest
+
+        request = MutableHttpRequest()
+        request.GET["foo"] = "bar"
+        request.POST.setdefault("foo", "bar")

--- a/ext/tests/typecheck/test_aliases.yml
+++ b/ext/tests/typecheck/test_aliases.yml
@@ -14,11 +14,3 @@
 
                 class Blog(models.Model):
                     created_at = models.DateTimeField()
-
--   case: mutable_http_request
-    main: |
-        from django_stubs_ext import MutableHttpRequest
-
-        request = MutableHttpRequest()
-        request.GET["foo"] = "bar"
-        request.POST.setdefault("foo", "bar")

--- a/tests/assert_type/http/test_request.py
+++ b/tests/assert_type/http/test_request.py
@@ -6,6 +6,8 @@ from typing import assert_type
 from django.http import QueryDict
 from django.http.request import _ImmutableQueryDict
 
+from django_stubs_ext import MutableHttpRequest
+
 q = QueryDict("", False)
 # Test constructor overloads -- Mutable
 assert_type(QueryDict("querystring", True), QueryDict)
@@ -34,3 +36,10 @@ mut_q["a"] = ["1", "2"]  # type: ignore[assignment]  # pyright: ignore[reportArg
 assert_type(mut_q.pop("a"), list[str])
 assert_type(mut_q.pop("a", 12), list[str] | int)  # ty: ignore[type-assertion-failure]
 assert_type(mut_q.popitem(), tuple[str, list[str]])
+
+
+# Test MutableHttpRequest helper
+request = MutableHttpRequest()
+assert_type(request, MutableHttpRequest)
+request.GET["foo"] = "bar"
+request.POST.setdefault("foo", "bar")


### PR DESCRIPTION
Fixes #3565

Django's concrete HttpRequest keeps GET and POST mutable, while WSGIRequest and ASGIRequest expose immutable query dictionaries. Recent mypy releases changed __new__ handling, so the existing stub workaround could no longer preserve custom HttpRequest subclasses.

This adds a public MutableHttpRequest helper in django-stubs-ext. At runtime it aliases Django's HttpRequest; during type checking it exposes mutable QueryDict attributes for tests and request factories without changing HttpRequest subclass inference.

Verified with:
- uv run pytest ext -q
- uv run pytest tests/typecheck/test_request.yml -q
- uv run mypy ext/django_stubs_ext
- targeted prek hooks